### PR TITLE
[Feat] 프로젝트 관련 기능 구현

### DIFF
--- a/src/main/java/com/_penLearning/Noddi/NoddiApplication.java
+++ b/src/main/java/com/_penLearning/Noddi/NoddiApplication.java
@@ -3,9 +3,11 @@ package com._penLearning.Noddi;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @EnableJpaAuditing  // BaseEntity의 createdAt, updatedAt 자동 주입 활성화
 @SpringBootApplication
+@EnableAsync // 비동기 기능 활성화
 public class NoddiApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/_penLearning/Noddi/domain/auth/service/AuthService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/auth/service/AuthService.java
@@ -4,6 +4,7 @@ import com._penLearning.Noddi.domain.auth.code.AuthErrorCode;
 import com._penLearning.Noddi.domain.auth.dto.AuthRequestDto;
 import com._penLearning.Noddi.domain.auth.dto.AuthResponseDto;
 import com._penLearning.Noddi.domain.auth.dto.TokenResponseDto;
+import com._penLearning.Noddi.domain.organization.code.OrganizationErrorCode;
 import com._penLearning.Noddi.domain.user.entity.User;
 import com._penLearning.Noddi.domain.user.repository.UserRepository;
 import com._penLearning.Noddi.domain.organization.entity.Organization;
@@ -44,7 +45,7 @@ public class AuthService {
 
         // 3. 조직 조회
         Organization organization = organizationRepository.findById(request.getOrganizationId())
-                .orElseThrow(() -> new IllegalArgumentException("조직이 존재하지 않습니다.")); //OrganizationErrorCode 작성 시 교체 예정
+                .orElseThrow(() -> new GeneralException(OrganizationErrorCode.ORGANIZATION_NOT_FOUND));
 
         // 4. 비밀번호 암호화 및 User 생성
         String encodedPassword = passwordEncoder.encode(request.getPassword());

--- a/src/main/java/com/_penLearning/Noddi/domain/auth/service/EmailService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/auth/service/EmailService.java
@@ -2,17 +2,15 @@ package com._penLearning.Noddi.domain.auth.service;
 
 import com._penLearning.Noddi.domain.auth.code.AuthErrorCode;
 import com._penLearning.Noddi.domain.auth.dto.AuthRequestDto;
+import com._penLearning.Noddi.domain.organization.code.OrganizationErrorCode;
 import com._penLearning.Noddi.domain.organization.entity.Organization;
 import com._penLearning.Noddi.domain.organization.repository.OrganizationRepository;
+import com._penLearning.Noddi.domain.user.repository.UserRepository;
 import com._penLearning.Noddi.global.exception.GeneralException;
+import com._penLearning.Noddi.global.util.EmailAsyncSender;
 import com._penLearning.Noddi.global.util.RedisUtil;
-import jakarta.mail.MessagingException;
-import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.mail.MailException;
-import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,9 +21,10 @@ import java.util.concurrent.ThreadLocalRandom;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class EmailService {
-    private final JavaMailSender mailSender;
     private final RedisUtil redisUtil;
     private final OrganizationRepository organizationRepository;
+    private final UserRepository userRepository;
+    private final EmailAsyncSender emailAsyncSender;
 
     private static final String CODE_PREFIX = "EMAIL_CODE:";
     private static final String VERIFIED_PREFIX = "EMAIL_VERIFIED:";
@@ -37,9 +36,14 @@ public class EmailService {
     // 인증번호 발송
     public void sendVerificationCode(AuthRequestDto.EmailSendRequestDto request) {
 
+        // 이미 가입 된 이메일에 전송 방지
+        if(userRepository.existsByEmail(request.getEmail())){
+            throw new GeneralException(AuthErrorCode.DUPLICATE_EMAIL);
+        }
+
         // 요청된 조직이 존재하는지 확인하고, 입력한 이메일의 도메인이 해당 조직의 도메인과 일치하는지 검증
         Organization organization = organizationRepository.findById(request.getOrganizationId())
-                .orElseThrow(() -> new IllegalArgumentException("조직이 존재하지 않습니다.")); //OrganizationErrorCode 작성 시 교체 예정
+                .orElseThrow(() -> new GeneralException(OrganizationErrorCode.ORGANIZATION_NOT_FOUND));
 
         validateEmailDomain(request.getEmail(), organization.getEmailDomain());
 
@@ -53,7 +57,7 @@ public class EmailService {
         String authCode = String.valueOf(ThreadLocalRandom.current().nextInt(100000, 1000000));
 
         // 메일 발송 (발송 중 에러 발생 시 여기서 예외가 터지므로 이래 Redis 로직은 실행되지 않음)
-        sendMail(request.getEmail(), authCode);
+        emailAsyncSender.sendMailAsync(request.getEmail(), authCode);
 
         // 이메일 발송이 "성공적으로 끝난 경우에만" Redis에 상태를 저장
         String redisKey = CODE_PREFIX + request.getOrganizationId() + ":" + request.getEmail();
@@ -105,30 +109,6 @@ public class EmailService {
         String emailDomain = email.substring(email.indexOf("@") + 1);
         if (!emailDomain.equalsIgnoreCase(allowedDomain)) {
             throw new GeneralException(AuthErrorCode.INVALID_EMAIL_DOMAIN); // "해당 조직의 이메일 도메인과 일치하지 않습니다."
-        }
-    }
-
-    // 실제 메일 발송 로직
-    private void sendMail(String toEmail, String authCode) {
-        try {
-            MimeMessage message = mailSender.createMimeMessage();
-            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
-
-            helper.setTo(toEmail);
-            helper.setSubject("[Noddi] 이메일 인증번호 안내");
-
-            String content = "<h3>Noddi 서비스 이용을 위한 인증번호입니다.</h3>" +
-                    "<br>인증번호: <b>" + authCode + "</b><br>" +
-                    "<p>5분 이내에 입력해 주세요.</p>";
-
-            helper.setText(content, true);
-
-            mailSender.send(message);
-
-        } catch (MessagingException | MailException e) {
-            // MimeMessage 조립 오류(MessagingException)와 SMTP 통신 오류(MailException) 모두 캐치
-            log.error("[Email Error] 메일 발송 실패: {}", e.getMessage());
-            throw new GeneralException(AuthErrorCode.MAIL_SEND_FAILED);
         }
     }
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/organization/code/OrganizationErrorCode.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/organization/code/OrganizationErrorCode.java
@@ -1,0 +1,17 @@
+package com._penLearning.Noddi.domain.organization.code;
+
+import com._penLearning.Noddi.global.apiPayload.code.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum OrganizationErrorCode implements BaseErrorCode {
+
+    ORGANIZATION_NOT_FOUND(HttpStatus.NOT_FOUND, "ORGANIZATION404_1", "해당 조직은 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/project/code/ProjectApi.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/code/ProjectApi.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 
@@ -51,8 +52,8 @@ public interface ProjectApi {
     })
     ApiResponse<Void> updateProject(
             @PathVariable Long projectId,
-            @Parameter(hidden = true) @AuthenticationPrincipal AuthMember authMember,
-            @RequestBody ProjectRequestDto.Update request
+            @Valid @RequestBody ProjectRequestDto.Update request,
+            @Parameter(hidden = true) @AuthenticationPrincipal AuthMember authMember
     );
 
     @Operation(summary = "프로젝트 삭제", description = "프로젝트 리더가 프로젝트를 삭제합니다. 관련된 멤버 정보도 함께 삭제됩니다.")

--- a/src/main/java/com/_penLearning/Noddi/domain/project/code/ProjectApi.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/code/ProjectApi.java
@@ -1,0 +1,68 @@
+package com._penLearning.Noddi.domain.project.code;
+
+import com._penLearning.Noddi.domain.auth.entity.AuthMember;
+import com._penLearning.Noddi.domain.project.dto.ProjectRequestDto;
+import com._penLearning.Noddi.domain.project.dto.ProjectResponseDto;
+import com._penLearning.Noddi.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.List;
+
+@Tag(name = "프로젝트(Project) API", description = "조직 내 프로젝트 생성 및 조회 관련 API")
+public interface ProjectApi {
+
+    @Operation(summary = "프로젝트 생성", description = "인증된 사용자가 자신이 속한 조직 내에 새로운 프로젝트를 생성합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "프로젝트 생성 성공",
+                    content = @Content(schema = @Schema(implementation = ProjectResponseDto.Info.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 (이름 누락 등)",
+                    content = @Content),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "유저 정보 조회 실패",
+                    content = @Content)
+    })
+    ApiResponse<ProjectResponseDto.Info> createProject(
+            @Parameter(hidden = true) @AuthenticationPrincipal AuthMember authMember,
+            ProjectRequestDto.Create request
+    );
+
+    @Operation(summary = "소속 조직 프로젝트 목록 조회", description = "요청한 유저가 속해있는 조직(Organization)의 모든 프로젝트 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "프로젝트 목록 조회 성공",
+                    content = @Content(schema = @Schema(implementation = ProjectResponseDto.Info.class)))
+    })
+    ApiResponse<List<ProjectResponseDto.Info>> getProjects(
+            @Parameter(hidden = true) @AuthenticationPrincipal AuthMember authMember
+    );
+
+    @Operation(summary = "프로젝트 정보 수정", description = "프로젝트 리더가 프로젝트의 이름과 설명을 수정합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "프로젝트 수정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 (이름 누락 등)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "리더 권한 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "프로젝트를 찾을 수 없음")
+    })
+    ApiResponse<Void> updateProject(
+            @PathVariable Long projectId,
+            @Parameter(hidden = true) @AuthenticationPrincipal AuthMember authMember,
+            @RequestBody ProjectRequestDto.Update request
+    );
+
+    @Operation(summary = "프로젝트 삭제", description = "프로젝트 리더가 프로젝트를 삭제합니다. 관련된 멤버 정보도 함께 삭제됩니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "프로젝트 삭제 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "리더 권한 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "프로젝트를 찾을 수 없음")
+    })
+    ApiResponse<Void> deleteProject(
+            @PathVariable Long projectId,
+            @Parameter(hidden = true) @AuthenticationPrincipal AuthMember authMember
+    );
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/project/code/ProjectErrorCode.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/code/ProjectErrorCode.java
@@ -12,7 +12,7 @@ public enum ProjectErrorCode implements BaseErrorCode {
     // 400 BAD_REQUEST
     INVALID_PROJECT_REQUEST(HttpStatus.BAD_REQUEST, "PROJECT400_1", "잘못된 프로젝트 요청입니다."),
     NOT_SAME_ORGANIZATION(HttpStatus.BAD_REQUEST, "PROJECT400_2", "다른 조직 멤버에게는 초대를 전송할 수 없습니다."),
-    CANNOT_REMOVE_LAST_LEADER(HttpStatus.BAD_REQUEST, "PROJECT400_3", "프로젝트의 마지막 멤버는 탈퇴하거나 권한응 강등할 수 없습니다."),
+    CANNOT_REMOVE_LAST_LEADER(HttpStatus.BAD_REQUEST, "PROJECT400_3", "프로젝트의 마지막 멤버는 탈퇴하거나 권한을 강등할 수 없습니다."),
 
     // 403 FORBIDDEN (권한 없음)
     NOT_PROJECT_LEADER(HttpStatus.FORBIDDEN, "PROJECT403_1", "프로젝트 관리자(LEADER) 권한이 필요합니다."),

--- a/src/main/java/com/_penLearning/Noddi/domain/project/code/ProjectErrorCode.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/code/ProjectErrorCode.java
@@ -1,0 +1,32 @@
+package com._penLearning.Noddi.domain.project.code;
+
+import com._penLearning.Noddi.global.apiPayload.code.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ProjectErrorCode implements BaseErrorCode {
+
+    // 400 BAD_REQUEST
+    INVALID_PROJECT_REQUEST(HttpStatus.BAD_REQUEST, "PROJECT400_1", "잘못된 프로젝트 요청입니다."),
+    NOT_SAME_ORGANIZATION(HttpStatus.BAD_REQUEST, "PROJECT400_2", "다른 조직 멤버에게는 초대를 전송할 수 없습니다."),
+    CANNOT_REMOVE_LAST_LEADER(HttpStatus.BAD_REQUEST, "PROJECT400_3", "프로젝트의 마지막 멤버는 탈퇴하거나 권한응 강등할 수 없습니다."),
+
+    // 403 FORBIDDEN (권한 없음)
+    NOT_PROJECT_LEADER(HttpStatus.FORBIDDEN, "PROJECT403_1", "프로젝트 관리자(LEADER) 권한이 필요합니다."),
+    NO_PERMISSION_TO_UPDATE(HttpStatus.FORBIDDEN, "PROJECT403_2", "프로젝트를 수정/삭제할 권한이 없습니다."),
+
+    // 404 NOT_FOUND (존재하지 않음)
+    PROJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "PROJECT404_1", "해당 프로젝트를 찾을 수 없습니다."),
+    PROJECT_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "PROJECT404_2", "해당 프로젝트의 멤버가 아닙니다."),
+
+    // 409 CONFLICT (충돌/중복)
+    ALREADY_PROJECT_MEMBER(HttpStatus.CONFLICT, "PROJECT409_1", "이미 프로젝트에 참여 중인 유저입니다."),
+    ALREADY_INVITED_USER(HttpStatus.CONFLICT, "PROJECT_409_2", "이미 초대를 받고 대기 중인 유저입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/project/code/ProjectMemberApi.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/code/ProjectMemberApi.java
@@ -1,0 +1,58 @@
+package com._penLearning.Noddi.domain.project.code;
+
+import com._penLearning.Noddi.domain.auth.entity.AuthMember;
+import com._penLearning.Noddi.domain.project.dto.ProjectMemberRequestDto;
+import com._penLearning.Noddi.domain.project.dto.ProjectMemberResponseDto;
+import com._penLearning.Noddi.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+
+@Tag(name = "프로젝트 멤버(Project Member) API", description = "프로젝트 멤버 초대, 수락, 권한 변경 및 조회 API")
+public interface ProjectMemberApi {
+
+    @Operation(summary = "프로젝트 멤버 초대", description = "프로젝트 리더가 특정 유저를 프로젝트에 초대합니다.")
+    ApiResponse<Void> inviteUser(
+            @PathVariable Long projectId,
+            @Parameter(hidden = true) @AuthenticationPrincipal AuthMember authMember,
+            @RequestBody ProjectMemberRequestDto.Invite request
+    );
+
+    @Operation(summary = "내가 받은 초대장 목록 조회", description = "유저 본인에게 온 대기 중인 프로젝트 초대장 목록을 조회합니다.")
+    ApiResponse<List<ProjectMemberResponseDto.InvitationInfo>> getMyInvitations(
+            @Parameter(hidden = true) @AuthenticationPrincipal AuthMember authMember
+    );
+
+    @Operation(summary = "프로젝트 초대 수락/거절", description = "받은 초대에 대해 수락(true) 또는 거절(false)을 처리합니다.")
+    ApiResponse<Void> respondToInvitation(
+            @PathVariable Long projectId,
+            @Parameter(hidden = true) @AuthenticationPrincipal AuthMember authMember,
+            @RequestBody ProjectMemberRequestDto.Respond request
+    );
+
+    @Operation(summary = "프로젝트 정식 멤버 조회", description = "해당 프로젝트에 가입 완료된(JOINED) 멤버 목록을 조회합니다.")
+    ApiResponse<List<ProjectMemberResponseDto.MemberInfo>> getMembers(
+            @PathVariable Long projectId,
+            @Parameter(hidden = true) @AuthenticationPrincipal AuthMember authMember
+    );
+
+    @Operation(summary = "프로젝트 멤버 권한 변경", description = "프로젝트 리더가 특정 멤버의 권한을 변경합니다.")
+    ApiResponse<Void> updateMemberRole(
+            @PathVariable Long projectId,
+            @PathVariable Long targetUserId,
+            @Parameter(hidden = true) @AuthenticationPrincipal AuthMember authMember,
+            @RequestBody ProjectMemberRequestDto.UpdateRole request
+    );
+
+    @Operation(summary = "프로젝트 멤버 탈퇴 및 강퇴", description = "리더가 멤버를 강퇴하거나, 본인이 프로젝트에서 스스로 탈퇴합니다.")
+    ApiResponse<Void> removeMember(
+            @PathVariable Long projectId,
+            @PathVariable Long targetUserId,
+            @Parameter(hidden = true) @AuthenticationPrincipal AuthMember authMember
+    );
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/controller/ProjectController.java
@@ -1,0 +1,62 @@
+package com._penLearning.Noddi.domain.project.controller;
+
+import com._penLearning.Noddi.domain.auth.entity.AuthMember;
+import com._penLearning.Noddi.domain.project.code.ProjectApi;
+import com._penLearning.Noddi.domain.project.dto.ProjectRequestDto;
+import com._penLearning.Noddi.domain.project.dto.ProjectResponseDto;
+import com._penLearning.Noddi.domain.project.service.ProjectService;
+import com._penLearning.Noddi.global.apiPayload.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/projects")
+@RequiredArgsConstructor
+public class ProjectController implements ProjectApi {
+
+    private final ProjectService projectService;
+
+    @Override
+    @PostMapping
+    public ApiResponse<ProjectResponseDto.Info> createProject(
+            @AuthenticationPrincipal AuthMember authMember,
+            @RequestBody @Valid ProjectRequestDto.Create request) {
+
+        ProjectResponseDto.Info response = projectService.createProject(authMember.getUserId(), request);
+        return ApiResponse.onSuccess("프로젝트가 성공적으로 생성되었습니다.", response);
+    }
+
+    @Override
+    @GetMapping
+    public ApiResponse<List<ProjectResponseDto.Info>> getProjects(
+            @AuthenticationPrincipal AuthMember authMember) {
+
+        List<ProjectResponseDto.Info> response = projectService.getProjectsByOrganization(authMember.getUserId());
+        return ApiResponse.onSuccess("프로젝트 목록 조회에 성공했습니다.", response);
+    }
+
+    @Override
+    @PatchMapping("/{projectId}")
+    public ApiResponse<Void> updateProject(
+            @PathVariable Long projectId,
+            @Valid @RequestBody ProjectRequestDto.Update request,
+            @AuthenticationPrincipal AuthMember authMember){
+            projectService.updateProject(authMember.getUserId(), projectId, request);
+
+            return ApiResponse.onSuccess("프로젝트 정보 수정을 성공했습니다.");
+    }
+
+    @Override
+    @DeleteMapping("/{projectId}")
+    public ApiResponse<Void> deleteProject(
+            @PathVariable Long projectId,
+            @AuthenticationPrincipal AuthMember authMember) {
+
+        projectService.deleteProject(projectId, authMember.getUserId());
+        return ApiResponse.onSuccess("프로젝트가 성공적으로 삭제되었습니다.");
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/project/controller/ProjectMemberController.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/controller/ProjectMemberController.java
@@ -1,0 +1,95 @@
+package com._penLearning.Noddi.domain.project.controller;
+
+import com._penLearning.Noddi.domain.auth.entity.AuthMember;
+import com._penLearning.Noddi.domain.project.code.ProjectMemberApi;
+import com._penLearning.Noddi.domain.project.dto.ProjectMemberRequestDto;
+import com._penLearning.Noddi.domain.project.dto.ProjectMemberResponseDto;
+import com._penLearning.Noddi.domain.project.service.ProjectMemberService;
+import com._penLearning.Noddi.global.apiPayload.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/projects")
+@RequiredArgsConstructor
+public class ProjectMemberController implements ProjectMemberApi {
+
+    private final ProjectMemberService projectMemberService;
+
+    @Override
+    @PostMapping("/{projectId}/members/invite")
+    public ApiResponse<Void> inviteUser(
+            @PathVariable Long projectId,
+            @AuthenticationPrincipal AuthMember authMember,
+            @RequestBody @Valid ProjectMemberRequestDto.Invite request) {
+
+        projectMemberService.inviteUser(projectId, authMember.getUserId(), request.getTargetUserId());
+        return ApiResponse.onSuccess("프로젝트 초대가 발송되었습니다.");
+    }
+
+    @Override
+    @GetMapping("/invitations")
+    public ApiResponse<List<ProjectMemberResponseDto.InvitationInfo>> getMyInvitations(
+            @AuthenticationPrincipal AuthMember authMember) {
+
+        List<ProjectMemberResponseDto.InvitationInfo> response = projectMemberService.getMyInvitations(authMember.getUserId());
+
+        return ApiResponse.onSuccess("받은 초대장 목록 조회에 성공했습니다.", response);
+    }
+
+    @Override
+    @PostMapping("/{projectId}/invitations/respond")
+    public ApiResponse<Void> respondToInvitation(
+            @PathVariable Long projectId,
+            @AuthenticationPrincipal AuthMember authMember,
+            @RequestBody @Valid ProjectMemberRequestDto.Respond request) {
+
+        projectMemberService.respondToInvitation(projectId, authMember.getUserId(), request.getIsAccepted());
+        String message = request.getIsAccepted() ? "초대를 수락하여 프로젝트에 가입되었습니다." : "초대를 거절했습니다.";
+
+        return ApiResponse.onSuccess(message);
+    }
+
+    @Override
+    @GetMapping("/{projectId}/members")
+    public ApiResponse<List<ProjectMemberResponseDto.MemberInfo>> getMembers(
+            @PathVariable Long projectId,
+            @AuthenticationPrincipal AuthMember authMember) {
+
+
+        List<ProjectMemberResponseDto.MemberInfo> response = projectMemberService.getMembers(projectId, authMember.getUserId()).stream()
+                .map(ProjectMemberResponseDto.MemberInfo::from)
+                .toList();
+
+        return ApiResponse.onSuccess("프로젝트 멤버 목록 조회에 성공했습니다.", response);
+    }
+
+    @Override
+    @PatchMapping("/{projectId}/members/{targetUserId}/role")
+    public ApiResponse<Void> updateMemberRole(
+            @PathVariable Long projectId,
+            @PathVariable Long targetUserId,
+            @AuthenticationPrincipal AuthMember authMember,
+            @RequestBody @Valid ProjectMemberRequestDto.UpdateRole request) {
+
+        projectMemberService.updateMemberRole(projectId, authMember.getUserId(), targetUserId, request.getNewRole());
+
+        return ApiResponse.onSuccess("멤버 권한이 성공적으로 변경되었습니다.");
+    }
+
+    @Override
+    @DeleteMapping("/{projectId}/members/{targetUserId}")
+    public ApiResponse<Void> removeMember(
+            @PathVariable Long projectId,
+            @PathVariable Long targetUserId,
+            @AuthenticationPrincipal AuthMember authMember) {
+
+        projectMemberService.removeMember(projectId, authMember.getUserId(), targetUserId);
+
+        return ApiResponse.onSuccess("프로젝트 멤버 탈퇴 처리가 완료되었습니다.");
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/project/controller/ProjectMemberController.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/controller/ProjectMemberController.java
@@ -5,6 +5,7 @@ import com._penLearning.Noddi.domain.project.code.ProjectMemberApi;
 import com._penLearning.Noddi.domain.project.dto.ProjectMemberRequestDto;
 import com._penLearning.Noddi.domain.project.dto.ProjectMemberResponseDto;
 import com._penLearning.Noddi.domain.project.service.ProjectMemberService;
+import com._penLearning.Noddi.domain.project.service.ProjectService;
 import com._penLearning.Noddi.global.apiPayload.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +20,7 @@ import java.util.List;
 public class ProjectMemberController implements ProjectMemberApi {
 
     private final ProjectMemberService projectMemberService;
+    private final ProjectService projectService;
 
     @Override
     @PostMapping("/{projectId}/members/invite")
@@ -60,11 +62,10 @@ public class ProjectMemberController implements ProjectMemberApi {
             @PathVariable Long projectId,
             @AuthenticationPrincipal AuthMember authMember) {
 
-
-        List<ProjectMemberResponseDto.MemberInfo> response = projectMemberService.getMembers(projectId, authMember.getUserId()).stream()
-                .map(ProjectMemberResponseDto.MemberInfo::from)
-                .toList();
-
+        // 1. 서비스 로직 호출 (결과물은 DTO 리스트로 받음)
+        List<ProjectMemberResponseDto.MemberInfo> response =
+                projectMemberService.getMembers(projectId, authMember.getUserId());
+        // 2. 일관된 응답 포맷(ApiResponse)으로 감싸서 리턴
         return ApiResponse.onSuccess("프로젝트 멤버 목록 조회에 성공했습니다.", response);
     }
 

--- a/src/main/java/com/_penLearning/Noddi/domain/project/dto/ProjectMemberRequestDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/dto/ProjectMemberRequestDto.java
@@ -1,0 +1,31 @@
+package com._penLearning.Noddi.domain.project.dto;
+
+import com._penLearning.Noddi.domain.project.entity.ProjectRole;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ProjectMemberRequestDto {
+
+    @Getter
+    @NoArgsConstructor
+    public static class Invite {
+        @NotNull(message = "초대할 유저의 ID는 필수입니다.")
+        private Long targetUserId;
+        // 유저 ID 대신 이메일(String targetEmail)로 초대하게 될 경우 이 필드를 변경해야 함
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class Respond {
+        @NotNull(message = "수락 여부는 필수 입력값입니다.")
+        private Boolean isAccepted;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class UpdateRole {
+        @NotNull(message = "변경할 권한은 필수 입력값입니다.")
+        private ProjectRole newRole;
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/project/dto/ProjectMemberResponseDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/dto/ProjectMemberResponseDto.java
@@ -1,0 +1,47 @@
+package com._penLearning.Noddi.domain.project.dto;
+
+import com._penLearning.Noddi.domain.project.entity.ProjectMember;
+import com._penLearning.Noddi.domain.project.entity.ProjectRole;
+import lombok.Builder;
+import lombok.Getter;
+
+public class ProjectMemberResponseDto {
+
+    // 프로젝트 멤버 조회용 Dto
+    @Getter
+    @Builder
+    public static class MemberInfo {
+        private Long userId;
+        private String name;
+        private String email;
+        private ProjectRole role;
+
+        public static MemberInfo from(ProjectMember projectMember) {
+            return MemberInfo.builder()
+                    .userId(projectMember.getUser().getUserId())
+                    .name(projectMember.getUser().getName())
+                    .email(projectMember.getUser().getEmail())
+                    .role(projectMember.getRole())
+                    .build();
+        }
+    }
+
+    // 내가 받은 초대장 조회용 Dto
+    @Getter
+    @Builder
+    public static class InvitationInfo {
+        private Long projectId;
+        private String projectName;
+        private String projectDescription;
+        private ProjectRole offeredRole; // 어떤 권한으로 초대받았는지 명시
+
+        public static InvitationInfo from(ProjectMember projectMember) {
+            return InvitationInfo.builder()
+                    .projectId(projectMember.getProject().getProjectId())
+                    .projectName(projectMember.getProject().getName()) // N:1 연관관계(Fetch Join)로 가져온 프로젝트 이름
+                    .projectDescription(projectMember.getProject().getDescription())
+                    .offeredRole(projectMember.getRole())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/project/dto/ProjectRequestDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/dto/ProjectRequestDto.java
@@ -1,0 +1,29 @@
+package com._penLearning.Noddi.domain.project.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ProjectRequestDto {
+
+    @Getter
+    @NoArgsConstructor
+    public static class Create {
+
+        @NotBlank(message = "프로젝트 이름은 필수 입력값입니다.")
+        private String name;
+
+        @NotBlank(message = "프로젝트 설명은 필수 입력값입니다.")
+        private String description;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class Update {
+        @NotBlank(message = "프로젝트 이름은 필수 입력값입니다.")
+        private String name;
+
+        @NotBlank(message = "프로젝트 설명은 필수 입력값입니다.")
+        private String description;
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/project/dto/ProjectResponseDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/dto/ProjectResponseDto.java
@@ -1,0 +1,31 @@
+package com._penLearning.Noddi.domain.project.dto;
+
+import com._penLearning.Noddi.domain.project.entity.Project;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+public class ProjectResponseDto {
+
+    @Getter
+    @Builder
+    public static class Info {
+
+        private Long projectId;
+        private String name;
+        private String description;
+        private String createdByName; // 생성자 이름 (UI 표시용)
+        private LocalDateTime createdAt;
+
+        public static Info from(Project project) {
+            return Info.builder()
+                    .projectId(project.getProjectId())
+                    .name(project.getName())
+                    .description(project.getDescription())
+                    .createdByName(project.getCreatedBy().getName()) // User 엔티티의 이름
+                    .createdAt(project.getCreatedAt())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/project/entity/JoinStatus.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/entity/JoinStatus.java
@@ -1,0 +1,7 @@
+package com._penLearning.Noddi.domain.project.entity;
+
+public enum JoinStatus {
+    INVITED,  // 초대를 받고 대기 중인 상태
+    JOINED,   // 수락 완료 (정식 멤버)
+    REJECTED  // 초대 거절
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/project/entity/Project.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/entity/Project.java
@@ -32,11 +32,25 @@ public class Project extends BaseEntity {
     @JoinColumn(name = "createdBy", nullable = false)
     private User createdBy;
 
+    public void updateProjectInfo(String name, String description) {
+        this.name = name;
+        this.description = description;
+    }
+
     @Builder
     public Project(Organization organization, String name, String description, User createdBy) {
         this.organization = organization;
         this.name = name;
         this.description = description;
         this.createdBy = createdBy;
+    }
+
+    public static Project create(String name, String description, Organization organization, User createdBy) {
+        return Project.builder()
+                .name(name)
+                .description(description)
+                .organization(organization)
+                .createdBy(createdBy)
+                .build();
     }
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/project/entity/ProjectMember.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/entity/ProjectMember.java
@@ -1,0 +1,67 @@
+package com._penLearning.Noddi.domain.project.entity;
+
+import com._penLearning.Noddi.domain.user.entity.User;
+import com._penLearning.Noddi.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "ProjectMember")
+public class ProjectMember extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long projectMemberId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "projectId", nullable = false)
+    private Project project;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userId", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ProjectRole role;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private JoinStatus status; // 상태 필드 추가
+
+    @Builder
+    public ProjectMember(Project project, User user, ProjectRole role, JoinStatus status) {
+        this.project = project;
+        this.user = user;
+        this.role = role;
+        this.status = status;
+    }
+
+    // 객체 생성 책임을 캡슐화한 정적 팩토리 메서드
+    public static ProjectMember create(Project project, User user, ProjectRole role, JoinStatus status) {
+        return ProjectMember.builder()
+                .project(project)
+                .user(user)
+                .role(role)
+                .status(status)
+                .build();
+    }
+
+    // 상태 변경 로직 캡슐화
+    public void acceptInvitation() {
+        this.status = JoinStatus.JOINED;
+    }
+
+    public void rejectInvitation() {
+        this.status = JoinStatus.REJECTED;
+    }
+
+    public void updateRole(ProjectRole newRole) {
+        this.role = newRole;
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/project/entity/ProjectMember.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/entity/ProjectMember.java
@@ -11,7 +11,9 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "ProjectMember")
+@Table(name = "ProjectMember", uniqueConstraints = {
+@UniqueConstraint(name = "UK_PROJECT_USER", columnNames = {"projectId", "userId"})
+})
 public class ProjectMember extends BaseEntity {
 
     @Id

--- a/src/main/java/com/_penLearning/Noddi/domain/project/entity/ProjectRole.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/entity/ProjectRole.java
@@ -1,0 +1,6 @@
+package com._penLearning.Noddi.domain.project.entity;
+
+public enum ProjectRole {
+    LEADER,  // 프로젝트 생성자 및 관리자
+    MEMBER   // 일반 초대 멤버
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/project/repository/ProjectMemberRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/repository/ProjectMemberRepository.java
@@ -1,0 +1,35 @@
+package com._penLearning.Noddi.domain.project.repository;
+
+import com._penLearning.Noddi.domain.project.dto.ProjectMemberResponseDto;
+import com._penLearning.Noddi.domain.project.entity.JoinStatus;
+import com._penLearning.Noddi.domain.project.entity.Project;
+import com._penLearning.Noddi.domain.project.entity.ProjectMember;
+import com._penLearning.Noddi.domain.project.entity.ProjectRole;
+import com._penLearning.Noddi.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Long> {
+
+    // 특정 프로젝트에 특정 유저가 존재하는지 확인 (중복 초대 방지)
+    boolean existsByProjectAndUser(Project project, User user);
+
+    // 단건 조회 (권한 검증 및 탈퇴 로직에 사용)
+    Optional<ProjectMember> findByProjectAndUser(Project project, User user);
+
+    // 프로젝트의 정식 멤버 목록 조회 (상태가 JOINED인 사람만)
+    @Query("SELECT pm FROM ProjectMember pm JOIN FETCH pm.user WHERE pm.project = :project AND pm.status = 'JOINED'")
+    List<ProjectMember> findJoinedMembersByProject(@Param("project") Project project);
+
+    // 내가 받은 초대장 목록 조회 (N+1 방지를 위해 Project 패치 조인)
+    @Query("SELECT pm FROM ProjectMember pm JOIN FETCH pm.project WHERE pm.user = :user AND pm.status = 'INVITED'")
+    List<ProjectMember> findInvitationsByUser(@Param("user") User user);
+
+    long countByProjectAndRoleAndStatus(Project project, ProjectRole role, JoinStatus status);
+
+    void deleteAllByProject(Project project);
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/project/repository/ProjectMemberRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/repository/ProjectMemberRepository.java
@@ -7,6 +7,7 @@ import com._penLearning.Noddi.domain.project.entity.ProjectMember;
 import com._penLearning.Noddi.domain.project.entity.ProjectRole;
 import com._penLearning.Noddi.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -32,4 +33,8 @@ public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Lo
     long countByProjectAndRoleAndStatus(Project project, ProjectRole role, JoinStatus status);
 
     void deleteAllByProject(Project project);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM ProjectMember pm WHERE pm.project = :project")
+    void bulkDeleteByProject(@Param("project") Project project);
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/project/repository/ProjectRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/repository/ProjectRepository.java
@@ -1,10 +1,16 @@
 package com._penLearning.Noddi.domain.project.repository;
 
+import com._penLearning.Noddi.domain.organization.entity.Organization;
 import com._penLearning.Noddi.domain.project.entity.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface ProjectRepository extends JpaRepository<Project, Long> {
-    List<Project> findByOrganization_OrganizationId(Long organizationId);
+
+    // N+1 문제 방지를 위해 createdBy(User)를 Fetch Join으로 함께 조회
+    @Query("SELECT p FROM Project p JOIN FETCH p.createdBy WHERE p.organization = :organization")
+    List<Project> findAllByOrganization(@Param("organization") Organization organization);
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/project/service/ProjectMemberService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/service/ProjectMemberService.java
@@ -1,0 +1,171 @@
+package com._penLearning.Noddi.domain.project.service;
+
+import com._penLearning.Noddi.domain.project.code.ProjectErrorCode;
+import com._penLearning.Noddi.domain.project.dto.ProjectMemberResponseDto;
+import com._penLearning.Noddi.domain.project.entity.JoinStatus;
+import com._penLearning.Noddi.domain.project.entity.Project;
+import com._penLearning.Noddi.domain.project.entity.ProjectMember;
+import com._penLearning.Noddi.domain.project.entity.ProjectRole;
+import com._penLearning.Noddi.domain.project.repository.ProjectMemberRepository;
+import com._penLearning.Noddi.domain.project.repository.ProjectRepository;
+import com._penLearning.Noddi.domain.user.code.UserErrorCode;
+import com._penLearning.Noddi.domain.user.entity.User;
+import com._penLearning.Noddi.domain.user.repository.UserRepository;
+import com._penLearning.Noddi.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProjectMemberService {
+
+    private final ProjectMemberRepository projectMemberRepository;
+    private final ProjectRepository projectRepository;
+    private final UserRepository userRepository;
+
+    // 관리자가 유저를 초대
+    @Transactional
+    public void inviteUser(Long projectId, Long requesterId, Long targetUserId) {
+        Project project = getProjectOrThrow(projectId);
+        validateLeaderPermission(project, requesterId); // 리더만 초대 가능
+
+        User targetUser = getUserOrThrow(targetUserId);
+
+        if (!project.getOrganization().getOrganizationId().equals(targetUser.getOrganization().getOrganizationId())) {
+            throw new GeneralException(ProjectErrorCode.NOT_SAME_ORGANIZATION);
+        }
+
+        projectMemberRepository.findByProjectAndUser(project, targetUser)
+                .ifPresent(existingMember -> {
+                    if (existingMember.getStatus() == JoinStatus.JOINED) {
+                        throw new GeneralException(ProjectErrorCode.ALREADY_PROJECT_MEMBER);
+                    } else if (existingMember.getStatus() == JoinStatus.INVITED) {
+                        throw new GeneralException(ProjectErrorCode.ALREADY_INVITED_USER);
+                    }
+                });
+
+        // 데이터가 없을 경우에만 새로운 초대 레코드 생성
+        ProjectMember newMember = ProjectMember.create(project, targetUser, ProjectRole.MEMBER, JoinStatus.INVITED);
+        projectMemberRepository.save(newMember);
+    }
+
+    // 받은 초대장 조회
+    public List<ProjectMemberResponseDto .InvitationInfo> getMyInvitations(Long userId) {
+        User user = getUserOrThrow(userId);
+        return projectMemberRepository.findInvitationsByUser(user).stream()
+                .map(ProjectMemberResponseDto.InvitationInfo::from)
+                .toList();
+    }
+
+    // 초대장 응답 처리
+    @Transactional
+    public void respondToInvitation(Long projectId, Long userId, boolean isAccepted) {
+        Project project = getProjectOrThrow(projectId);
+        User user = getUserOrThrow(userId);
+
+        ProjectMember invitation = getProjectMemberOrThrow(project, user);
+
+        // 이미 가입했거나 다른 상태인지 팩트 체크
+        if (invitation.getStatus() != JoinStatus.INVITED) {
+            throw new GeneralException(ProjectErrorCode.INVALID_PROJECT_REQUEST);
+        }
+
+        if (isAccepted) {
+            invitation.acceptInvitation(); // 상태를 JOINED로 UPDATE (JPA 더티 체킹)
+        } else {
+            projectMemberRepository.delete(invitation); // 거절 시 데이터를 삭제하여 다시 초대받을 수 있게 처리
+        }
+    }
+
+    // 프로젝트 멤버 조회
+    public List<ProjectMember> getMembers(Long projectId, Long requesterId) {
+        Project project = getProjectOrThrow(projectId);
+
+        // 요청자가 해당 프로젝트의 멤버인지 확인 (외부인 차단)
+        User requester = getUserOrThrow(requesterId);
+
+        ProjectMember requesterMember = getProjectMemberOrThrow(project, requester);
+
+        if (requesterMember.getStatus() != JoinStatus.JOINED) {
+            throw new GeneralException(ProjectErrorCode.PROJECT_MEMBER_NOT_FOUND);
+        }        return projectMemberRepository.findJoinedMembersByProject(project);
+    }
+
+    // 멤버 권한 변경 (리더만 가능)
+    @Transactional
+    public void updateMemberRole(Long projectId, Long requesterId, Long targetUserId, ProjectRole newRole) {
+        Project project = getProjectOrThrow(projectId);
+        validateLeaderPermission(project, requesterId);
+
+        User targetUser = getUserOrThrow(targetUserId);
+        ProjectMember targetMember = getProjectMemberOrThrow(project, targetUser);
+
+        // 방어 로직: 아직 수락하지 않은(INVITED) 사람은 권한 변경 불가
+        if (targetMember.getStatus() != JoinStatus.JOINED) {
+            throw new GeneralException(ProjectErrorCode.INVALID_PROJECT_REQUEST);
+        }
+        // 방어 로직: 마지막 리더는 권한 강등 불가
+        if (targetMember.getRole() == ProjectRole.LEADER && newRole == ProjectRole.MEMBER) {
+            validateNotLastLeader(project, targetMember);
+        }
+        targetMember.updateRole(newRole);
+    }
+
+    // 프로젝트 탈퇴 및 추방
+    @Transactional
+    public void removeMember(Long projectId, Long requesterId, Long targetUserId) {
+        Project project = getProjectOrThrow(projectId);
+        User targetUser = getUserOrThrow(targetUserId);
+        ProjectMember targetMember = getProjectMemberOrThrow(project, targetUser);
+
+        // 본인이 스스로 탈퇴하는 경우이거나, 리더가 남을 강퇴하는 경우만 허용
+        if (!requesterId.equals(targetUserId)) {
+            validateLeaderPermission(project, requesterId);
+        }
+
+        // 마지막 리더 탈퇴 방어
+        validateNotLastLeader(project, targetMember);
+        projectMemberRepository.delete(targetMember);
+    }
+
+    // --- 내부 검증 및 조회 편의 메서드 ---
+
+    // 리더인지 확인
+    private void validateLeaderPermission(Project project, Long userId) {
+        User user = getUserOrThrow(userId);
+        ProjectMember member = getProjectMemberOrThrow(project, user);
+
+        if (member.getRole() != ProjectRole.LEADER) {
+            throw new GeneralException(ProjectErrorCode.NOT_PROJECT_LEADER);
+        }
+    }
+
+    // 마지막 리더 탈퇴 방지 위한 헬퍼 메서드
+    private void validateNotLastLeader(Project project, ProjectMember targetMember) {
+        if (targetMember.getRole() == ProjectRole.LEADER) {
+            long leaderCount = projectMemberRepository.countByProjectAndRoleAndStatus(project, ProjectRole.LEADER, JoinStatus.JOINED);
+            if (leaderCount <= 1) {
+                throw new GeneralException(ProjectErrorCode.CANNOT_REMOVE_LAST_LEADER);
+            }
+        }
+    }
+
+    private Project getProjectOrThrow(Long projectId) {
+        return projectRepository.findById(projectId)
+                .orElseThrow(() -> new GeneralException(ProjectErrorCode.PROJECT_NOT_FOUND));
+    }
+
+    private User getUserOrThrow(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    private ProjectMember getProjectMemberOrThrow(Project project, User user) {
+        return projectMemberRepository.findByProjectAndUser(project, user)
+                .orElseThrow(() -> new GeneralException(ProjectErrorCode.PROJECT_MEMBER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/project/service/ProjectMemberService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/service/ProjectMemberService.java
@@ -82,17 +82,22 @@ public class ProjectMemberService {
     }
 
     // 프로젝트 멤버 조회
-    public List<ProjectMember> getMembers(Long projectId, Long requesterId) {
+    public List<ProjectMemberResponseDto.MemberInfo> getMembers(
+            Long projectId, Long requesterId
+    ) {
         Project project = getProjectOrThrow(projectId);
-
-        // 요청자가 해당 프로젝트의 멤버인지 확인 (외부인 차단)
         User requester = getUserOrThrow(requesterId);
 
-        ProjectMember requesterMember = getProjectMemberOrThrow(project, requester);
+        ProjectMember requesterMember =
+                getProjectMemberOrThrow(project, requester);
 
         if (requesterMember.getStatus() != JoinStatus.JOINED) {
             throw new GeneralException(ProjectErrorCode.PROJECT_MEMBER_NOT_FOUND);
-        }        return projectMemberRepository.findJoinedMembersByProject(project);
+        }
+
+        return projectMemberRepository.findJoinedMembersByProject(project).stream()
+                .map(ProjectMemberResponseDto.MemberInfo::from)
+                .toList();
     }
 
     // 멤버 권한 변경 (리더만 가능)

--- a/src/main/java/com/_penLearning/Noddi/domain/project/service/ProjectService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/service/ProjectService.java
@@ -9,6 +9,8 @@ import com._penLearning.Noddi.domain.project.entity.ProjectMember;
 import com._penLearning.Noddi.domain.project.entity.ProjectRole;
 import com._penLearning.Noddi.domain.project.repository.ProjectMemberRepository;
 import com._penLearning.Noddi.domain.project.repository.ProjectRepository;
+import com._penLearning.Noddi.domain.team.repository.TeamInviteRepository;
+import com._penLearning.Noddi.domain.team.repository.TeamMemberRepository;
 import com._penLearning.Noddi.domain.team.repository.TeamRepository;
 import com._penLearning.Noddi.domain.user.code.UserErrorCode;
 import com._penLearning.Noddi.domain.user.entity.User;
@@ -30,6 +32,8 @@ public class ProjectService {
     private final ProjectMemberRepository projectMemberRepository;
     private final UserRepository userRepository;
     private final TeamRepository teamRepository;
+    private final TeamInviteRepository teamInviteRepository;
+    private final TeamMemberRepository teamMemberRepository;
 
     // 프로젝트 생성
     @Transactional
@@ -88,16 +92,15 @@ public class ProjectService {
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new GeneralException(ProjectErrorCode.PROJECT_NOT_FOUND));
 
-        // 1. 요청자가 해당 프로젝트의 LEADER(관리자)인지 검증
+        // 1. 요청자가 해당 프로젝트의 LEADER인지 검증
         validateProjectLeader(project, requesterId);
-        // 2. 하위 자원인 Team 데이터 먼저 삭제
-        teamRepository.deleteAllByProject(project);
-        // 3. 연관된 프로젝트 멤버 데이터 삭제
-        projectMemberRepository.deleteAllByProject(project);
-        // 4. 프로젝트 삭제
+
+        // 2. 연관된 프로젝트 멤버 데이터 단일 쿼리로 벌크 삭제 (팀 도메인 로직 제외)
+        projectMemberRepository.bulkDeleteByProject(project);
+
+        // 3. 프로젝트 삭제
         projectRepository.delete(project);
     }
-
     // 리더 권한 검증 헬퍼 메서드
     private void validateProjectLeader(Project project, Long userId) {
         User user = userRepository.findById(userId)

--- a/src/main/java/com/_penLearning/Noddi/domain/project/service/ProjectService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/service/ProjectService.java
@@ -1,0 +1,118 @@
+package com._penLearning.Noddi.domain.project.service;
+
+import com._penLearning.Noddi.domain.project.code.ProjectErrorCode;
+import com._penLearning.Noddi.domain.project.dto.ProjectRequestDto;
+import com._penLearning.Noddi.domain.project.dto.ProjectResponseDto;
+import com._penLearning.Noddi.domain.project.entity.JoinStatus;
+import com._penLearning.Noddi.domain.project.entity.Project;
+import com._penLearning.Noddi.domain.project.entity.ProjectMember;
+import com._penLearning.Noddi.domain.project.entity.ProjectRole;
+import com._penLearning.Noddi.domain.project.repository.ProjectMemberRepository;
+import com._penLearning.Noddi.domain.project.repository.ProjectRepository;
+import com._penLearning.Noddi.domain.team.repository.TeamRepository;
+import com._penLearning.Noddi.domain.user.code.UserErrorCode;
+import com._penLearning.Noddi.domain.user.entity.User;
+import com._penLearning.Noddi.domain.user.repository.UserRepository;
+import com._penLearning.Noddi.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProjectService {
+
+    private final ProjectRepository projectRepository;
+    private final ProjectMemberRepository projectMemberRepository;
+    private final UserRepository userRepository;
+    private final TeamRepository teamRepository;
+
+    // 프로젝트 생성
+    @Transactional
+    public ProjectResponseDto.Info createProject(Long userId, ProjectRequestDto.Create request) {
+        // 1. JWT에서 추출한 userId로 유저 객체 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(UserErrorCode.USER_NOT_FOUND));
+
+        // 2. 엔티티 생성 (유저의 소속 조직 자동 매핑)
+        Project project = Project.create(
+                request.getName(),
+                request.getDescription(),
+                user.getOrganization(),
+                user
+        );
+
+        // 3. DB 저장 및 반환
+        Project savedProject = projectRepository.save(project);
+
+        // 4. 프로젝트 생성한 유저를 리더로 등록
+        ProjectMember leaderMember = ProjectMember.create(
+                project,
+                user,
+                ProjectRole.LEADER,
+                JoinStatus.JOINED
+        );
+
+        projectMemberRepository.save(leaderMember);
+        return ProjectResponseDto.Info.from(savedProject);
+    }
+
+    // 소속 조직의 프로젝트 목록 조회
+    public List<ProjectResponseDto.Info> getProjectsByOrganization(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(UserErrorCode.USER_NOT_FOUND));
+
+        // 소속 조직 기반으로 프로젝트 목록 조회 (Fetch Join 적용됨)
+        List<Project> projects = projectRepository.findAllByOrganization(user.getOrganization());
+
+        return projects.stream()
+                .map(ProjectResponseDto.Info::from)
+                .collect(Collectors.toList());
+    }
+    // 프로젝트 정보 수정(리더만 가능)
+    @Transactional
+    public void updateProject(Long projectId, Long requesterId, ProjectRequestDto.Update request) {
+        Project project = getProjectOrThrow(projectId);
+        validateProjectLeader(project, requesterId); // 리더 권한 검증 재사용
+
+        project.updateProjectInfo(request.getName(), request.getDescription());
+    }
+
+    // 프로젝트 삭제 (리더만 가능)
+    @Transactional
+    public void deleteProject(Long projectId, Long requesterId) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new GeneralException(ProjectErrorCode.PROJECT_NOT_FOUND));
+
+        // 1. 요청자가 해당 프로젝트의 LEADER(관리자)인지 검증
+        validateProjectLeader(project, requesterId);
+        // 2. 하위 자원인 Team 데이터 먼저 삭제
+        teamRepository.deleteAllByProject(project);
+        // 3. 연관된 프로젝트 멤버 데이터 삭제
+        projectMemberRepository.deleteAllByProject(project);
+        // 4. 프로젝트 삭제
+        projectRepository.delete(project);
+    }
+
+    // 리더 권한 검증 헬퍼 메서드
+    private void validateProjectLeader(Project project, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(UserErrorCode.USER_NOT_FOUND));
+
+        ProjectMember member = projectMemberRepository.findByProjectAndUser(project, user)
+                .orElseThrow(() -> new GeneralException(ProjectErrorCode.PROJECT_MEMBER_NOT_FOUND));
+
+        if (member.getRole() != ProjectRole.LEADER || member.getStatus() != JoinStatus.JOINED) {
+            throw new GeneralException(ProjectErrorCode.NOT_PROJECT_LEADER);
+        }
+    }
+
+    private Project getProjectOrThrow(Long projectId) {
+        return projectRepository.findById(projectId)
+                .orElseThrow(() -> new GeneralException(ProjectErrorCode.PROJECT_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/team/repository/TeamRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/team/repository/TeamRepository.java
@@ -1,5 +1,6 @@
 package com._penLearning.Noddi.domain.team.repository;
 
+import com._penLearning.Noddi.domain.project.entity.Project;
 import com._penLearning.Noddi.domain.team.entity.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -13,4 +14,6 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
     // 같은 조직 내 팀 전체 조회 (타 팀 Q&A 대상 리스트용)
     @Query("SELECT t FROM Team t WHERE t.project.organization.organizationId = :organizationId")
     List<Team> findAllByOrganizationId(@Param("organizationId") Long organizationId);
+
+    void deleteAllByProject(Project project);
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/team/repository/TeamRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/team/repository/TeamRepository.java
@@ -3,6 +3,7 @@ package com._penLearning.Noddi.domain.team.repository;
 import com._penLearning.Noddi.domain.project.entity.Project;
 import com._penLearning.Noddi.domain.team.entity.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -14,6 +15,10 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
     // 같은 조직 내 팀 전체 조회 (타 팀 Q&A 대상 리스트용)
     @Query("SELECT t FROM Team t WHERE t.project.organization.organizationId = :organizationId")
     List<Team> findAllByOrganizationId(@Param("organizationId") Long organizationId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Team t WHERE t.project = :project")
+    void bulkDeleteByProject(@Param("project") Project project);
 
     void deleteAllByProject(Project project);
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/user/code/UserErrorCode.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/user/code/UserErrorCode.java
@@ -1,0 +1,18 @@
+package com._penLearning.Noddi.domain.user.code;
+
+import com._penLearning.Noddi.global.apiPayload.code.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorCode implements BaseErrorCode {
+
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER404", "사용자를 찾을 수 없습니다." );
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/_penLearning/Noddi/global/config/TestDataInitializer.java
+++ b/src/main/java/com/_penLearning/Noddi/global/config/TestDataInitializer.java
@@ -2,37 +2,63 @@ package com._penLearning.Noddi.global.config;
 
 import com._penLearning.Noddi.domain.organization.entity.Organization;
 import com._penLearning.Noddi.domain.organization.repository.OrganizationRepository;
+import com._penLearning.Noddi.domain.user.entity.User;
+import com._penLearning.Noddi.domain.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class TestDataInitializer implements CommandLineRunner {
 
     private final OrganizationRepository organizationRepository;
+    private final UserRepository userRepository;
+    private final BCryptPasswordEncoder passwordEncoder;
 
     @Override
     @Transactional
     public void run(String... args) {
-        if (organizationRepository.count() == 0) {
+        if (organizationRepository.count() == 0 && userRepository.count() == 0) {
 
-            // 1. 홍익대학교 학생 도메인 적용
+            // 1. 조직 생성
             Organization hongik = Organization.builder()
                     .name("홍익대학교")
                     .emailDomain("g.hongik.ac.kr")
                     .build();
 
-            // 2. 메일 발송 기능 자체 테스트용 (필요 시 사용)
             Organization testOrg = Organization.builder()
                     .name("테스트 조직(Gmail)")
                     .emailDomain("gmail.com")
                     .build();
 
             organizationRepository.saveAll(List.of(hongik, testOrg));
+
+            String encodedPassword = passwordEncoder.encode("1234");
+
+            User user1 = User.builder()
+                    .name("김철수")
+                    .email("chulsoo@g.hongik.ac.kr")
+                    .password(encodedPassword)
+                    .organization(hongik)
+                    .build();
+
+            User user2 = User.builder()
+                    .name("김영희")
+                    .email("younghee@gmail.com")
+                    .password(encodedPassword)
+                    .organization(testOrg)
+                    .build();
+
+            userRepository.saveAll(List.of(user1, user2));
+
+            log.info("[TestDataInitializer] 초기 테스트 데이터 주입 완료: 조직 2개, 유저 2명");
         }
     }
 }

--- a/src/main/java/com/_penLearning/Noddi/global/util/EmailAsyncSender.java
+++ b/src/main/java/com/_penLearning/Noddi/global/util/EmailAsyncSender.java
@@ -1,0 +1,43 @@
+package com._penLearning.Noddi.global.util;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EmailAsyncSender {
+
+    private final JavaMailSender mailSender;
+
+    @Async
+    public void sendMailAsync(String toEmail, String authCode) {
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+            helper.setTo(toEmail);
+            helper.setSubject("[Noddi] 이메일 인증번호 안내");
+
+            String content = "<h3>Noddi 서비스 이용을 위한 인증번호입니다.</h3>" +
+                    "<br>인증번호: <b>" + authCode + "</b><br>" +
+                    "<p>5분 이내에 입력해 주세요.</p>";
+
+            helper.setText(content, true);
+
+            mailSender.send(message);
+
+        } catch (MessagingException | MailException e) {
+            // 비동기 스레드 내부에서 예외가 터지므로,
+            // API 호출자에게 에러를 던지기보다 로그를 남기는 방식으로 처리합니다.
+            log.error("[Email Error] 비동기 메일 발송 실패 (수신자: {}): {}", toEmail, e.getMessage());
+        }
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,7 +7,7 @@ spring:
     password: ${DB_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
## <i>PULL REQUEST</i>

## 🎋 작업 브랜치
- feature/3 -> develop
- #6

작성하신 코드와 코드 리뷰를 거쳐 탄생한 최종 결과물을 바탕으로, 팀원들이 한눈에 작업 내역을 파악할 수 있도록 PR 템플릿을 정리했습니다. 그대로 복사해서 사용하시면 됩니다.

---

## 💡 작업동기

* IA 기획 명세에 따른 **프로젝트(Project) 및 프로젝트 멤버(ProjectMember) 도메인의 핵심 비즈니스 로직(CRUD) 구현** 및 N:M 관계 매핑

## 🔑 주요 변경사항

### 1. 프로젝트 멤버(ProjectMember) 도메인 구축

* `Project`와 `User` 간의 다대다(N:M) 관계를 해소하는 중간 매핑 엔티티 설계.
* 프로젝트 내 권한 관리를 위한 `ProjectRole` (LEADER, MEMBER) 도입.
* 가입 상태 관리를 위한 `JoinStatus` (INVITED, JOINED, REJECTED) 도입.

### 2. 초대 전용(Invite-only) 가입 플로우 구현

* 기획 스펙에 맞추어 유저 직접 요청 방식이 아닌 '초대 기반 플로우' 구현.
* **주요 API:** 멤버 초대, 내가 받은 초대장 조회, 초대 수락/거절 API 구현.
* **예외 처리 고도화:**
* 동일한 조직(Organization)에 속한 유저만 초대할 수 있도록 방어 로직 추가.
* 중복 초대 시 상태에 따라 예외 응답 세분화 (`ALREADY_PROJECT_MEMBER`, `ALREADY_INVITED_USER`).

### 3. 무결성 및 인가(Authorization) 강화

* **프로젝트 삭제 안전성:** 리더만 삭제 가능하며, 삭제 시 연관된 하위 엔티티(`Team`, `ProjectMember`)가 먼저 삭제되도록 처리(FK 제약조건 충돌 방지).
* **멤버 목록 조회 인가:** 로그인한 유저라도 해당 프로젝트의 정식 멤버(`JOINED`)가 아니면 멤버 목록을 조회할 수 없도록 권한 검증 추가.
* **Ghost 프로젝트 방지:** 프로젝트 내 마지막 남은 리더(LEADER)가 스스로 탈퇴하거나 MEMBER로 권한을 강등하는 것을 차단하는 로직 추가.
* **리더 자동 할당:** 프로젝트 생성 시 요청자를 `ProjectMember` 테이블에 `LEADER` 권한으로 자동 등록하는 로직 추가.

### 5. 테스트 인프라

* 로컬 스웨거 테스트 편의성을 위한 `TestDataInitializer` 수정 (서버 구동 시 테스트 조직 및 유저 자동 주입).

## 🏞 스크린샷 (선택)
> 스크린샷을 첨부해주세요.

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
