### PR TITLE
[Feat] 실시간 회의 개설 기능 구현

### DIFF
--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/code/AiStatus.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/code/AiStatus.java
@@ -1,0 +1,8 @@
+package com._penLearning.Noddi.domain.meeting.code;
+
+public enum AiStatus {
+    PENDING,
+    PROCESSING,
+    COMPLETED,
+    FAILED
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/code/MeetingApi.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/code/MeetingApi.java
@@ -11,8 +11,59 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
+import java.util.List;
+
 @Tag(name = "02. Meeting API", description = "회의 예약/시작/종료/AI 요약 관련 API")
 public interface MeetingApi {
+
+    @Operation(summary = "회의 단건 조회", description = "회의의 현재 상태, 접속 URL, AI 요약 상태 등 상세 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "해당 팀의 팀원이 아님",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "회의를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    ApiResponse<MeetingResponseDto.Info> getMeeting(
+            Long meetingId,
+            @AuthenticationPrincipal AuthMember authMember
+    );
+    @Operation(summary = "팀별 회의 목록 조회", description = "특정 팀의 모든 회의(예약/진행/종료) 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "해당 팀의 팀원이 아님",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "팀을 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    ApiResponse<List<MeetingResponseDto.Info>> getMeetingsByTeam(
+            Long teamId,
+            @AuthenticationPrincipal AuthMember authMember
+    );
+    @Operation(summary = "회의 참가자 목록 조회", description = "해당 회의에 참가한 유저 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "해당 팀의 팀원이 아님",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "회의를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    ApiResponse<List<MeetingResponseDto.ParticipantInfo>> getParticipants(
+            Long meetingId,
+            @AuthenticationPrincipal AuthMember authMember
+    );
 
     @Operation(summary = "회의 예약 생성", description = "팀의 회의를 예약 상태(SCHEDULED)로 등록합니다. Daily.co 방은 아직 생성되지 않습니다.")
     @ApiResponses(value = {

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/code/MeetingErrorCode.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/code/MeetingErrorCode.java
@@ -1,0 +1,28 @@
+package com._penLearning.Noddi.domain.meeting.code;
+
+import com._penLearning.Noddi.global.apiPayload.code.BaseErrorCode;
+import jakarta.persistence.Entity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.h2.api.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum MeetingErrorCode implements BaseErrorCode {
+    INVALID_STATUS_FOR_START(HttpStatus.BAD_REQUEST, "MEETING400_1", "예약(SCHEDULED) 상태인 회의만 시작할 수 있습니다."),
+    INVALID_STATUS_FOR_END(HttpStatus.BAD_REQUEST, "MEETING400_2", "진행 중(IN_PROGRESS)인 회의만 종료할 수 있습니다."),
+    INVALID_STATUS_FOR_SUMMARY(HttpStatus.BAD_REQUEST, "MEETING400_3", "종료된(ENDED) 회의만 AI 요약을 요청할 수 있습니다."),
+    ALREADY_PROCESSING_SUMMARY(HttpStatus.BAD_REQUEST, "MEETING400_4", "이미 AI 요약이 진행 중이거나 완료된 회의입니다."),
+    RECORDING_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEETING400_5", "녹음 파일이 존재하지 않아 요약을 진행할 수 없습니다."),
+    // 403 Forbidden: 해당 팀원이 아닌 경우
+    NOT_TEAM_MEMBER(HttpStatus.FORBIDDEN, "MEETING403_1", "해당 팀의 팀원만 회의에 접근할 수 있습니다."),
+    // 404 Not Found: 회의를 찾을 수 없는 경우
+    MEETING_NOT_FOUND(HttpStatus.NOT_FOUND, "MEETING404_1", "존재하지 않는 회의입니다."),
+    // 500 Internal Server Error: 외부 연동 장애
+    WEBRTC_ROOM_CREATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "MEETING500_1", "WebRTC 방 생성 중 오류가 발생했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/code/MeetingErrorCode.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/code/MeetingErrorCode.java
@@ -17,6 +17,7 @@ public enum MeetingErrorCode implements BaseErrorCode {
     RECORDING_NOT_READY(HttpStatus.BAD_REQUEST, "MEETING400_5", "녹음본 파일이 아직 인코딩 중입니다. 잠시 후 다시 시도해 주세요."),
     // 403 Forbidden: 해당 팀원이 아닌 경우
     NOT_TEAM_MEMBER(HttpStatus.FORBIDDEN, "MEETING403_1", "해당 팀의 팀원만 회의에 접근할 수 있습니다."),
+    NOT_MEETING_CREATOR(HttpStatus.FORBIDDEN, "MEETING403_2", "해당 팀의 회의의 생성자만 종료할 수 있습니다."),
     // 404 Not Found: 회의를 찾을 수 없는 경우
     MEETING_NOT_FOUND(HttpStatus.NOT_FOUND, "MEETING404_1", "존재하지 않는 회의입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEETING404_2", "존재하지 않는 유저입니다."),

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/code/MeetingErrorCode.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/code/MeetingErrorCode.java
@@ -14,7 +14,7 @@ public enum MeetingErrorCode implements BaseErrorCode {
     INVALID_STATUS_FOR_END(HttpStatus.BAD_REQUEST, "MEETING400_2", "진행 중(IN_PROGRESS)인 회의만 종료할 수 있습니다."),
     INVALID_STATUS_FOR_SUMMARY(HttpStatus.BAD_REQUEST, "MEETING400_3", "종료된(ENDED) 회의만 AI 요약을 요청할 수 있습니다."),
     ALREADY_PROCESSING_SUMMARY(HttpStatus.BAD_REQUEST, "MEETING400_4", "이미 AI 요약이 진행 중이거나 완료된 회의입니다."),
-    RECORDING_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEETING400_5", "녹음 파일이 존재하지 않아 요약을 진행할 수 없습니다."),
+    RECORDING_NOT_READY(HttpStatus.BAD_REQUEST, "MEETING400_5", "녹음본 파일이 아직 인코딩 중입니다. 잠시 후 다시 시도해 주세요."),
     // 403 Forbidden: 해당 팀원이 아닌 경우
     NOT_TEAM_MEMBER(HttpStatus.FORBIDDEN, "MEETING403_1", "해당 팀의 팀원만 회의에 접근할 수 있습니다."),
     // 404 Not Found: 회의를 찾을 수 없는 경우

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/code/MeetingErrorCode.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/code/MeetingErrorCode.java
@@ -19,8 +19,8 @@ public enum MeetingErrorCode implements BaseErrorCode {
     NOT_TEAM_MEMBER(HttpStatus.FORBIDDEN, "MEETING403_1", "해당 팀의 팀원만 회의에 접근할 수 있습니다."),
     // 404 Not Found: 회의를 찾을 수 없는 경우
     MEETING_NOT_FOUND(HttpStatus.NOT_FOUND, "MEETING404_1", "존재하지 않는 회의입니다."),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEETING404_2", "존재하지 않는 팀입니다."),
-    TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "MEETING404_3", "존재하지 않는 유저입니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEETING404_2", "존재하지 않는 유저입니다."),
+    TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "MEETING404_3", "존재하지 않는 팀입니다."),
     // 500 Internal Server Error: 외부 연동 장애
     WEBRTC_ROOM_CREATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "MEETING500_1", "WebRTC 방 생성 중 오류가 발생했습니다.");
 

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/code/MeetingStatus.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/code/MeetingStatus.java
@@ -1,0 +1,7 @@
+package com._penLearning.Noddi.domain.meeting.code;
+
+public enum MeetingStatus {
+    SCHEDULED,
+    IN_PROGRESS,
+    ENDED
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/controller/MeetingController.java
@@ -11,12 +11,38 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
-@RequestMapping("/api/v1/meeting")
+@RequestMapping("/api/v1/meetings")
 @RequiredArgsConstructor
 public class MeetingController implements MeetingApi {
 
     private final MeetingService meetingService;
+
+    @Override
+    @GetMapping("/{meetingId}")
+    public ApiResponse<MeetingResponseDto.Info> getMeeting(
+            @PathVariable Long meetingId, @AuthenticationPrincipal AuthMember authMember) {
+        MeetingResponseDto.Info response = meetingService.getMeetingInfo(meetingId, authMember.getUserId());
+        return ApiResponse.onSuccess("회의 정보 조회가 완료되었습니다.", response);
+    }
+
+    @Override
+    @GetMapping
+    public ApiResponse<List<MeetingResponseDto.Info>> getMeetingsByTeam(
+            @RequestParam Long teamId, @AuthenticationPrincipal AuthMember authMember) {
+        List<MeetingResponseDto.Info> response = meetingService.getMeetingsByTeam(teamId, authMember.getUserId());
+        return ApiResponse.onSuccess("팀 회의 목록 조회가 완료되었습니다.", response);
+    }
+
+    @Override
+    @GetMapping("/{meetingId}/participants")
+    public ApiResponse<List<MeetingResponseDto.ParticipantInfo>> getParticipants(
+            @PathVariable Long meetingId, @AuthenticationPrincipal AuthMember authMember) {
+        List<MeetingResponseDto.ParticipantInfo> response = meetingService.getParticipants(meetingId, authMember.getUserId());
+        return ApiResponse.onSuccess("회의 참가자 목록 조회가 완료되었습니다.", response);
+    }
 
     @Override
     @PostMapping

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/controller/MeetingWebHookController.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/controller/MeetingWebHookController.java
@@ -1,8 +1,47 @@
 package com._penLearning.Noddi.domain.meeting.controller;
 
+import com._penLearning.Noddi.domain.meeting.service.MeetingService;
+import com._penLearning.Noddi.global.infrastructure.webRtc.dto.DailyWebhookPayloadDto;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 //비동기 요청 확인 위한 로그 출력 목적 태그
 @Slf4j
+@RestController
+@RequestMapping("/webhooks")
+@RequiredArgsConstructor
 public class MeetingWebHookController {
+    private final MeetingService meetingService;
+
+    @PostMapping("/daily")
+    public ResponseEntity<Void> handleDailyWebhook(
+            @RequestBody DailyWebhookPayloadDto payload
+    ) {
+        log.info("[Daily.co Webhook] 이벤트 수신: action={}, roomName={}",
+                payload.getAction(), payload.getRoomName());
+        switch (payload.getAction()) {
+            case "recording.ready" -> {
+                String recordingUrl = buildS3Url(payload.getS3Bucket(), payload.getS3Key());
+                log.info("[Daily.co Webhook] 녹음본 준비 완료: url={}", recordingUrl);
+                meetingService.updateRecordingUrl(payload.getRoomName(), recordingUrl);
+            }
+            case "meeting.ended" -> {
+                log.info("[Daily.co Webhook] 회의 자동 종료 처리: roomName={}", payload.getRoomName());
+                //자동 종료 메서드 추가
+                 meetingService.endMeetingByRoomName(payload.getRoomName());
+            }
+            default ->
+                    log.debug("[Daily.co Webhook] 처리하지 않는 이벤트: {}", payload.getAction());
+        }
+        return ResponseEntity.ok().build();
+    }
+    private String buildS3Url(String bucket, String key) {
+        return String.format("https://%s.s3.amazonaws.com/%s", bucket, key);
+    }
+
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/controller/MeetingWebHookController.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/controller/MeetingWebHookController.java
@@ -2,46 +2,96 @@ package com._penLearning.Noddi.domain.meeting.controller;
 
 import com._penLearning.Noddi.domain.meeting.service.MeetingService;
 import com._penLearning.Noddi.global.infrastructure.webRtc.dto.DailyWebhookPayloadDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-//비동기 요청 확인 위한 로그 출력 목적 태그
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Base64;
+
 @Slf4j
 @RestController
 @RequestMapping("/webhooks")
 @RequiredArgsConstructor
 public class MeetingWebHookController {
+
     private final MeetingService meetingService;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    @Value("${daily.webhook.secret:}")
+    private String webhookSecret;
 
     @PostMapping("/daily")
     public ResponseEntity<Void> handleDailyWebhook(
-            @RequestBody DailyWebhookPayloadDto payload
+            @RequestHeader(value = "X-Webhook-Signature", required = false) String signature,
+            @RequestBody String rawPayload
     ) {
-        log.info("[Daily.co Webhook] 이벤트 수신: action={}, roomName={}",
-                payload.getAction(), payload.getRoomName());
-        switch (payload.getAction()) {
-            case "recording.ready" -> {
-                String recordingUrl = buildS3Url(payload.getS3Bucket(), payload.getS3Key());
-                log.info("[Daily.co Webhook] 녹음본 준비 완료: url={}", recordingUrl);
-                meetingService.updateRecordingUrl(payload.getRoomName(), recordingUrl);
+        try {
+            // 시크릿 키가 세팅되어 있다면 무조건 검증을 수행
+            if (webhookSecret != null && !webhookSecret.isEmpty()) {
+                // 서명이 아예 안 왔거나, 우리가 계산한 해시값과 다르면 해커의 공격으로 간주
+                if (signature == null || !isValidSignature(rawPayload, signature)) {
+                    log.warn("[Daily.co Webhook] 서명 검증 실패. 비정상적인 접근입니다.");
+                    // 401 Unauthorized 에러를 반환
+                    return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+                }
             }
-            case "meeting.ended" -> {
-                log.info("[Daily.co Webhook] 회의 자동 종료 처리: roomName={}", payload.getRoomName());
-                //자동 종료 메서드 추가
-                 meetingService.endMeetingByRoomName(payload.getRoomName());
+
+            DailyWebhookPayloadDto payload = objectMapper.readValue(rawPayload, DailyWebhookPayloadDto.class);
+
+            log.info("[Daily.co Webhook] 이벤트 수신: action={}, roomName={}", payload.getAction(), payload.getRoomName());
+
+            // [3] 기존 분기 처리 로직
+            switch (payload.getAction()) {
+                case "recording.ready" -> {
+                    String recordingUrl = buildS3Url(payload.getS3Bucket(), payload.getS3Key());
+                    log.info("[Daily.co Webhook] 녹음본 준비 완료: url={}", recordingUrl);
+                    meetingService.updateRecordingUrl(payload.getRoomName(), recordingUrl);
+                }
+                case "meeting.ended" -> {
+                    log.info("[Daily.co Webhook] 회의 자동 종료 처리: roomName={}", payload.getRoomName());
+                    meetingService.endMeetingByRoomName(payload.getRoomName());
+                }
+                default ->
+                        log.debug("[Daily.co Webhook] 처리하지 않는 이벤트: {}", payload.getAction());
             }
-            default ->
-                    log.debug("[Daily.co Webhook] 처리하지 않는 이벤트: {}", payload.getAction());
+            return ResponseEntity.ok().build();
+
+        } catch (Exception e) {
+            log.error("[Daily.co Webhook] 웹훅 처리 중 에러 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
-        return ResponseEntity.ok().build();
     }
+
+    // HMAC-SHA256 해시 검증 로직
+    private boolean isValidSignature(String payload, String providedSignature) throws Exception {
+        Mac mac = Mac.getInstance("HmacSHA256");
+        SecretKeySpec secretKey = new SecretKeySpec(webhookSecret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+        mac.init(secretKey);
+
+        // 원본 데이터(String)를 바이트 단위로 쪼개어 해시 암호화를 진행
+        byte[] computedHash = mac.doFinal(payload.getBytes(StandardCharsets.UTF_8));
+        // 암호화된 바이트 배열을 사람이 읽을 수 있는 문자인 Base64로 인코딩
+        String computedSignature = Base64.getEncoder().encodeToString(computedHash);
+
+        // 우리가 직접 계산한 결과와, Daily.co가 헤더로 보내준 서명이 똑같은지 비교
+        return MessageDigest.isEqual(
+                computedSignature.getBytes(StandardCharsets.UTF_8),
+                providedSignature.getBytes(StandardCharsets.UTF_8)
+        );
+    }
+
     private String buildS3Url(String bucket, String key) {
         return String.format("https://%s.s3.amazonaws.com/%s", bucket, key);
     }
-
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/controller/MeetingWebHookController.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/controller/MeetingWebHookController.java
@@ -1,0 +1,8 @@
+package com._penLearning.Noddi.domain.meeting.controller;
+
+import lombok.extern.slf4j.Slf4j;
+
+//비동기 요청 확인 위한 로그 출력 목적 태그
+@Slf4j
+public class MeetingWebHookController {
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/controller/MeetingWebHookController.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/controller/MeetingWebHookController.java
@@ -34,13 +34,14 @@ public class MeetingWebHookController {
     @PostMapping("/daily")
     public ResponseEntity<Void> handleDailyWebhook(
             @RequestHeader(value = "X-Webhook-Signature", required = false) String signature,
+            @RequestHeader(value = "X-Webhook-Timestamp", required = false) String timestamp,
             @RequestBody String rawPayload
     ) {
         try {
             // 시크릿 키가 세팅되어 있다면 무조건 검증을 수행
             if (webhookSecret != null && !webhookSecret.isEmpty()) {
                 // 서명이 아예 안 왔거나, 우리가 계산한 해시값과 다르면 해커의 공격으로 간주
-                if (signature == null || !isValidSignature(rawPayload, signature)) {
+                if (signature == null || !isValidSignature(timestamp, rawPayload, signature)) {
                     log.warn("[Daily.co Webhook] 서명 검증 실패. 비정상적인 접근입니다.");
                     // 401 Unauthorized 에러를 반환
                     return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
@@ -51,19 +52,20 @@ public class MeetingWebHookController {
 
             log.info("[Daily.co Webhook] 이벤트 수신: action={}, roomName={}", payload.getAction(), payload.getRoomName());
 
-            // [3] 기존 분기 처리 로직
-            switch (payload.getAction()) {
-                case "recording.ready" -> {
-                    String recordingUrl = buildS3Url(payload.getS3Bucket(), payload.getS3Key());
-                    log.info("[Daily.co Webhook] 녹음본 준비 완료: url={}", recordingUrl);
-                    meetingService.updateRecordingUrl(payload.getRoomName(), recordingUrl);
+            if (payload.getAction() != null) {
+                switch (payload.getAction()) {
+                    case "recording.ready-to-download" -> {
+                        String recordingUrl = buildS3Url(payload.getS3Bucket(), payload.getS3Key());
+                        log.info("[Daily.co Webhook] 녹음본 준비 완료: url={}", recordingUrl);
+                        meetingService.updateRecordingUrl(payload.getRoomName(), recordingUrl);
+                    }
+                    case "meeting.ended" -> {
+                        log.info("[Daily.co Webhook] 회의 자동 종료 처리: roomName={}", payload.getRoomName());
+                        meetingService.endMeetingByRoomName(payload.getRoomName());
+                    }
+                    default ->
+                            log.debug("[Daily.co Webhook] 처리하지 않는 이벤트: {}", payload.getAction());
                 }
-                case "meeting.ended" -> {
-                    log.info("[Daily.co Webhook] 회의 자동 종료 처리: roomName={}", payload.getRoomName());
-                    meetingService.endMeetingByRoomName(payload.getRoomName());
-                }
-                default ->
-                        log.debug("[Daily.co Webhook] 처리하지 않는 이벤트: {}", payload.getAction());
             }
             return ResponseEntity.ok().build();
 
@@ -74,14 +76,15 @@ public class MeetingWebHookController {
     }
 
     // HMAC-SHA256 해시 검증 로직
-    private boolean isValidSignature(String payload, String providedSignature) throws Exception {
+    private boolean isValidSignature(String timestamp, String payload, String providedSignature)
+            throws Exception {
         Mac mac = Mac.getInstance("HmacSHA256");
+
         SecretKeySpec secretKey = new SecretKeySpec(webhookSecret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
         mac.init(secretKey);
 
-        // 원본 데이터(String)를 바이트 단위로 쪼개어 해시 암호화를 진행
-        byte[] computedHash = mac.doFinal(payload.getBytes(StandardCharsets.UTF_8));
-        // 암호화된 바이트 배열을 사람이 읽을 수 있는 문자인 Base64로 인코딩
+        String messageToSign = timestamp + "." + payload;
+        byte[] computedHash = mac.doFinal(messageToSign.getBytes(StandardCharsets.UTF_8));
         String computedSignature = Base64.getEncoder().encodeToString(computedHash);
 
         // 우리가 직접 계산한 결과와, Daily.co가 헤더로 보내준 서명이 똑같은지 비교

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/dto/MeetingRequestDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/dto/MeetingRequestDto.java
@@ -1,0 +1,18 @@
+package com._penLearning.Noddi.domain.meeting.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class MeetingRequestDto {
+    @Getter
+    @NoArgsConstructor
+    public static class Create {
+        @NotNull(message = "팀 ID는 필수입니다.")
+        private Long teamId;
+
+        @NotBlank(message = "회의 제목은 필수입니다.")
+        private String title;
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/dto/MeetingResponseDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/dto/MeetingResponseDto.java
@@ -1,0 +1,65 @@
+package com._penLearning.Noddi.domain.meeting.dto;
+
+import com._penLearning.Noddi.domain.meeting.code.AiStatus;
+import com._penLearning.Noddi.domain.meeting.code.MeetingStatus;
+import com._penLearning.Noddi.domain.meeting.entity.Meeting;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+public class MeetingResponseDto {
+    private static final String DAILY_URL_PREFIX = "https://noddi.daily.co/";
+
+    @Getter
+    @Builder
+    public static class Info {
+        private Long meetingId;
+        private Long teamId;
+        private String title;
+        private MeetingStatus status;
+        private AiStatus aiStatus;
+        private String roomName;
+        private String roomUrl; // 조합된 프론트엔드 접속 URL
+        private LocalDateTime startedAt;
+        private LocalDateTime endedAt;
+        private LocalDateTime createdAt;
+        public static Info from(Meeting meeting) {
+            String url = meeting.getRoomName() != null
+                    ? DAILY_URL_PREFIX + meeting.getRoomName()
+                    : null;
+            return Info.builder()
+                    .meetingId(meeting.getMeetingId())
+                    .teamId(meeting.getTeam().getTeamId())
+                    .title(meeting.getTitle())
+                    .status(meeting.getStatus())
+                    .aiStatus(meeting.getAiStatus())
+                    .roomName(meeting.getRoomName())
+                    .roomUrl(url)
+                    .startedAt(meeting.getStartedAt())
+                    .endedAt(meeting.getEndedAt())
+                    .createdAt(meeting.getCreatedAt())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class Start {
+        private Long meetingId;
+        private String roomName;
+        private String roomUrl;
+
+        public static Start from(Meeting meeting) {
+            String url = meeting.getRoomName() != null
+                    ? DAILY_URL_PREFIX + meeting.getRoomName()
+                    : null;
+            return Start.builder()
+                    .meetingId(meeting.getMeetingId())
+                    .roomName(meeting.getRoomName())
+                    .roomUrl(url)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/entity/AiStatus.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/entity/AiStatus.java
@@ -1,5 +1,0 @@
-package com._penLearning.Noddi.domain.meeting.entity;
-
-public enum AiStatus {
-    PENDING, PROCESSING, COMPLETED, FAILED
-}

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/entity/Meeting.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/entity/Meeting.java
@@ -61,12 +61,12 @@ public class Meeting extends BaseEntity {
         this.aiStatus = AiStatus.PENDING;
     }
 
-    public void start(String roomId) {
+    public void start(String roomName) {
         if (this.status != MeetingStatus.SCHEDULED) {
             throw new GeneralException(MeetingErrorCode.INVALID_STATUS_FOR_START);
         }
         this.status = MeetingStatus.IN_PROGRESS;
-        this.roomName = roomId;
+        this.roomName = roomName;
         this.startedAt = LocalDateTime.now();
     }
 

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/entity/Meeting.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/entity/Meeting.java
@@ -47,7 +47,7 @@ public class Meeting extends BaseEntity {
     private LocalDateTime endedAt;
 
     //webRTC 방 ID LAZY 방식으로 주입(회의 시작 버튼을 눌러야 회의가 열림)
-    private String roomId;
+    private String roomName;
     private String recordingUrl;
     @Lob
     private String transcriptText;
@@ -66,7 +66,7 @@ public class Meeting extends BaseEntity {
             throw new GeneralException(MeetingErrorCode.INVALID_STATUS_FOR_START);
         }
         this.status = MeetingStatus.IN_PROGRESS;
-        this.roomId = roomId;
+        this.roomName = roomId;
         this.startedAt = LocalDateTime.now();
     }
 

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/entity/Meeting.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/entity/Meeting.java
@@ -1,8 +1,12 @@
 package com._penLearning.Noddi.domain.meeting.entity;
 
+import com._penLearning.Noddi.domain.meeting.code.AiStatus;
+import com._penLearning.Noddi.domain.meeting.code.MeetingErrorCode;
+import com._penLearning.Noddi.domain.meeting.code.MeetingStatus;
 import com._penLearning.Noddi.domain.team.entity.Team;
 import com._penLearning.Noddi.domain.user.entity.User;
 import com._penLearning.Noddi.global.common.BaseEntity;
+import com._penLearning.Noddi.global.exception.GeneralException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -14,7 +18,6 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "Meeting")
 public class Meeting extends BaseEntity {
 
     @Id
@@ -36,17 +39,18 @@ public class Meeting extends BaseEntity {
     @Column(nullable = false)
     private MeetingStatus status;
 
-    private LocalDateTime startedAt;
-    private LocalDateTime endedAt;
-    private String roomId;
-    private String recordingUrl;
-
-    @Lob
-    private String transcriptText;
-
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private AiStatus aiStatus;
+
+    private LocalDateTime startedAt;
+    private LocalDateTime endedAt;
+
+    //webRTC 방 ID LAZY 방식으로 주입(회의 시작 버튼을 눌러야 회의가 열림)
+    private String roomId;
+    private String recordingUrl;
+    @Lob
+    private String transcriptText;
 
     @Builder
     public Meeting(Team team, String title, User createdBy) {
@@ -58,24 +62,46 @@ public class Meeting extends BaseEntity {
     }
 
     public void start(String roomId) {
+        if (this.status != MeetingStatus.SCHEDULED) {
+            throw new GeneralException(MeetingErrorCode.INVALID_STATUS_FOR_START);
+        }
         this.status = MeetingStatus.IN_PROGRESS;
         this.roomId = roomId;
         this.startedAt = LocalDateTime.now();
     }
 
-    public void end(String recordingUrl, String transcriptText) {
+    public void end() {
+        if (this.status != MeetingStatus.IN_PROGRESS) {
+            throw new GeneralException(MeetingErrorCode.INVALID_STATUS_FOR_END);
+        }
         this.status = MeetingStatus.ENDED;
         this.endedAt = LocalDateTime.now();
+    }
+
+    /**
+     * 3. 녹음본 URL 업데이트
+     * - 시점: WebRTC Webhook(room.empty 등)으로 S3 업로드 완료 알림 수신 시
+     */
+    public void updateRecordingUrl(String recordingUrl) {
         this.recordingUrl = recordingUrl;
-        this.transcriptText = transcriptText;
+    }
+
+    //Ai 요약 관련 메소드
+    public void startAiProcessing() {
+        if (this.status != MeetingStatus.ENDED) {
+            throw new GeneralException(MeetingErrorCode.INVALID_STATUS_FOR_SUMMARY);
+        }
+        if (this.recordingUrl == null) {
+            throw new GeneralException(MeetingErrorCode.RECORDING_NOT_READY);
+        }
         this.aiStatus = AiStatus.PROCESSING;
     }
-
-    public void completeAi() {
+    public void completeAiProcessing(String transcriptText) {
         this.aiStatus = AiStatus.COMPLETED;
+        this.transcriptText = transcriptText;
     }
 
-    public void failAi() {
+    public void failAiProcessing() {
         this.aiStatus = AiStatus.FAILED;
     }
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/entity/MeetingParticipant.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/entity/MeetingParticipant.java
@@ -10,16 +10,18 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
 @Entity
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "MeetingParticipant", uniqueConstraints = {
+@Table(name = "MeetingParticipant",
+        uniqueConstraints = {
+        //동일 회의 동일 유저 중복 참가 불가
         @UniqueConstraint(columnNames = {"meetingId", "userId"})
 })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MeetingParticipant {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Long participantId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "meetingId", nullable = false)

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/entity/MeetingStatus.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/entity/MeetingStatus.java
@@ -1,5 +1,0 @@
-package com._penLearning.Noddi.domain.meeting.entity;
-
-public enum MeetingStatus {
-    SCHEDULED, IN_PROGRESS, ENDED
-}

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/repository/MeetingParticipantRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/repository/MeetingParticipantRepository.java
@@ -1,11 +1,16 @@
 package com._penLearning.Noddi.domain.meeting.repository;
 
+import com._penLearning.Noddi.domain.meeting.entity.Meeting;
 import com._penLearning.Noddi.domain.meeting.entity.MeetingParticipant;
+import com._penLearning.Noddi.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MeetingParticipantRepository extends JpaRepository<MeetingParticipant, Long> {
-    List<MeetingParticipant> findByMeeting_MeetingId(Long meetingId);
-    boolean existsByMeeting_MeetingIdAndUser_UserId(Long meetingId, Long userId);
+    // 회의 내 특정 참가자 조회 (퇴장 처리 시 사용) - ID조회보다 에러응답 세분화에 용이해서 채택
+    Optional<MeetingParticipant> findByMeetingAndUser(Meeting meeting, User user);
+    // 특정 회의의 전체 참가자 목록 조회
+    List<MeetingParticipant> findAllByMeeting(Meeting meeting);
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/repository/MeetingRepository.java
@@ -1,10 +1,23 @@
 package com._penLearning.Noddi.domain.meeting.repository;
 
 import com._penLearning.Noddi.domain.meeting.entity.Meeting;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
-    List<Meeting> findByTeam_TeamIdOrderByCreatedAtDesc(Long teamId);
+    Optional<Meeting> findByMeetingId(Long meetingId);
+    /**
+     * 비관적 락(Pessimistic Write Lock) 조회
+     * - 사용 시점: start() 호출 시 동시에 여러 명이 눌러도 방이 1개만 생성되도록 보장
+     * - 동작: SELECT ... FOR UPDATE → 트랜잭션 종료 전까지 다른 트랜잭션이 대기
+     */
+    @Lock(LockModeType.PESSIMISTIC_READ)
+    @Query("SELECT m FROM Meeting m WHERE m.meetingId = :meetingId")
+    Optional<Meeting> findByIdWithPessimisticLock(@Param("meetingId") Long meetingId);
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/repository/MeetingRepository.java
@@ -18,7 +18,7 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
      * - 사용 시점: start() 호출 시 동시에 여러 명이 눌러도 방이 1개만 생성되도록 보장
      * - 동작: SELECT ... FOR UPDATE → 트랜잭션 종료 전까지 다른 트랜잭션이 대기
      */
-    @Lock(LockModeType.PESSIMISTIC_READ)
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT m FROM Meeting m WHERE m.meetingId = :meetingId")
     Optional<Meeting> findByIdWithPessimisticLock(@Param("meetingId") Long meetingId);
     List<Meeting> findAllByTeam(Team team);

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/repository/MeetingRepository.java
@@ -22,4 +22,5 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
     @Query("SELECT m FROM Meeting m WHERE m.meetingId = :meetingId")
     Optional<Meeting> findByIdWithPessimisticLock(@Param("meetingId") Long meetingId);
     List<Meeting> findAllByTeam(Team team);
+    Optional<Meeting> findByRoomName(String roomName);
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingService.java
@@ -1,5 +1,6 @@
 package com._penLearning.Noddi.domain.meeting.service;
 
+갸import com._penLearning.Noddi.domain.meeting.code.AiStatus;
 import com._penLearning.Noddi.domain.meeting.code.MeetingErrorCode;
 import com._penLearning.Noddi.domain.meeting.code.MeetingStatus;
 import com._penLearning.Noddi.domain.meeting.dto.MeetingRequestDto;
@@ -133,6 +134,15 @@ public class MeetingService {
         Meeting meeting = getMeetingOrThrow(meetingId);
         User user = getUserOrThrow(currentUserId);
         validateTeamMember(meeting.getTeam(), user);
+
+        //  ENDED(종료된) 회의만 요약 가능
+        if (meeting.getStatus() != MeetingStatus.ENDED) {
+            throw new GeneralException(MeetingErrorCode.INVALID_STATUS_FOR_SUMMARY);
+        }
+        // 이미 PROCESSING(요약 중)이거나 COMPLETED(완료)면 중복 연타 거부
+        if (meeting.getAiStatus() == AiStatus.PROCESSING || meeting.getAiStatus() == AiStatus.COMPLETED) {
+            throw new GeneralException(MeetingErrorCode.ALREADY_PROCESSING_SUMMARY);
+        }
 
         if (meeting.getRecordingUrl() == null) {
             throw new GeneralException(MeetingErrorCode.RECORDING_NOT_READY);

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingService.java
@@ -80,6 +80,8 @@ public class MeetingService {
     }
 
     public MeetingResponseDto.Start startMeeting(Long meetingId, Long currentUserId) {
+
+        transactionTemplate.setPropagationBehavior(org.springframework.transaction.TransactionDefinition.PROPAGATION_REQUIRES_NEW);
         Meeting meeting = getMeetingOrThrow(meetingId);
         User user = getUserOrThrow(currentUserId);
         validateTeamMember(meeting.getTeam(), user);
@@ -122,6 +124,8 @@ public class MeetingService {
     }
 
     public void endMeeting(Long meetingId, Long currentUserId) {
+        //쓰기 전용 트랜잭션 열기
+        transactionTemplate.setPropagationBehavior(org.springframework.transaction.TransactionDefinition.PROPAGATION_REQUIRES_NEW);
 
         String roomNameToDelete = transactionTemplate.execute(status -> {
             Meeting meeting = getMeetingWithLockOrThrow(meetingId);

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingService.java
@@ -94,21 +94,31 @@ public class MeetingService {
 
         //트랜잭션 없는 상태에서 외부 API 호출
         String roomName = webRtcClient.createRoom();
+        log.info("[MeetingService] Daily.co 방 생성 완료: meetingId={}, roomName={}", meetingId, roomName);
         //DB 트랜잭션을 열고 상태를 바꿈
-        return transactionTemplate.execute(status -> {
-            Meeting lockedMeeting = getMeetingWithLockOrThrow(meetingId);
+        try {
+            return transactionTemplate.execute(status -> {
+                Meeting lockedMeeting = getMeetingWithLockOrThrow(meetingId);
 
-            if (lockedMeeting.getStatus() == MeetingStatus.IN_PROGRESS) {
+                if (lockedMeeting.getStatus() == MeetingStatus.IN_PROGRESS) {
+                    saveParticipantIfabsent(lockedMeeting, user);
+                    return MeetingResponseDto.Start.from(lockedMeeting);
+                }
+
+                lockedMeeting.start(roomName);
                 saveParticipantIfabsent(lockedMeeting, user);
+                log.info("[MeetingService] 회의 시작 완료(DB 업데이트): meetingId={}, roomName={}", meetingId, roomName);
                 return MeetingResponseDto.Start.from(lockedMeeting);
+            });
+        }catch (Exception e) {
+            log.error("[MeetingService] DB 상태 변경 실패로 인해 Daily.co 방 보상 삭제(롤백) 진행: roomName={}", roomName, e);
+            try {
+                webRtcClient.deleteRoom(roomName);
+            } catch (Exception ex) {
+                log.error("[MeetingService] Daily.co 보상 삭제 실패 (수동 확인 필요): roomName={}", roomName, ex);
             }
-
-            lockedMeeting.start(roomName);
-            saveParticipantIfabsent(lockedMeeting, user);
-            log.info("[MeetingService] 회의 시작 완료(DB 업데이트): meetingId={}, roomName={}", meetingId, roomName);
-            return MeetingResponseDto.Start.from(lockedMeeting);
-        });
-
+            throw e;
+        }
     }
 
     public void endMeeting(Long meetingId, Long currentUserId) {

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingService.java
@@ -110,9 +110,19 @@ public class MeetingService {
         log.info("[MeetingService] 회의 종료 완료: meetingId={}", meetingId);
     }
 
+    @Transactional
+    public void endMeetingByRoomName(String roomName) {
+        Meeting meeting = getMeetingByRoomNameOrThrow(roomName);
+        // 이미 종료된 회의가 아닐 때만 종료 처리
+        if (meeting.getStatus() == MeetingStatus.IN_PROGRESS) {
+            meeting.end();
+            log.info("[MeetingService] Webhook에 의해 회의 자동 종료 완료: roomName={}", roomName);
+        }
+    }
+
     //웹훅 수신: 녹음본 S3 업로드 완료 시 URL 갱신
-    public void updateRecordingUrl(Long meetingId, String recordingUrl) {
-        Meeting meeting = getMeetingOrThrow(meetingId);
+    public void updateRecordingUrl(String roomName, String recordingUrl) {
+        Meeting meeting = getMeetingByRoomNameOrThrow(roomName);
         meeting.updateRecordingUrl(recordingUrl);
         log.info("[MeetingService] Webhook 녹음본 URL 갱신 완료: meetingId={}, url={}",
                 meeting.getMeetingId(), recordingUrl);
@@ -144,6 +154,11 @@ public class MeetingService {
     }
     private Meeting getMeetingOrThrow(Long meetingId) {
         return meetingRepository.findById(meetingId)
+                .orElseThrow(() -> new GeneralException(MeetingErrorCode.MEETING_NOT_FOUND));
+    }
+
+    private Meeting getMeetingByRoomNameOrThrow(String roomName) {
+        return meetingRepository.findByRoomName(roomName)
                 .orElseThrow(() -> new GeneralException(MeetingErrorCode.MEETING_NOT_FOUND));
     }
 

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingService.java
@@ -106,7 +106,7 @@ public class MeetingService {
         meeting.end();
 
         if(meeting.getRoomName() != null) {
-            webRtcClient.deletRoom(meeting.getRoomName());
+            webRtcClient.deleteRoom(meeting.getRoomName());
         }
         log.info("[MeetingService] 회의 종료 완료: meetingId={}", meetingId);
     }

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingService.java
@@ -152,7 +152,7 @@ public class MeetingService {
     }
 
     private void validateTeamMember(Team team, User user) {
-        boolean isMember = teamMemberRepository.existsByTeamTeamAndUser(team, user);
+        boolean isMember = teamMemberRepository.existsByTeamAndUser(team, user);
         if (!isMember) {
             throw new GeneralException(MeetingErrorCode.NOT_TEAM_MEMBER);
         }

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingService.java
@@ -1,6 +1,6 @@
 package com._penLearning.Noddi.domain.meeting.service;
 
-갸import com._penLearning.Noddi.domain.meeting.code.AiStatus;
+import com._penLearning.Noddi.domain.meeting.code.AiStatus;
 import com._penLearning.Noddi.domain.meeting.code.MeetingErrorCode;
 import com._penLearning.Noddi.domain.meeting.code.MeetingStatus;
 import com._penLearning.Noddi.domain.meeting.dto.MeetingRequestDto;

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingService.java
@@ -20,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.List;
 
@@ -34,6 +35,7 @@ public class MeetingService {
     private final TeamMemberRepository teamMemberRepository;
     private final UserRepository userRepository;
     private final WebRtcClient webRtcClient;
+    private final TransactionTemplate transactionTemplate;
 
     public MeetingResponseDto.Info getMeetingInfo(Long meetingId, Long currentUserId) {
         Meeting meeting = getMeetingOrThrow(meetingId);
@@ -77,38 +79,59 @@ public class MeetingService {
         return MeetingResponseDto.Info.from(savedMeeting);
     }
 
-    @Transactional
     public MeetingResponseDto.Start startMeeting(Long meetingId, Long currentUserId) {
-        Meeting meeting = getMeetingWithLockOrThrow(meetingId);
+        Meeting meeting = getMeetingOrThrow(meetingId);
         User user = getUserOrThrow(currentUserId);
         validateTeamMember(meeting.getTeam(), user);
 
         if(meeting.getStatus() == MeetingStatus.IN_PROGRESS) {
             log.info("[MeetingService] 이미 진행 중인 회의 재입장: meetingId={}", meetingId);
-            return MeetingResponseDto.Start.from(meeting);
+            return transactionTemplate.execute(status -> {
+                saveParticipantIfabsent(meeting, user);
+                return MeetingResponseDto.Start.from(meeting);
+            });
         }
 
+        //트랜잭션 없는 상태에서 외부 API 호출
         String roomName = webRtcClient.createRoom();
-        meeting.start(roomName);
-        saveParticipantIfabsent(meeting, user);
-        log.info("[MeetingService] 회의 시작 완료: meetingId={}, roomName={}",
-                meetingId, roomName);
-        return MeetingResponseDto.Start.from(meeting);
+        //DB 트랜잭션을 열고 상태를 바꿈
+        return transactionTemplate.execute(status -> {
+            Meeting lockedMeeting = getMeetingWithLockOrThrow(meetingId);
+
+            if (lockedMeeting.getStatus() == MeetingStatus.IN_PROGRESS) {
+                saveParticipantIfabsent(lockedMeeting, user);
+                return MeetingResponseDto.Start.from(lockedMeeting);
+            }
+
+            lockedMeeting.start(roomName);
+            saveParticipantIfabsent(lockedMeeting, user);
+            log.info("[MeetingService] 회의 시작 완료(DB 업데이트): meetingId={}, roomName={}", meetingId, roomName);
+            return MeetingResponseDto.Start.from(lockedMeeting);
+        });
 
     }
 
-    @Transactional
     public void endMeeting(Long meetingId, Long currentUserId) {
-        Meeting meeting = getMeetingOrThrow(meetingId);
-        User user = getUserOrThrow(currentUserId);
-        validateTeamMember(meeting.getTeam(), user);
 
-        meeting.end();
+        String roomNameToDelete = transactionTemplate.execute(status -> {
+            Meeting meeting = getMeetingWithLockOrThrow(meetingId);
+            User user = getUserOrThrow(currentUserId);
+            validateTeamMember(meeting.getTeam(), user);
 
-        if(meeting.getRoomName() != null) {
-            webRtcClient.deleteRoom(meeting.getRoomName());
+            if (!meeting.getCreatedBy().getUserId().equals(user.getUserId())) {
+                throw new GeneralException(MeetingErrorCode.NOT_MEETING_CREATOR);
+            }
+
+            meeting.end();
+            log.info("[MeetingService] 회의 종료 완료(DB 업데이트): meetingId={}", meetingId);
+
+            return meeting.getRoomName();
+        });
+
+        if(roomNameToDelete != null) {
+            webRtcClient.deleteRoom(roomNameToDelete);
+            log.info("[MeetingService] Daily.co 방 삭제 완료: roomName={}", roomNameToDelete);
         }
-        log.info("[MeetingService] 회의 종료 완료: meetingId={}", meetingId);
     }
 
     @Transactional
@@ -122,6 +145,7 @@ public class MeetingService {
     }
 
     //웹훅 수신: 녹음본 S3 업로드 완료 시 URL 갱신
+    @Transactional
     public void updateRecordingUrl(String roomName, String recordingUrl) {
         Meeting meeting = getMeetingByRoomNameOrThrow(roomName);
         meeting.updateRecordingUrl(recordingUrl);
@@ -131,7 +155,7 @@ public class MeetingService {
 
     @Transactional
     public void triggerSummary(Long meetingId, Long currentUserId) {
-        Meeting meeting = getMeetingOrThrow(meetingId);
+        Meeting meeting = getMeetingWithLockOrThrow(meetingId);
         User user = getUserOrThrow(currentUserId);
         validateTeamMember(meeting.getTeam(), user);
 

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingService.java
@@ -1,0 +1,7 @@
+package com._penLearning.Noddi.domain.meeting.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class MeetingService {
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingService.java
@@ -53,7 +53,7 @@ public class MeetingService {
 
     @Transactional
     public MeetingResponseDto.Start startMeeting(Long meetingId, Long currentUserId) {
-        Meeting meeting = getMeetingOrThrow(meetingId);
+        Meeting meeting = getMeetingWithLockOrThrow(meetingId);
         User user = getUserOrThrow(currentUserId);
         validateTeamMember(meeting.getTeam(), user);
 
@@ -63,7 +63,7 @@ public class MeetingService {
         }
 
         String roomName = webRtcClient.createRoom();
-        meeting.start();
+        meeting.start(roomName);
         saveParticipantIfabsent(meeting, user);
         log.info("[MeetingService] 회의 시작 완료: meetingId={}, roomName={}",
                 meetingId, roomName);
@@ -121,6 +121,11 @@ public class MeetingService {
     private User getUserOrThrow(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(MeetingErrorCode.USER_NOT_FOUND));
+    }
+
+    private Meeting getMeetingWithLockOrThrow(Long meetingId) {
+        return meetingRepository.findByIdWithPessimisticLock(meetingId)
+                .orElseThrow(() -> new GeneralException(MeetingErrorCode.MEETING_NOT_FOUND));
     }
 
     private void saveParticipantIfabsent(Meeting meeting, User user) {

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingService.java
@@ -20,6 +20,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @Slf4j
 @RequiredArgsConstructor
@@ -32,11 +34,34 @@ public class MeetingService {
     private final UserRepository userRepository;
     private final WebRtcClient webRtcClient;
 
+    public MeetingResponseDto.Info getMeetingInfo(Long meetingId, Long currentUserId) {
+        Meeting meeting = getMeetingOrThrow(meetingId);
+        User user = getUserOrThrow(currentUserId);
+        validateTeamMember(meeting.getTeam(), user);
+        return MeetingResponseDto.Info.from(meeting);
+    }
+
+    public List<MeetingResponseDto.Info> getMeetingsByTeam(Long teamId, Long currentUserId) {
+        Team team = getTeamOrThrow(teamId);
+        User user = getUserOrThrow(currentUserId);
+        validateTeamMember(team, user);
+        return meetingRepository.findAllByTeam(team).stream()
+                .map(MeetingResponseDto.Info::from)
+                .toList();
+    }
+
+    public List<MeetingResponseDto.ParticipantInfo> getParticipants(Long meetingId, Long currentUserId) {
+        Meeting meeting = getMeetingOrThrow(meetingId);
+        User user = getUserOrThrow(currentUserId);
+        validateTeamMember(meeting.getTeam(), user);
+        return meetingParticipantRepository.findAllByMeeting(meeting).stream()
+                .map(MeetingResponseDto.ParticipantInfo::from)
+                .toList();
+    }
     //회의 예약 생성 (SCHEDULED)
     @Transactional
     public MeetingResponseDto.Info createMeeting(MeetingRequestDto.Create request, Long currentUserId) {
-        Team team = teamRepository.findById(request.getTeamId())
-                .orElseThrow(() -> new GeneralException(MeetingErrorCode.TEAM_NOT_FOUND));
+        Team team = getTeamOrThrow(request.getTeamId());
         User user = getUserOrThrow(currentUserId);
         validateTeamMember(team, user);
 
@@ -113,6 +138,10 @@ public class MeetingService {
         }
     }
 
+    private Team getTeamOrThrow(Long teamId) {
+        return teamRepository.findById(teamId)
+                .orElseThrow(() -> new GeneralException(MeetingErrorCode.TEAM_NOT_FOUND));
+    }
     private Meeting getMeetingOrThrow(Long meetingId) {
         return meetingRepository.findById(meetingId)
                 .orElseThrow(() -> new GeneralException(MeetingErrorCode.MEETING_NOT_FOUND));

--- a/src/main/java/com/_penLearning/Noddi/domain/team/repository/TeamMemberRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/team/repository/TeamMemberRepository.java
@@ -12,5 +12,5 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
     List<TeamMember> findByTeam_TeamId(Long teamId);
     List<TeamMember> findByUser_UserId(Long userId);
     Optional<TeamMember> findByTeam_TeamIdAndUser_UserId(Long teamId, Long userId);
-    boolean existsByTeamTeamAndUser(Team team, User user);
+    boolean existsByTeamAndUser(Team team, User user);
 }

--- a/src/main/java/com/_penLearning/Noddi/global/config/TestDataInitializer.java
+++ b/src/main/java/com/_penLearning/Noddi/global/config/TestDataInitializer.java
@@ -2,37 +2,130 @@ package com._penLearning.Noddi.global.config;
 
 import com._penLearning.Noddi.domain.organization.entity.Organization;
 import com._penLearning.Noddi.domain.organization.repository.OrganizationRepository;
+import com._penLearning.Noddi.domain.project.entity.Project;
+import com._penLearning.Noddi.domain.project.repository.ProjectRepository;
+import com._penLearning.Noddi.domain.team.entity.Team;
+import com._penLearning.Noddi.domain.team.entity.TeamMember;
+import com._penLearning.Noddi.domain.team.entity.TeamRole;
+import com._penLearning.Noddi.domain.team.repository.TeamMemberRepository;
+import com._penLearning.Noddi.domain.team.repository.TeamRepository;
+import com._penLearning.Noddi.domain.user.entity.User;
+import com._penLearning.Noddi.domain.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 
+@Slf4j
 @Component
+@Profile({"local", "dev", "default"}) // 👈 default 프로필(로컬 기본 실행)에서도 작동하도록 추가!
 @RequiredArgsConstructor
 public class TestDataInitializer implements CommandLineRunner {
 
     private final OrganizationRepository organizationRepository;
+    private final UserRepository userRepository;
+    private final ProjectRepository projectRepository;
+    private final TeamRepository teamRepository;
+    private final TeamMemberRepository teamMemberRepository;
+    private final BCryptPasswordEncoder passwordEncoder;
 
     @Override
     @Transactional
     public void run(String... args) {
-        if (organizationRepository.count() == 0) {
+        // 💡 유저 데이터가 없을 때 더미 생성을 확실히 실행!
+        if (userRepository.count() == 0) {
 
-            // 1. 홍익대학교 학생 도메인 적용
+            // 1. 조직(Organization) 더미 생성
             Organization hongik = Organization.builder()
                     .name("홍익대학교")
                     .emailDomain("g.hongik.ac.kr")
                     .build();
 
-            // 2. 메일 발송 기능 자체 테스트용 (필요 시 사용)
             Organization testOrg = Organization.builder()
                     .name("테스트 조직(Gmail)")
                     .emailDomain("gmail.com")
                     .build();
 
             organizationRepository.saveAll(List.of(hongik, testOrg));
+
+            // 비밀번호 'test' 암호화
+            String encodedPassword = passwordEncoder.encode("test");
+
+            // 2. 유저(User) 3명 더미 생성
+            User user1 = User.builder()
+                    .organization(testOrg)
+                    .email("test1@gmail.com")
+                    .name("테스트 유저 1")
+                    .password(encodedPassword)
+                    .build();
+
+            User user2 = User.builder()
+                    .organization(testOrg)
+                    .email("test2@gmail.com")
+                    .name("테스트 유저 2")
+                    .password(encodedPassword)
+                    .build();
+
+            User user3 = User.builder()
+                    .organization(testOrg)
+                    .email("test3@gmail.com")
+                    .name("테스트 유저 3")
+                    .password(encodedPassword)
+                    .build();
+
+            userRepository.saveAll(List.of(user1, user2, user3));
+
+            // 3. 프로젝트(Project) 더미 생성
+            Project testProject = Project.builder()
+                    .organization(testOrg)
+                    .name("Noddi 협업 캡스톤 프로젝트")
+                    .description("실시간 WebRTC 오디오 및 AI 요약 MVP")
+                    .createdBy(user1)
+                    .build();
+
+            projectRepository.save(testProject);
+
+            // 4. 팀(Team) 더미 생성 (1번 팀)
+            Team testTeam = Team.builder()
+                    .project(testProject)
+                    .name("Noddi 백엔드 개발팀")
+                    .createdBy(user1)
+                    .build();
+
+            teamRepository.save(testTeam);
+
+            // 5. 1번 팀에 유저 3명 모두 팀원으로 매핑 (TeamMember)
+            TeamMember tm1 = TeamMember.builder()
+                    .team(testTeam)
+                    .user(user1)
+                    .role(TeamRole.OWNER)
+                    .build();
+
+            TeamMember tm2 = TeamMember.builder()
+                    .team(testTeam)
+                    .user(user2)
+                    .role(TeamRole.MEMBER)
+                    .build();
+
+            TeamMember tm3 = TeamMember.builder()
+                    .team(testTeam)
+                    .user(user3)
+                    .role(TeamRole.MEMBER)
+                    .build();
+
+            teamMemberRepository.saveAll(List.of(tm1, tm2, tm3));
+
+            log.info("[TestDataInitializer] 로컬/개발용 더미 데이터 생성 완료!");
+            log.info(" - 공통 비밀번호: test");
+            log.info(" - 1번 팀(teamId: {}) 팀원 계정 목록:", testTeam.getTeamId());
+            log.info("   1) test1@gmail.com (userId: {}, LEADER)", user1.getUserId());
+            log.info("   2) test2@gmail.com (userId: {}, MEMBER)", user2.getUserId());
+            log.info("   3) test3@gmail.com (userId: {}, MEMBER)", user3.getUserId());
         }
     }
 }

--- a/src/main/java/com/_penLearning/Noddi/global/config/WebRtcConfig.java
+++ b/src/main/java/com/_penLearning/Noddi/global/config/WebRtcConfig.java
@@ -1,0 +1,20 @@
+package com._penLearning.Noddi.global.config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class WebRtcConfig {
+    @Value("${daily.api.key}")
+    private String dailyApiKey;
+
+    @Bean(name = "dailyRestClient")
+    public RestClient dailyRestClient() {
+        return RestClient.builder()
+                .baseUrl("https://api.daily.co/v1")
+                .defaultHeader("Authorization", "Bearer " + dailyApiKey)
+                .defaultHeader("Content-Type", "application/json")
+                .build();
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/global/config/WebRtcConfig.java
+++ b/src/main/java/com/_penLearning/Noddi/global/config/WebRtcConfig.java
@@ -2,6 +2,7 @@ package com._penLearning.Noddi.global.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 
 @Configuration
@@ -11,6 +12,10 @@ public class WebRtcConfig {
 
     @Bean(name = "dailyRestClient")
     public RestClient dailyRestClient() {
+        // 💡 3초 타임아웃 설정으로 DB 커넥션 풀 고갈 완벽 방어!
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(3000); // 연결 타임아웃 3초
+        factory.setReadTimeout(3000);    // 응답 타임아웃 3초
         return RestClient.builder()
                 .baseUrl("https://api.daily.co/v1")
                 .defaultHeader("Authorization", "Bearer " + dailyApiKey)

--- a/src/main/java/com/_penLearning/Noddi/global/infrastructure/webRtc/DailyCoWebRtcClient.java
+++ b/src/main/java/com/_penLearning/Noddi/global/infrastructure/webRtc/DailyCoWebRtcClient.java
@@ -1,0 +1,48 @@
+package com._penLearning.Noddi.global.infrastructure.webRtc;
+
+import com._penLearning.Noddi.global.infrastructure.webRtc.dto.DailyCreateRoomResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DailyCoWebRtcClient implements WebRtcClient{
+
+    @Qualifier("dailyRestClient")
+    private final RestClient restClient;
+
+    @Override
+    public String createRoom() {
+        //방 이름 고유화
+        String roomName = "noddi-" + UUID.randomUUID().toString().substring(0, 8);
+
+        DailyCreateRoomResponseDto response = restClient.post()
+                .uri("/rooms")
+                .body(Map.of("name", roomName,
+                        "privacy", "private"
+                        , "properties", Map.of(
+                                "enable_recording", "cloud"
+                        )
+                ))
+                .retrieve()
+                .body(DailyCreateRoomResponseDto.class);
+        log.info("[Daily.co] 방 생성 완료: roomName={}", response.getName());
+        return response.getName();
+    }
+
+    @Override
+    public void deletRoom(String roomName) {
+        restClient.delete()
+                .uri("/rooms/{roomName}", roomName)
+                .retrieve()
+                .toBodilessEntity();
+        log.info("[Daily.co] 방 삭제 완료: roomName={}", roomName);
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/global/infrastructure/webRtc/DailyCoWebRtcClient.java
+++ b/src/main/java/com/_penLearning/Noddi/global/infrastructure/webRtc/DailyCoWebRtcClient.java
@@ -57,7 +57,7 @@ public class DailyCoWebRtcClient implements WebRtcClient{
     }
 
     @Override
-    public void deletRoom(String roomName) {
+    public void deleteRoom(String roomName) {
         restClient.delete()
                 .uri("/rooms/{roomName}", roomName)
                 .retrieve()

--- a/src/main/java/com/_penLearning/Noddi/global/infrastructure/webRtc/DailyCoWebRtcClient.java
+++ b/src/main/java/com/_penLearning/Noddi/global/infrastructure/webRtc/DailyCoWebRtcClient.java
@@ -1,5 +1,7 @@
 package com._penLearning.Noddi.global.infrastructure.webRtc;
 
+import com._penLearning.Noddi.domain.meeting.code.MeetingErrorCode;
+import com._penLearning.Noddi.global.exception.GeneralException;
 import com._penLearning.Noddi.global.infrastructure.webRtc.dto.DailyCreateRoomResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,18 +25,20 @@ public class DailyCoWebRtcClient implements WebRtcClient{
         //방 이름 고유화
         String roomName = "noddi-" + UUID.randomUUID().toString().substring(0, 8);
 
-        DailyCreateRoomResponseDto response = restClient.post()
-                .uri("/rooms")
-                .body(Map.of("name", roomName,
-                        "privacy", "private"
-                        , "properties", Map.of(
-                                "enable_recording", "cloud"
-                        )
-                ))
-                .retrieve()
-                .body(DailyCreateRoomResponseDto.class);
-        log.info("[Daily.co] 방 생성 완료: roomName={}", response.getName());
-        return response.getName();
+        try {
+            DailyCreateRoomResponseDto response = restClient.post()
+                    .uri("/rooms")
+                    .body(Map.of("name", roomName, "privacy", "private", "properties", Map.of("enable_recording", "cloud")))
+                    .retrieve()
+                    .body(DailyCreateRoomResponseDto.class);
+
+            log.info("[Daily.co] 방 생성 완료: roomName={}", response.getName());
+            return response.getName();
+        } catch (Exception e) {
+            // 💡 타임아웃이나 Daily.co API 에러 발생 시 예쁜 커스텀 에러로 변환!
+            log.error("[Daily.co] 방 생성 통신 실패/타임아웃 발생: {}", e.getMessage());
+            throw new GeneralException(MeetingErrorCode.WEBRTC_ROOM_CREATE_FAILED);
+        }
     }
 
     @Override

--- a/src/main/java/com/_penLearning/Noddi/global/infrastructure/webRtc/DailyCoWebRtcClient.java
+++ b/src/main/java/com/_penLearning/Noddi/global/infrastructure/webRtc/DailyCoWebRtcClient.java
@@ -25,10 +25,25 @@ public class DailyCoWebRtcClient implements WebRtcClient{
         //방 이름 고유화
         String roomName = "noddi-" + UUID.randomUUID().toString().substring(0, 8);
 
+        //현재 시각 + 10분(600초) 후 Unix Timestamp(초 단위) 계산
+        long exp = (System.currentTimeMillis() / 1000) + 600;
         try {
             DailyCreateRoomResponseDto response = restClient.post()
                     .uri("/rooms")
-                    .body(Map.of("name", roomName, "privacy", "private", "properties", Map.of("enable_recording", "cloud")))
+                    .body(Map.of(
+                            "name", roomName,
+                            "privacy", "public",
+                            "properties", Map.of(
+                                    "enable_recording", "cloud",
+                                    "enable_hand_raising", true,     // 1. 손들기 기능 켜기
+                                    "enable_emoji_reactions", true,  // 2. 이모지 리액션 켜기
+                                    "enable_chat", true,             // 3. 텍스트 채팅창 켜기
+                                    "lang", "ko",                     // 4. 한국어 UI 설정
+                                    "max_participants", 10,           // 5. 최대 정원 10명 제한
+                                    "exp", exp,                       // 6. 10분 후 방 만료
+                                    "eject_at_room_exp", true         // 7. 만료 시 자동 강퇴
+                            )
+                    ))
                     .retrieve()
                     .body(DailyCreateRoomResponseDto.class);
 

--- a/src/main/java/com/_penLearning/Noddi/global/infrastructure/webRtc/WebRtcClient.java
+++ b/src/main/java/com/_penLearning/Noddi/global/infrastructure/webRtc/WebRtcClient.java
@@ -1,0 +1,15 @@
+package com._penLearning.Noddi.global.infrastructure.webRtc;
+
+//Api변경 확장성을 위해 인터페이스를 사용합니다
+public interface WebRtcClient {
+    /**
+     * Daily.co에 방을 생성하고 roomId(URL)를 반환합니다.
+     * @return 생성된 방의 고유 이름 (예: "noddi-room-abc123")
+     */
+    String createRoom();
+    /**
+     * Daily.co에 방을 삭제합니다. (회의 종료 시 호출)
+     * @param roomName 삭제할 방 이름
+     */
+    void deletRoom(String roomName);
+}

--- a/src/main/java/com/_penLearning/Noddi/global/infrastructure/webRtc/WebRtcClient.java
+++ b/src/main/java/com/_penLearning/Noddi/global/infrastructure/webRtc/WebRtcClient.java
@@ -11,5 +11,5 @@ public interface WebRtcClient {
      * Daily.co에 방을 삭제합니다. (회의 종료 시 호출)
      * @param roomName 삭제할 방 이름
      */
-    void deletRoom(String roomName);
+    void deleteRoom(String roomName);
 }

--- a/src/main/java/com/_penLearning/Noddi/global/infrastructure/webRtc/dto/DailyCreateRoomResponseDto.java
+++ b/src/main/java/com/_penLearning/Noddi/global/infrastructure/webRtc/dto/DailyCreateRoomResponseDto.java
@@ -1,0 +1,10 @@
+package com._penLearning.Noddi.global.infrastructure.webRtc.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+//daily.co REST API의 방 생성 응답 JSON을 매핑하는 Dto
+@Getter
+public class DailyCreateRoomResponseDto {
+    private String name;
+}

--- a/src/main/java/com/_penLearning/Noddi/global/infrastructure/webRtc/dto/DailyWebhookPayloadDto.java
+++ b/src/main/java/com/_penLearning/Noddi/global/infrastructure/webRtc/dto/DailyWebhookPayloadDto.java
@@ -1,24 +1,58 @@
 package com._penLearning.Noddi.global.infrastructure.webRtc.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 
-//daily.co가 웹훅으로 보내주는 이벤트 페이로드 Dto
+// Daily.co 웹훅 실제 수신 JSON 페이로드 Dto
 @Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class DailyWebhookPayloadDto {
-    //(예: "recording.ready", "meeting.ended")
-    private String action;
 
-    @JsonProperty("room_name")
-    private String roomName;
+    // Daily.co는 이벤트 종류를 "type" 필드로
+    @JsonProperty("type")
+    private String type;
 
-    //recording.ready 이벤트 시에만 채워짐
-    @JsonProperty("recording_id")
-    private String recordingId;
+    private String action; // 하위 호환성용
 
-    @JsonProperty("s3_key")
-    private String s3Key;
+    // 세부 데이터는 "payload" 중첩 객체 안에 있음
+    @JsonProperty("payload")
+    private EventDetail payload;
 
-    @JsonProperty("s3_bucket")
-    private String s3Bucket;
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class EventDetail {
+        @JsonProperty("room")
+        private String room;
+
+        @JsonProperty("room_name")
+        private String roomName;
+
+        @JsonProperty("s3_key")
+        private String s3Key;
+
+        @JsonProperty("s3_bucket")
+        private String s3Bucket;
+
+        public String getRoomName() {
+            return room != null ? room : roomName;
+        }
+    }
+
+    // 💡 기존 컨트롤러 코드와의 호환성을 위한 헬퍼 메서드들
+    public String getAction() {
+        return type != null ? type : action;
+    }
+
+    public String getRoomName() {
+        return payload != null ? payload.getRoomName() : null;
+    }
+
+    public String getS3Bucket() {
+        return payload != null ? payload.getS3Bucket() : null;
+    }
+
+    public String getS3Key() {
+        return payload != null ? payload.getS3Key() : null;
+    }
 }

--- a/src/main/java/com/_penLearning/Noddi/global/infrastructure/webRtc/dto/DailyWebhookPayloadDto.java
+++ b/src/main/java/com/_penLearning/Noddi/global/infrastructure/webRtc/dto/DailyWebhookPayloadDto.java
@@ -1,0 +1,24 @@
+package com._penLearning.Noddi.global.infrastructure.webRtc.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+//daily.co가 웹훅으로 보내주는 이벤트 페이로드 Dto
+@Getter
+public class DailyWebhookPayloadDto {
+    //(예: "recording.ready", "meeting.ended")
+    private String action;
+
+    @JsonProperty("room_name")
+    private String roomName;
+
+    //recording.ready 이벤트 시에만 채워짐
+    @JsonProperty("recording_id")
+    private String recordingId;
+
+    @JsonProperty("s3_key")
+    private String s3Key;
+
+    @JsonProperty("s3_bucket")
+    private String s3Bucket;
+}

--- a/src/main/java/com/_penLearning/Noddi/global/security/SecurityConfig.java
+++ b/src/main/java/com/_penLearning/Noddi/global/security/SecurityConfig.java
@@ -50,8 +50,10 @@ public class SecurityConfig {
                                 .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/api-docs/**", "/v3/api-docs/**").permitAll()
                                 // 회원가입, 로그인 API 허용
                                 .requestMatchers("/api/v1/auth/**").permitAll()
-                                // 임시로 모든 API 테스트 위해 허용
-                                .anyRequest().permitAll()
+                                // Daily.co 웹훅 수신 주소 허용 (JWT 무인증 외부 알림)
+                                .requestMatchers("/webhooks/**").permitAll()
+                                // 그 외 모든 요청은 인증 필요 (테스트 시 필요시 permitAll로 변경 가능)
+                                .anyRequest().authenticated()
 
                 )
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,3 +16,6 @@ spring:
 jwt:
   secret: YOUR_VERY_LONG_SECRET_KEY_EXCLUSIVELY_FOR_HS512_ALGORITHM_MIN_64_BYTES
   expiration: 86400000
+daily:
+  api:
+    key: ${DAILY_API_KEY}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -35,7 +35,7 @@ spring:
           timeout: 5000
           writetimeout: 5000
 jwt:
-  secret: TEMPKEYTEMPKEYTEMPKEYTEMPKEY1234567890abcdefghijklmnopqrstuvw1234
+  secret: TEMPKEYTEMPKEYTEMPKEYTEMPKEY1234567890abcdefghijklmnopqrstuvw1234 #환경변수 설정 필요
   access-token-expiration: 3600000
 cors:
   allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000}
@@ -43,3 +43,5 @@ cors:
 daily:
   api:
     key: ${DAILY_API_KEY}
+  webhook:
+    secret: TEMPKEYTEMPKEYTEMPKEYTEMPKEY1234567890abcdefghijklmnopqrstuvw1234 #환경변수 설정 필요

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -39,3 +39,7 @@ jwt:
   access-token-expiration: 3600000
 cors:
   allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000}
+
+daily:
+  api:
+    key: ${DAILY_API_KEY}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -44,4 +44,4 @@ daily:
   api:
     key: ${DAILY_API_KEY}
   webhook:
-    secret: TEMPKEYTEMPKEYTEMPKEYTEMPKEY1234567890abcdefghijklmnopqrstuvw1234 #환경변수 설정 필요
+    secret: "noddi-secret-123" # Base64 아니고 평문, 환경변수 설정 필요


### PR DESCRIPTION
## <i>PULL REQUEST</i>

## 🎋 작업 브랜치
- feature/3 -> develop
- #3  (관련이슈 번호)

## 💡 작업동기
- 실시간 화상회의방 개설 기능 구현

## 🔑 주요 변경사항
- 현재 화상회의 개설 기능은 작업 완료됐고 녹화본 링크 db저장 관련은 STT 구현할 때 한 번 더 확인해야함
- 웹훅 포스트 url도 배포 후 수정 필요

### 📌 1. 개요 (Overview)
* **작업 목적**: 
팀별 실시간 WebRTC 화상/음성 회의 예약, 
시작(지연 생성), 
종료, 
참가자/회의 조회, 
Daily.co 웹훅 수신 및 AI 요약 수동 트리거 파이프라인 전체 백엔드 구현.
* **주요 해결 이슈**:
  - 동시 시작 시 중복 방 생성 및 데드락(Deadlock) 방지
  - 브라우저 이탈 시 '고아 방(Orphan Room)' 상태 자동 정리 (웹훅 기반)
  - 과금 방지를 위한 수동 AI 요약 트리거 및 중복 연타 방지

---

### 🔥 2. 주요 구현 기능 (Key Features)

1. **지연 방 생성 (Lazy Room Creation) 전략**:
   - 회의 예약(`POST`) 시에는 DB에 `SCHEDULED` 상태로만 저장하고, 최초 참가자가 '회의 시작'(`PATCH /start`)을 누를 때만 외부 WebRTC(Daily.co) 방을 획기적으로 생성하여 불필요한 과금 방지.
2. **비관적 배타 락(`PESSIMISTIC_WRITE`)을 이용한 동시성 제어**:
   - `SELECT ... FOR UPDATE` 쿼리를 통해 0.001초 차이로 동시 진입한 유저가 있어도 락을 통해 줄을 세우고, 두 번째 진입자는 기존 방 주소를 재사용(멱등성 보장)하도록 구현.
3. **Daily.co Webhook 연동 (비동기 자동화)**:
   - `recording.ready`: S3 녹음본 생성이 완료되면 백엔드가 알림을 받아 DB에 `recordingUrl` 자동 업데이트.
   - `meeting.ended`: 유저가 회의 종료 버튼을 누르지 않고 나가도 참가자 0명 시 백엔드가 비동기로 DB 상태를 `ENDED`로 자동 전환.
4. **수동 AI 요약 트리거 (`POST /{id}/summary`)**:
   - 녹음본 파일 존재 검증 및 `aiStatus`가 `PROCESSING`일 때 중복 클릭 거부 예외 처리.
5. **회의 관련 GET 조회 API 3종 구축**:
   - 회의 단건 상세 조회 (`GET /{id}`)
   - 팀별 회의 목록 조회 (`GET ?teamId={id}`)
   - 회의 참가자 목록 조회 (`GET /{id}/participants`)
6. **로컬/개발용 테스트 더미 세팅 (`@Profile({"local", "dev", "default"})`)**:
   - 운영(`prod`) 배포 시에는 스크립트가 비활성화되어 보안/과금 이슈를 원천 차단.

---

### 📂 3. 주요 변경 파일 및 역할 (Files & Responsibilities)

#### 🔹 `domain/meeting/`
* `controller/MeetingController.java`: Meeting API 7개 엔드포인트 구현체 (`MeetingApi` 인터페이스 구현, `@AuthenticationPrincipal AuthMember` 주입)
* `controller/MeetingWebHookController.java`: Daily.co 전용 외부 웹훅 알림 수신 컨트롤러 (`/webhooks/daily`)
* `service/MeetingService.java`: 비관적 락 조회, 권한 검증, 방 생성/종료, 웹훅 처리 등 회의 도메인 핵심 비즈니스 로직
* `repository/MeetingRepository.java`: `findByIdWithPessimisticLock` (비관적 배타 락), `findByRoomName`, `findAllByTeam` 쿼리 메서드 정의
* `repository/MeetingParticipantRepository.java`: 회의 참가자 목록 조회 및 중복 참가 방지 쿼리
* `dto/MeetingRequestDto.java` & `MeetingResponseDto.java`: Static Inner Class 기반 DTO 그룹화 (`Create`, `Info`, `Start`, `ParticipantInfo`)
* `code/MeetingErrorCode.java`: `NOT_TEAM_MEMBER`(403), `RECORDING_NOT_READY`(400), `WEBRTC_ROOM_CREATE_FAILED`(500) 등 세분화된 에러 코드 정의

#### 🔹 `global/`
* `infrastructure/webRtc/DailyCoWebRtcClient.java`: Daily.co REST API 룸 생성/삭제 통신 클라이언트
* `config/WebRtcConfig.java`: Daily.co `RestClient` 빈 설정 (Timeout 3초/5초 가드레일 설정으로 DB 커넥션 고갈 방지)
* `config/SecurityConfig.java`: `/webhooks/**` 경로 시큐리티 `permitAll()` 허용
* `config/TestDataInitializer.java`: 개발용 더미 계정 3개 (`test1~3@gmail.com` / `test`) 및 1번 팀 매핑 자동화

---

### ⚙️ 4. 테스트용 Daily.co 방 정책 설정 (Room Policy)

로컬/스테이징 테스트 및 자원 관리를 위해 방 생성 시 아래 프로퍼티를 적용했습니다:
* **`max_participants`: 10** ➔ 과도한 트래픽 및 오버헤드 방지를 위해 최대 정원을 10명으로 제한.
* **`exp`: [현재시각 + 600초]** ➔ 로컬 테스트용으로 방 유효기간을 생성 후 10분으로 설정.
* **`eject_at_room_exp`: true** ➔ 10분 만료 시 남아있는 유저를 자동으로 강퇴 처리.
* **`lang`: "ko"** ➔ Daily Prebuilt UI 화면 한국어 적용.
* **`enable_chat`: true**, **`enable_hand_raising`: true**, **`enable_emoji_reactions`: true** ➔ 채팅, 손들기, 이모지 버튼 활성화.

---

### 🧪 5. 팀원 테스트 방법
노션 참고

---

## 🏞 스크린샷 (선택)
> 스크린샷을 첨부해주세요.

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
