### PR TITLE
[Feat] 팀 기능 구현

### DIFF
--- a/src/main/java/com/_penLearning/Noddi/NoddiApplication.java
+++ b/src/main/java/com/_penLearning/Noddi/NoddiApplication.java
@@ -4,8 +4,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing  // BaseEntity의 createdAt, updatedAt 자동 주입 활성화
+@EnableScheduling
 @SpringBootApplication
 @EnableAsync // 비동기 기능 활성화
 public class NoddiApplication {

--- a/src/main/java/com/_penLearning/Noddi/domain/project/code/ProjectErrorCode.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/code/ProjectErrorCode.java
@@ -12,7 +12,7 @@ public enum ProjectErrorCode implements BaseErrorCode {
     // 400 BAD_REQUEST
     INVALID_PROJECT_REQUEST(HttpStatus.BAD_REQUEST, "PROJECT400_1", "잘못된 프로젝트 요청입니다."),
     NOT_SAME_ORGANIZATION(HttpStatus.BAD_REQUEST, "PROJECT400_2", "다른 조직 멤버에게는 초대를 전송할 수 없습니다."),
-    CANNOT_REMOVE_LAST_LEADER(HttpStatus.BAD_REQUEST, "PROJECT400_3", "프로젝트의 마지막 멤버는 탈퇴하거나 권한응 강등할 수 없습니다."),
+    CANNOT_REMOVE_LAST_LEADER(HttpStatus.BAD_REQUEST, "PROJECT400_3", "프로젝트의 마지막 리더는 탈퇴하거나 권한을 강등할 수 없습니다."),
 
     // 403 FORBIDDEN (권한 없음)
     NOT_PROJECT_LEADER(HttpStatus.FORBIDDEN, "PROJECT403_1", "프로젝트 관리자(LEADER) 권한이 필요합니다."),

--- a/src/main/java/com/_penLearning/Noddi/domain/team/code/TeamApi.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/team/code/TeamApi.java
@@ -1,0 +1,79 @@
+package com._penLearning.Noddi.domain.team.code;
+
+import com._penLearning.Noddi.domain.auth.entity.AuthMember;
+import com._penLearning.Noddi.domain.team.dto.TeamRequestDto;
+import com._penLearning.Noddi.domain.team.dto.TeamResponseDto;
+import com._penLearning.Noddi.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Team API", description = "팀 및 팀 멤버 관리 API")
+public interface TeamApi {
+
+    @Operation(summary = "팀 생성", description = "지정된 프로젝트 내에 새로운 팀을 생성합니다. (프로젝트 정식 멤버만 가능)")
+    ApiResponse<Long> createTeam(
+            @PathVariable Long projectId,
+            @Parameter(hidden = true) AuthMember authMember, // 실제 인증 객체 타입으로 교체 (예: AuthMember)
+            @RequestBody TeamRequestDto.Create request
+    );
+
+    @Operation(summary = "팀 멤버 초대", description = "팀 리더가 동일한 프로젝트 내의 정식 멤버를 팀으로 초대합니다.")
+    ApiResponse<Void> inviteTeamMember(
+            @PathVariable Long teamId,
+            @Parameter(hidden = true) AuthMember authMember,
+            @RequestBody TeamRequestDto.InviteMember request
+    );
+
+    @Operation(summary = "팀 초대 응답", description = "팀 초대를 수락하거나 거절합니다.")
+    ApiResponse<Void> respondToInvite(
+            @PathVariable Long inviteId,
+            @Parameter(hidden = true) AuthMember authMember,
+            @RequestBody TeamRequestDto.RespondInvite request
+    );
+
+    @Operation(summary = "팀 정보 수정", description = "팀 리더가 팀의 이름과 설명을 수정합니다.")
+    ApiResponse<Void> updateTeam(@PathVariable Long teamId,
+                                 @Parameter(hidden = true) AuthMember authMember,
+                                 @RequestBody TeamRequestDto.UpdateInfo request);
+
+    @Operation(summary = "팀 삭제", description = "팀 리더가 팀을 삭제합니다. 관련된 초대장과 멤버 정보도 함께 삭제됩니다.")
+    ApiResponse<Void> deleteTeam(@PathVariable Long teamId,
+                                 @Parameter(hidden = true) AuthMember authMember);
+
+    @Operation(summary = "팀 멤버 권한 변경", description = "팀 리더가 멤버의 권한(LEADER, MEMBER)을 변경합니다.")
+    ApiResponse<Void> updateMemberRole(@PathVariable Long teamId,
+                                       @PathVariable Long targetUserId,
+                                       @Parameter(hidden = true) AuthMember authMember,
+                                       @RequestBody TeamRequestDto.UpdateRole request);
+
+    @Operation(summary = "팀 멤버 강퇴 및 탈퇴", description = "팀 리더가 멤버를 강퇴하거나, 본인이 팀에서 탈퇴합니다.")
+    ApiResponse<Void> removeMember(@PathVariable Long teamId,
+                                   @PathVariable Long targetUserId,
+                                   @Parameter(hidden = true) AuthMember authMember);
+
+    @Operation(summary = "프로젝트 내 팀 목록 조회", description = "특정 프로젝트에 속한 모든 팀의 목록을 조회합니다. (프로젝트 정식 멤버만 가능)")
+    ApiResponse<List<TeamResponseDto.ProjectTeamInfo>> getTeamsByProject(
+            @PathVariable Long projectId,
+            @Parameter(hidden = true) AuthMember authMember
+    );
+
+    @Operation(summary = "내 팀 목록 조회", description = "내가 속해 있는 팀들의 목록을 조회합니다.")
+    ApiResponse<List<TeamResponseDto.TeamInfo>> getMyTeams(
+            @Parameter(hidden = true) AuthMember authMember
+    );
+
+    @Operation(summary = "팀 멤버 목록 조회", description = "특정 팀에 소속된 정식 멤버들의 목록을 조회합니다. (해당 팀원만 조회 가능)")
+    ApiResponse<List<TeamResponseDto.MemberInfo>> getTeamMembers(
+            @PathVariable Long teamId,
+            @Parameter(hidden = true) AuthMember authMember
+    );
+
+    @Operation(summary = "받은 팀 초대장 목록 조회", description = "내가 받은 대기 중(PENDING)인 팀 초대장 목록을 조회합니다.")
+    ApiResponse<List<TeamResponseDto.InvitationInfo>> getMyInvitations(
+            @Parameter(hidden = true) AuthMember authMember
+    );
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/team/code/TeamErrorCode.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/team/code/TeamErrorCode.java
@@ -1,0 +1,33 @@
+package com._penLearning.Noddi.domain.team.code;
+
+import com._penLearning.Noddi.global.apiPayload.code.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum TeamErrorCode implements BaseErrorCode {
+
+    // 400 BAD_REQUEST
+    INVITE_NOT_PENDING(HttpStatus.BAD_REQUEST, "TEAM400_1", "이미 처리되었거나 만료된 초대장입니다."),
+    CANNOT_REMOVE_LAST_LEADER(HttpStatus.BAD_REQUEST, "TEAM400_3", "팀의 마지막 리더는 탈퇴하거나 권한을 강등할 수 없습니다."),
+
+
+    // 403 FORBIDDEN (인가/권한 예외)
+    NOT_TEAM_LEADER(HttpStatus.FORBIDDEN, "TEAM403_1", "팀의 리더만 수행할 수 있는 권한입니다."),
+    NOT_PROJECT_MEMBER(HttpStatus.FORBIDDEN, "TEAM403_2", "프로젝트에 정식 가입된 상태여야 팀에 참여하거나 초대할 수 있습니다."),
+    NOT_INVITEE(HttpStatus.FORBIDDEN, "TEAM403_3", "본인에게 온 초대장만 응답할 수 있습니다."),
+
+    // 404 NOT_FOUND (조회 실패)
+    TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "TEAM404_1", "팀을 찾을 수 없습니다."),
+    INVITE_NOT_FOUND(HttpStatus.NOT_FOUND, "TEAM404_2", "초대장을 찾을 수 없습니다."),
+
+    // 409 CONFLICT (중복 방지)
+    ALREADY_TEAM_MEMBER(HttpStatus.CONFLICT, "TEAM409_1", "이미 해당 팀에 가입된 유저입니다."),
+    ALREADY_INVITED(HttpStatus.CONFLICT, "TEAM409_2", "이미 해당 유저에게 발송된 대기 중인 초대장이 존재합니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/team/controller/TeamController.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/team/controller/TeamController.java
@@ -1,0 +1,136 @@
+package com._penLearning.Noddi.domain.team.controller;
+
+import com._penLearning.Noddi.domain.auth.entity.AuthMember;
+import com._penLearning.Noddi.domain.team.code.TeamApi;
+import com._penLearning.Noddi.domain.team.dto.TeamRequestDto;
+import com._penLearning.Noddi.domain.team.dto.TeamResponseDto;
+import com._penLearning.Noddi.domain.team.service.TeamCommandService;
+import com._penLearning.Noddi.domain.team.service.TeamQueryService;
+import com._penLearning.Noddi.global.apiPayload.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class TeamController implements TeamApi {
+
+    private final TeamCommandService teamCommandService;
+    private final TeamQueryService teamQueryService;
+
+    @Override
+    @PostMapping("/projects/{projectId}/teams")
+    public ApiResponse<Long> createTeam(
+            @PathVariable Long projectId,
+            @AuthenticationPrincipal AuthMember authMember,
+            @RequestBody @Valid TeamRequestDto.Create request) {
+
+        Long teamId = teamCommandService.createTeam(
+                projectId,
+                authMember.getUserId(),
+                request.getName(),
+                request.getDescription()
+        );
+        return ApiResponse.onSuccess("팀이 성공적으로 생성되었습니다.", teamId);
+    }
+
+    @Override
+    @PostMapping("/teams/{teamId}/members/invite")
+    public ApiResponse<Void> inviteTeamMember(
+            @PathVariable Long teamId,
+            @AuthenticationPrincipal AuthMember authMember,
+            @RequestBody @Valid TeamRequestDto.InviteMember request) {
+
+        teamCommandService.inviteTeamMember(teamId, authMember.getUserId(), request.getTargetUserId());
+        return ApiResponse.onSuccess("팀 멤버 초대장이 발송되었습니다.", null);
+    }
+
+    @Override
+    @PostMapping("/teams/invitations/{inviteId}/respond")
+    public ApiResponse<Void> respondToInvite(
+            @PathVariable Long inviteId,
+            @AuthenticationPrincipal AuthMember authMember,
+            @RequestBody @Valid TeamRequestDto.RespondInvite request) {
+
+        teamCommandService.respondToInvite(inviteId, authMember.getUserId(), request.getIsAccepted());
+        return ApiResponse.onSuccess("초대 응답이 정상적으로 처리되었습니다.", null);
+    }
+
+    @Override
+    @PatchMapping("/teams/{teamId}")
+    public ApiResponse<Void> updateTeam(
+            @PathVariable Long teamId,
+            @AuthenticationPrincipal AuthMember authMember,
+            @RequestBody @Valid TeamRequestDto.UpdateInfo request) {
+        teamCommandService.updateTeam(teamId, authMember.getUserId(), request);
+        return ApiResponse.onSuccess("팀 정보가 성공적으로 수정되었습니다.", null);
+    }
+
+    @Override
+    @DeleteMapping("/teams/{teamId}")
+    public ApiResponse<Void> deleteTeam(
+            @PathVariable Long teamId,
+            @AuthenticationPrincipal AuthMember authMember) {
+        teamCommandService.deleteTeam(teamId, authMember.getUserId());
+        return ApiResponse.onSuccess("팀이 성공적으로 삭제되었습니다.", null);
+    }
+
+    @Override
+    @PatchMapping("/teams/{teamId}/members/{targetUserId}/role")
+    public ApiResponse<Void> updateMemberRole(
+            @PathVariable Long teamId,
+            @PathVariable Long targetUserId,
+            @AuthenticationPrincipal AuthMember authMember,
+            @RequestBody @Valid TeamRequestDto.UpdateRole request) {
+        teamCommandService.updateMemberRole(teamId, authMember.getUserId(), targetUserId, request.getRole());
+        return ApiResponse.onSuccess("팀 멤버 권한이 성공적으로 변경되었습니다.", null);
+    }
+
+    @Override
+    @DeleteMapping("/teams/{teamId}/members/{targetUserId}")
+    public ApiResponse<Void> removeMember(
+            @PathVariable Long teamId,
+            @PathVariable Long targetUserId,
+            @AuthenticationPrincipal AuthMember authMember) {
+        teamCommandService.removeMember(teamId, authMember.getUserId(), targetUserId);
+        return ApiResponse.onSuccess("팀 멤버가 성공적으로 삭제/탈퇴되었습니다.", null);
+    }
+
+    @Override
+    @GetMapping("/projects/{projectId}/teams")
+    public ApiResponse<List<TeamResponseDto.ProjectTeamInfo>> getTeamsByProject(
+            @PathVariable Long projectId,
+            @AuthenticationPrincipal AuthMember authMember) {
+        List<TeamResponseDto.ProjectTeamInfo> response = teamQueryService.getTeamsByProject(projectId, authMember.getUserId());
+        return ApiResponse.onSuccess("프로젝트 내 팀 목록 조회에 성공했습니다.", response);
+    }
+
+    @Override
+    @GetMapping("/users/me/teams")
+    public ApiResponse<List<TeamResponseDto.TeamInfo>> getMyTeams(
+            @AuthenticationPrincipal AuthMember authMember) {
+        List<TeamResponseDto.TeamInfo> response = teamQueryService.getMyTeams(authMember.getUserId());
+        return ApiResponse.onSuccess("내 팀 목록 조회에 성공했습니다.", response);
+    }
+
+    @Override
+    @GetMapping("/teams/{teamId}/members")
+    public ApiResponse<List<TeamResponseDto.MemberInfo>> getTeamMembers(
+            @PathVariable Long teamId,
+            @AuthenticationPrincipal AuthMember authMember) {
+        List<TeamResponseDto.MemberInfo> response = teamQueryService.getTeamMembers(teamId, authMember.getUserId());
+        return ApiResponse.onSuccess("팀 멤버 목록 조회에 성공했습니다.", response);
+    }
+
+    @Override
+    @GetMapping("/users/me/teams/invitations")
+    public ApiResponse<List<TeamResponseDto.InvitationInfo>> getMyInvitations(
+            @AuthenticationPrincipal AuthMember authMember) {
+        List<TeamResponseDto.InvitationInfo> response = teamQueryService.getMyInvitations(authMember.getUserId());
+        return ApiResponse.onSuccess("받은 팀 초대장 목록 조회에 성공했습니다.", response);
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/team/controller/TeamMemberController.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/team/controller/TeamMemberController.java
@@ -1,0 +1,4 @@
+package com._penLearning.Noddi.domain.team.controller;
+
+public class TeamMemberController {
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/team/dto/TeamMemberRequestDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/team/dto/TeamMemberRequestDto.java
@@ -1,0 +1,4 @@
+package com._penLearning.Noddi.domain.team.dto;
+
+public class TeamMemberRequestDto {
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/team/dto/TeamMemberResponseDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/team/dto/TeamMemberResponseDto.java
@@ -1,0 +1,4 @@
+package com._penLearning.Noddi.domain.team.dto;
+
+public class TeamMemberResponseDto {
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/team/dto/TeamRequestDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/team/dto/TeamRequestDto.java
@@ -1,0 +1,48 @@
+package com._penLearning.Noddi.domain.team.dto;
+
+import com._penLearning.Noddi.domain.team.entity.TeamRole;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class TeamRequestDto {
+
+    @Getter
+    @NoArgsConstructor
+    public static class Create {
+        @NotBlank(message = "팀 이름은 필수 입력값입니다.")
+        private String name;
+
+        private String description;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class InviteMember {
+        @NotNull(message = "초대할 유저의 ID는 필수입니다.")
+        private Long targetUserId;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class RespondInvite {
+        @NotNull(message = "수락 여부는 필수 입력값입니다.")
+        private Boolean isAccepted;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class UpdateInfo {
+        @NotBlank(message = "팀 이름은 필수 입력값입니다.")
+        private String name;
+        private String description;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class UpdateRole {
+        @NotNull(message = "변경할 권한은 필수 입력값입니다.")
+        private TeamRole role;
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/team/dto/TeamResponseDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/team/dto/TeamResponseDto.java
@@ -1,0 +1,83 @@
+package com._penLearning.Noddi.domain.team.dto;
+
+import com._penLearning.Noddi.domain.team.entity.Team;
+import com._penLearning.Noddi.domain.team.entity.TeamInvite;
+import com._penLearning.Noddi.domain.team.entity.TeamMember;
+import com._penLearning.Noddi.domain.team.entity.TeamRole;
+import lombok.Builder;
+import lombok.Getter;
+
+public class TeamResponseDto {
+
+    @Getter
+    @Builder
+    public static class TeamInfo {
+        private Long teamId;
+        private String name;
+        private String description;
+        private TeamRole myRole;
+
+        public static TeamInfo from(TeamMember teamMember) {
+            return TeamInfo.builder()
+                    .teamId(teamMember.getTeam().getTeamId())
+                    .name(teamMember.getTeam().getName())
+                    .description(teamMember.getTeam().getDescription())
+                    .myRole(teamMember.getRole())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class ProjectTeamInfo {
+        private Long teamId;
+        private String name;
+        private String description;
+        private String creatorName;
+
+        public static ProjectTeamInfo from(Team team) {
+            return ProjectTeamInfo.builder()
+                    .teamId(team.getTeamId())
+                    .name(team.getName())
+                    .description(team.getDescription())
+                    .creatorName(team.getCreatedBy().getName())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class MemberInfo {
+        private Long userId;
+        private String name;
+        private String email;
+        private TeamRole role;
+
+        public static MemberInfo from(TeamMember teamMember) {
+            return MemberInfo.builder()
+                    .userId(teamMember.getUser().getUserId()) // User 엔티티의 ID 필드명에 맞게 수정
+                    .name(teamMember.getUser().getName())
+                    .email(teamMember.getUser().getEmail())
+                    .role(teamMember.getRole())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class InvitationInfo {
+        private Long inviteId;
+        private Long teamId;
+        private String teamName;
+        private String inviterName;
+
+        public static InvitationInfo from(TeamInvite invite) {
+            return InvitationInfo.builder()
+                    .inviteId(invite.getInviteId())
+                    .teamId(invite.getTeam().getTeamId())
+                    .teamName(invite.getTeam().getName())
+                    .inviterName(invite.getInviter().getName())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/team/entity/Team.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/team/entity/Team.java
@@ -26,14 +26,22 @@ public class Team extends BaseEntity {
     @Column(nullable = false)
     private String name;
 
+    private String description;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "createdBy", nullable = false)
     private User createdBy;
 
+    public void updateTeamInfo(String name, String description) {
+        this.name = name;
+        this.description = description;
+    }
+
     @Builder
-    public Team(Project project, String name, User createdBy) {
+    public Team(Project project, String name, String description, User createdBy) {
         this.project = project;
         this.name = name;
+        this.description = description;
         this.createdBy = createdBy;
     }
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/team/entity/TeamInvite.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/team/entity/TeamInvite.java
@@ -1,6 +1,7 @@
 package com._penLearning.Noddi.domain.team.entity;
 
 import com._penLearning.Noddi.domain.user.entity.User;
+import com._penLearning.Noddi.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -13,7 +14,7 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "TeamInvite")
-public class TeamInvite {
+public class TeamInvite extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -35,10 +36,17 @@ public class TeamInvite {
     @Column(nullable = false)
     private InviteStatus status;
 
-    private LocalDateTime respondedAt;
+    // BaseEntity의 createdAt 필드를 활용 (필드명은 실제 환경에 맞게 수정)
+    public boolean isExpired(int validDays) {
+        return this.getCreatedAt().plusDays(validDays).isBefore(LocalDateTime.now());
+    }
 
-    @Column(nullable = false)
-    private LocalDateTime createdAt;
+    // 만료 상태 변경 메서드 추가
+    public void expire() {
+        this.status = InviteStatus.EXPIRED;
+    }
+
+    private LocalDateTime respondedAt;
 
     @Builder
     public TeamInvite(Team team, User inviter, User invitee) {
@@ -46,7 +54,6 @@ public class TeamInvite {
         this.inviter = inviter;
         this.invitee = invitee;
         this.status = InviteStatus.PENDING;
-        this.createdAt = LocalDateTime.now();
     }
 
     public void accept() {

--- a/src/main/java/com/_penLearning/Noddi/domain/team/entity/TeamMember.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/team/entity/TeamMember.java
@@ -1,6 +1,7 @@
 package com._penLearning.Noddi.domain.team.entity;
 
 import com._penLearning.Noddi.domain.user.entity.User;
+import com._penLearning.Noddi.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -13,9 +14,9 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "TeamMember", uniqueConstraints = {
-        @UniqueConstraint(columnNames = {"teamId", "userId"})
+        @UniqueConstraint(name = "UK_TEAM_USER", columnNames = {"teamId", "userId"})
 })
-public class TeamMember {
+public class TeamMember extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -33,14 +34,14 @@ public class TeamMember {
     @Column(nullable = false)
     private TeamRole role;
 
-    @Column(nullable = false)
-    private LocalDateTime joinedAt;
+    public void updateRole(TeamRole newRole) {
+        this.role = newRole;
+    }
 
     @Builder
     public TeamMember(Team team, User user, TeamRole role) {
         this.team = team;
         this.user = user;
         this.role = role;
-        this.joinedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/team/entity/TeamRole.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/team/entity/TeamRole.java
@@ -1,5 +1,5 @@
 package com._penLearning.Noddi.domain.team.entity;
 
 public enum TeamRole {
-    OWNER, MEMBER
+    LEADER, MEMBER
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/team/repository/TeamInviteRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/team/repository/TeamInviteRepository.java
@@ -5,9 +5,11 @@ import com._penLearning.Noddi.domain.team.entity.Team;
 import com._penLearning.Noddi.domain.team.entity.TeamInvite;
 import com._penLearning.Noddi.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -29,6 +31,23 @@ public interface TeamInviteRepository extends JpaRepository<TeamInvite, Long> {
     // 초대장 응답 시 초대장 단건 조회 (초대한 팀 정보까지 한 번에 로드)
     @Query("SELECT ti FROM TeamInvite ti JOIN FETCH ti.team WHERE ti.inviteId = :inviteId")
     Optional<TeamInvite> findByIdWithTeam(@Param("inviteId") Long inviteId);
+
+    // 초대장 일괄 만료 쿼리
+    @Modifying(
+            flushAutomatically = true,
+            clearAutomatically = true
+    )
+    @Query("""
+    update TeamInvite ti
+       set ti.status = :expiredStatus
+     where ti.status = :pendingStatus
+       and ti.createdAt < :expirationThreshold
+    """)
+    int bulkExpireInvitations(
+            @Param("expirationThreshold") LocalDateTime expirationThreshold,
+            @Param("pendingStatus") InviteStatus pendingStatus,
+            @Param("expiredStatus") InviteStatus expiredStatus
+    );
 
     // 팀 삭제 전 연관된 초대장 일괄 삭제용
     void deleteAllByTeam(Team team);

--- a/src/main/java/com/_penLearning/Noddi/domain/team/repository/TeamInviteRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/team/repository/TeamInviteRepository.java
@@ -1,12 +1,35 @@
 package com._penLearning.Noddi.domain.team.repository;
 
 import com._penLearning.Noddi.domain.team.entity.InviteStatus;
+import com._penLearning.Noddi.domain.team.entity.Team;
 import com._penLearning.Noddi.domain.team.entity.TeamInvite;
+import com._penLearning.Noddi.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface TeamInviteRepository extends JpaRepository<TeamInvite, Long> {
-    List<TeamInvite> findByInvitee_UserIdAndStatus(Long userId, InviteStatus status);
-    boolean existsByTeam_TeamIdAndInvitee_UserIdAndStatus(Long teamId, Long inviteeId, InviteStatus status);
+
+    // 이미 '대기 중(PENDING)'인 초대장이 있는지 확인 (중복 초대 발송 방어 로직용)
+    boolean existsByTeamAndInviteeAndStatus(Team team, User invitee, InviteStatus status);
+
+    // 특정 유저가 받은 특정 상태(PENDING)의 초대장 목록 조회
+    @Query("""
+    select ti
+    from TeamInvite ti
+    join fetch ti.team
+    join fetch ti.inviter
+    where ti.invitee = :invitee
+      and ti.status = :status
+    """)    List<TeamInvite> findByInviteeAndStatusWithTeam(@Param("invitee") User invitee, @Param("status") InviteStatus status);
+
+    // 초대장 응답 시 초대장 단건 조회 (초대한 팀 정보까지 한 번에 로드)
+    @Query("SELECT ti FROM TeamInvite ti JOIN FETCH ti.team WHERE ti.inviteId = :inviteId")
+    Optional<TeamInvite> findByIdWithTeam(@Param("inviteId") Long inviteId);
+
+    // 팀 삭제 전 연관된 초대장 일괄 삭제용
+    void deleteAllByTeam(Team team);
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/team/repository/TeamMemberRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/team/repository/TeamMemberRepository.java
@@ -1,14 +1,35 @@
 package com._penLearning.Noddi.domain.team.repository;
 
+import com._penLearning.Noddi.domain.team.entity.Team;
 import com._penLearning.Noddi.domain.team.entity.TeamMember;
+import com._penLearning.Noddi.domain.team.entity.TeamRole;
+import com._penLearning.Noddi.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
-    List<TeamMember> findByTeam_TeamId(Long teamId);
-    List<TeamMember> findByUser_UserId(Long userId);
-    Optional<TeamMember> findByTeam_TeamIdAndUser_UserId(Long teamId, Long userId);
-    boolean existsByTeam_TeamIdAndUser_UserId(Long teamId, Long userId);
+
+    // 특정 팀의 전체 멤버 목록 조회
+    @Query("SELECT tm FROM TeamMember tm JOIN FETCH tm.user WHERE tm.team = :team")
+    List<TeamMember> findAllByTeamWithUser(@Param("team") Team team);
+
+    // 특정 유저가 속한 모든 팀 정보 조회 (팀 목록 조회용)
+    @Query("SELECT tm FROM TeamMember tm JOIN FETCH tm.team WHERE tm.user = :user")
+    List<TeamMember> findAllByUserWithTeam(@Param("user") User user);
+
+    // 특정 유저의 팀 멤버 정보 단건 조회
+    Optional<TeamMember> findByTeamAndUser(Team team, User user);
+
+    // 이미 팀에 가입된 유저인지 확인
+    boolean existsByTeamAndUser(Team team, User user);
+
+    // 팀 삭제 전 연관된 멤버 일괄 삭제용
+    void deleteAllByTeam(Team team);
+
+    // 팀 내 특정 권한(LEADER)을 가진 멤버 수 카운트 (마지막 리더 검증용)
+    long countByTeamAndRole(Team team, TeamRole role);
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/team/repository/TeamRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/team/repository/TeamRepository.java
@@ -9,11 +9,10 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {
-    List<Team> findByProject_ProjectId(Long projectId);
 
-    // 같은 조직 내 팀 전체 조회 (타 팀 Q&A 대상 리스트용)
-    @Query("SELECT t FROM Team t WHERE t.project.organization.organizationId = :organizationId")
-    List<Team> findAllByOrganizationId(@Param("organizationId") Long organizationId);
+    // 특정 프로젝트에 속한 모든 팀 조회
+    @Query("select t from Team t join fetch t.createdBy where t.project = :project")
+    List<Team> findAllByProject(@Param("project") Project project);
 
     void deleteAllByProject(Project project);
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/team/scheduler/TeamInviteScheduler.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/team/scheduler/TeamInviteScheduler.java
@@ -1,0 +1,40 @@
+package com._penLearning.Noddi.domain.team.scheduler;
+
+import com._penLearning.Noddi.domain.team.entity.InviteStatus;
+import com._penLearning.Noddi.domain.team.repository.TeamInviteRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TeamInviteScheduler {
+
+    private final TeamInviteRepository teamInviteRepository;
+
+    // 매일 자정(00:00:00)에 실행되도록 Cron 표현식 설정
+    @Scheduled(
+            cron = "${scheduler.team-invite.cron:0 0 * * * *}",
+            zone = "${scheduler.team-invite.zone:Asia/Seoul}"
+    )    @Transactional
+    public void expireOldInvitations() {
+        // 기준선: 시스템 현재 시간으로부터 정확히 7일 전
+        LocalDateTime threshold = LocalDateTime.now().minusDays(7);
+
+        // 기준선 이전에 생성된 PENDING 상태 초대장을 EXPIRED로 일괄 변경
+        int expiredCount = teamInviteRepository.bulkExpireInvitations(
+                threshold,
+                InviteStatus.PENDING,
+                InviteStatus.EXPIRED
+        );
+
+        if (expiredCount > 0) {
+            log.info("[TeamInviteScheduler] 유효기간(7일)이 지난 초대장 {}건을 EXPIRED 상태로 일괄 변경했습니다.", expiredCount);
+        }
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/team/service/TeamCommandService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/team/service/TeamCommandService.java
@@ -1,0 +1,253 @@
+package com._penLearning.Noddi.domain.team.service;
+
+import com._penLearning.Noddi.domain.project.code.ProjectErrorCode;
+import com._penLearning.Noddi.domain.project.entity.JoinStatus;
+import com._penLearning.Noddi.domain.project.entity.Project;
+import com._penLearning.Noddi.domain.project.entity.ProjectMember;
+import com._penLearning.Noddi.domain.project.repository.ProjectMemberRepository;
+import com._penLearning.Noddi.domain.project.repository.ProjectRepository;
+import com._penLearning.Noddi.domain.team.code.TeamErrorCode;
+import com._penLearning.Noddi.domain.team.dto.TeamRequestDto;
+import com._penLearning.Noddi.domain.team.dto.TeamResponseDto;
+import com._penLearning.Noddi.domain.team.entity.*;
+import com._penLearning.Noddi.domain.team.repository.TeamInviteRepository;
+import com._penLearning.Noddi.domain.team.repository.TeamMemberRepository;
+import com._penLearning.Noddi.domain.team.repository.TeamRepository;
+import com._penLearning.Noddi.domain.user.code.UserErrorCode;
+import com._penLearning.Noddi.domain.user.entity.User;
+import com._penLearning.Noddi.domain.user.repository.UserRepository;
+import com._penLearning.Noddi.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TeamCommandService {
+
+    private final TeamRepository teamRepository;
+    private final TeamMemberRepository teamMemberRepository;
+    private final TeamInviteRepository teamInviteRepository;
+    private final ProjectRepository projectRepository;
+    private final ProjectMemberRepository projectMemberRepository;
+    private final UserRepository userRepository;
+    private final TeamInviteExpirationService teamInviteExpirationService;
+
+    // 팀 생성 (생성자는 자동으로 LEADER 역할 부여)
+    @Transactional
+    public Long createTeam(Long projectId, Long requesterId, String teamName, String description) {
+        Project project = getProjectOrThrow(projectId);
+        User requester = getUserOrThrow(requesterId);
+
+        // 요청자가 해당 프로젝트의 정식 멤버(JOINED)인지 팩트 체크
+        validateProjectMember(project, requester);
+
+        Team team = Team.builder()
+                .project(project)
+                .name(teamName)
+                .description(description)
+                .createdBy(requester)
+                .build();
+        teamRepository.save(team);
+
+        TeamMember leader = TeamMember.builder()
+                .team(team)
+                .user(requester)
+                .role(TeamRole.LEADER)
+                .build();
+        teamMemberRepository.save(leader);
+
+        return team.getTeamId();
+    }
+
+    // 팀 멤버 초대장 발송
+    @Transactional
+    public void inviteTeamMember(Long teamId, Long requesterId, Long targetUserId) {
+        Team team = getTeamOrThrow(teamId);
+        User requester = getUserOrThrow(requesterId);
+        User targetUser = getUserOrThrow(targetUserId);
+
+        validateTeamLeader(team, requester);
+        validateProjectMember(team.getProject(), targetUser);
+
+        if (teamMemberRepository.existsByTeamAndUser(team, targetUser)) {
+            throw new GeneralException(TeamErrorCode.ALREADY_TEAM_MEMBER);
+        }
+
+        if (teamInviteRepository.existsByTeamAndInviteeAndStatus(team, targetUser, InviteStatus.PENDING)) {
+            throw new GeneralException(TeamErrorCode.ALREADY_INVITED);
+        }
+
+        TeamInvite invite = TeamInvite.builder()
+                .team(team)
+                .inviter(requester)
+                .invitee(targetUser)
+                .build();
+        teamInviteRepository.save(invite);
+    }
+
+    // 팀 초대 응답
+    @Transactional
+    public void respondToInvite(Long inviteId, Long userId, boolean isAccepted) {
+        TeamInvite invite = teamInviteRepository.findByIdWithTeam(inviteId)
+                .orElseThrow(() -> new GeneralException(TeamErrorCode.INVITE_NOT_FOUND));
+
+        if (!invite.getInvitee().getUserId().equals(userId)) {
+            throw new GeneralException(TeamErrorCode.NOT_INVITEE);
+        }
+
+        if (invite.getStatus() != InviteStatus.PENDING) {
+            throw new GeneralException(TeamErrorCode.INVITE_NOT_PENDING);
+        }
+
+        if (invite.isExpired(7)) {
+            teamInviteExpirationService.expire(inviteId);
+            throw new GeneralException(TeamErrorCode.INVITE_NOT_PENDING);
+        }
+
+        if (isAccepted) {
+
+            validateProjectMember(
+                    invite.getTeam().getProject(),
+                    invite.getInvitee()
+            );
+
+            if (teamMemberRepository.existsByTeamAndUser(
+                    invite.getTeam(),
+                    invite.getInvitee()
+            )) {
+                throw new GeneralException(TeamErrorCode.ALREADY_TEAM_MEMBER);
+            }
+
+            invite.accept();
+
+            TeamMember newMember = TeamMember.builder()
+                    .team(invite.getTeam())
+                    .user(invite.getInvitee())
+                    .role(TeamRole.MEMBER)
+                    .build();
+            teamMemberRepository.save(newMember);
+        } else {
+            invite.reject();
+        }
+    }
+
+    // 팀 정보 수정
+    @Transactional
+    public void updateTeam(Long teamId, Long requesterId, TeamRequestDto.UpdateInfo request) {
+        Team team = getTeamOrThrow(teamId);
+        User requester = getUserOrThrow(requesterId);
+
+        validateTeamLeader(team, requester); // 리더 권한 검증
+
+        team.updateTeamInfo(request.getName(), request.getDescription());
+    }
+
+    // 팀 삭제
+    @Transactional
+    public void deleteTeam(Long teamId, Long requesterId) {
+        Team team = getTeamOrThrow(teamId);
+        User requester = getUserOrThrow(requesterId);
+
+        validateTeamLeader(team, requester);
+
+        // 하위 데이터 일괄 삭제 (FK 제약조건 방어)
+        teamInviteRepository.deleteAllByTeam(team);
+        teamMemberRepository.deleteAllByTeam(team);
+
+        // 팀 삭제
+        teamRepository.delete(team);
+    }
+
+    // 멤버 권한 변경
+    @Transactional
+    public void updateMemberRole(Long teamId, Long requesterId, Long targetUserId, TeamRole newRole) {
+        Team team = getTeamOrThrow(teamId);
+        User requester = getUserOrThrow(requesterId);
+        User targetUser = getUserOrThrow(targetUserId);
+
+        validateTeamLeader(team, requester);
+
+        TeamMember targetMember = teamMemberRepository.findByTeamAndUser(team, targetUser)
+                .orElseThrow(() -> new GeneralException(TeamErrorCode.TEAM_NOT_FOUND));
+
+        // 자신이 리더인데 MEMBER로 강등하려는 경우 방어
+        if (targetMember.getRole() == TeamRole.LEADER && newRole == TeamRole.MEMBER) {
+            validateNotLastLeader(team, targetMember);
+        }
+
+        targetMember.updateRole(newRole);
+    }
+
+    // 팀 멤버 탈퇴 / 강퇴
+    @Transactional
+    public void removeMember(Long teamId, Long requesterId, Long targetUserId) {
+        Team team = getTeamOrThrow(teamId);
+        User targetUser = getUserOrThrow(targetUserId);
+
+        TeamMember targetMember = teamMemberRepository.findByTeamAndUser(team, targetUser)
+                .orElseThrow(() -> new GeneralException(TeamErrorCode.TEAM_NOT_FOUND));
+
+        // 본인이 스스로 탈퇴하는 경우가 아니라면, 요청자가 리더인지 검증
+        if (!requesterId.equals(targetUserId)) {
+            User requester = getUserOrThrow(requesterId);
+            validateTeamLeader(team, requester);
+        }
+
+        validateNotLastLeader(team, targetMember); // 마지막 리더 탈퇴 방어
+
+        teamMemberRepository.delete(targetMember);
+    }
+
+    // --- 내부 검증 헬퍼 메서드 ---
+
+    private void validateProjectMember(Project project, User user) {
+        ProjectMember projectMember = projectMemberRepository.findByProjectAndUser(project, user)
+                .orElseThrow(() -> new GeneralException(TeamErrorCode.NOT_PROJECT_MEMBER));
+
+        if (projectMember.getStatus() != JoinStatus.JOINED) {
+            throw new GeneralException(TeamErrorCode.NOT_PROJECT_MEMBER);
+        }
+    }
+
+    private void validateTeamLeader(Team team, User user) {
+        validateProjectMember(team.getProject(), user);
+
+        TeamMember teamMember =
+                teamMemberRepository.findByTeamAndUser(team, user)
+                        .orElseThrow(() ->
+                                new GeneralException(TeamErrorCode.NOT_TEAM_LEADER));
+
+        if (teamMember.getRole() != TeamRole.LEADER) {
+            throw new GeneralException(TeamErrorCode.NOT_TEAM_LEADER);
+        }
+    }
+
+    // 마지막 리더인지 검증하는 헬퍼 메서드
+    private void validateNotLastLeader(Team team, TeamMember targetMember) {
+        if (targetMember.getRole() == TeamRole.LEADER) {
+            long leaderCount = teamMemberRepository.countByTeamAndRole(team, TeamRole.LEADER);
+            if (leaderCount <= 1) {
+                throw new GeneralException(TeamErrorCode.CANNOT_REMOVE_LAST_LEADER);
+            }
+        }
+    }
+
+    private Project getProjectOrThrow(Long projectId) {
+        return projectRepository.findById(projectId)
+                .orElseThrow(() -> new GeneralException(ProjectErrorCode.PROJECT_NOT_FOUND));
+    }
+
+    private Team getTeamOrThrow(Long teamId) {
+        return teamRepository.findById(teamId)
+                .orElseThrow(() -> new GeneralException(TeamErrorCode.TEAM_NOT_FOUND));
+    }
+
+    private User getUserOrThrow(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(UserErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/team/service/TeamInviteExpirationService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/team/service/TeamInviteExpirationService.java
@@ -1,0 +1,25 @@
+package com._penLearning.Noddi.domain.team.service;
+
+import com._penLearning.Noddi.domain.team.code.TeamErrorCode;
+import com._penLearning.Noddi.domain.team.entity.TeamInvite;
+import com._penLearning.Noddi.domain.team.repository.TeamInviteRepository;
+import com._penLearning.Noddi.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TeamInviteExpirationService {
+
+    private final TeamInviteRepository teamInviteRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void expire(Long inviteId) {
+        TeamInvite invite = teamInviteRepository.findById(inviteId)
+                .orElseThrow(() -> new GeneralException(TeamErrorCode.INVITE_NOT_FOUND));
+
+        invite.expire();
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/team/service/TeamQueryService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/team/service/TeamQueryService.java
@@ -1,0 +1,140 @@
+package com._penLearning.Noddi.domain.team.service;
+
+import com._penLearning.Noddi.domain.project.code.ProjectErrorCode;
+import com._penLearning.Noddi.domain.project.entity.JoinStatus;
+import com._penLearning.Noddi.domain.project.entity.Project;
+import com._penLearning.Noddi.domain.project.entity.ProjectMember;
+import com._penLearning.Noddi.domain.project.repository.ProjectMemberRepository;
+import com._penLearning.Noddi.domain.project.repository.ProjectRepository;
+import com._penLearning.Noddi.domain.team.code.TeamErrorCode;
+import com._penLearning.Noddi.domain.team.dto.TeamResponseDto;
+import com._penLearning.Noddi.domain.team.entity.InviteStatus;
+import com._penLearning.Noddi.domain.team.entity.Team;
+import com._penLearning.Noddi.domain.team.entity.TeamMember;
+import com._penLearning.Noddi.domain.team.entity.TeamRole;
+import com._penLearning.Noddi.domain.team.repository.TeamInviteRepository;
+import com._penLearning.Noddi.domain.team.repository.TeamMemberRepository;
+import com._penLearning.Noddi.domain.team.repository.TeamRepository;
+import com._penLearning.Noddi.domain.user.code.UserErrorCode;
+import com._penLearning.Noddi.domain.user.entity.User;
+import com._penLearning.Noddi.domain.user.repository.UserRepository;
+import com._penLearning.Noddi.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TeamQueryService {
+    private final TeamRepository teamRepository;
+    private final TeamMemberRepository teamMemberRepository;
+    private final TeamInviteRepository teamInviteRepository;
+    private final ProjectRepository projectRepository;
+    private final ProjectMemberRepository projectMemberRepository;
+    private final UserRepository userRepository;
+
+    public List<TeamResponseDto.ProjectTeamInfo> getTeamsByProject(Long projectId, Long requesterId) {
+        Project project = getProjectOrThrow(projectId);
+        User requester = getUserOrThrow(requesterId);
+
+        // 프로젝트 정식 멤버인지 검증 (외부인 접근 차단)
+        validateProjectMember(project, requester);
+
+        return teamRepository.findAllByProject(project).stream()
+                .map(TeamResponseDto.ProjectTeamInfo::from)
+                .toList();
+    }
+
+    // 내가 속한 팀 목록 조회
+    public List<TeamResponseDto.TeamInfo> getMyTeams(Long userId) {
+        User user = getUserOrThrow(userId);
+
+        return teamMemberRepository.findAllByUserWithTeam(user).stream()
+                .map(TeamResponseDto.TeamInfo::from)
+                .toList();
+    }
+
+    // 특정 팀의 멤버 목록 조회
+    public List<TeamResponseDto.MemberInfo> getTeamMembers(Long teamId, Long requesterId) {
+        Team team = getTeamOrThrow(teamId);
+        User requester = getUserOrThrow(requesterId);
+
+        // 팀 멤버 목록은 해당 팀에 소속된 유저만 조회 가능 (외부인 차단)
+        validateTeamMembership(team, requester);
+
+        return teamMemberRepository.findAllByTeamWithUser(team).stream()
+                .map(TeamResponseDto.MemberInfo::from)
+                .toList();
+    }
+
+    // 내가 받은 팀 초대장 목록 조회
+    public List<TeamResponseDto.InvitationInfo> getMyInvitations(Long userId) {
+        User user = getUserOrThrow(userId);
+
+        // PENDING 상태인 초대장만, Team 정보와 함께 페치 조인으로 가져옴
+        return teamInviteRepository.findByInviteeAndStatusWithTeam(user, InviteStatus.PENDING).stream()
+                .map(TeamResponseDto.InvitationInfo::from)
+                .toList();
+    }
+
+    // --- 내부 검증 헬퍼 메서드 ---
+
+    private void validateProjectMember(Project project, User user) {
+        ProjectMember projectMember = projectMemberRepository.findByProjectAndUser(project, user)
+                .orElseThrow(() -> new GeneralException(TeamErrorCode.NOT_PROJECT_MEMBER));
+
+        if (projectMember.getStatus() != JoinStatus.JOINED) {
+            throw new GeneralException(TeamErrorCode.NOT_PROJECT_MEMBER);
+        }
+    }
+
+    private void validateTeamLeader(Team team, User user) {
+        validateProjectMember(team.getProject(), user);
+
+        TeamMember teamMember =
+                teamMemberRepository.findByTeamAndUser(team, user)
+                        .orElseThrow(() ->
+                                new GeneralException(TeamErrorCode.NOT_TEAM_LEADER));
+
+        if (teamMember.getRole() != TeamRole.LEADER) {
+            throw new GeneralException(TeamErrorCode.NOT_TEAM_LEADER);
+        }
+    }
+
+    // 마지막 리더인지 검증하는 헬퍼 메서드
+    private void validateNotLastLeader(Team team, TeamMember targetMember) {
+        if (targetMember.getRole() == TeamRole.LEADER) {
+            long leaderCount = teamMemberRepository.countByTeamAndRole(team, TeamRole.LEADER);
+            if (leaderCount <= 1) {
+                throw new IllegalArgumentException("팀의 마지막 리더는 탈퇴하거나 권한을 강등할 수 없습니다.");
+            }
+        }
+    }
+
+    // 팀에 속해 있는지만 확인하는 검증 로직
+    private void validateTeamMembership(Team team, User user) {
+        if (!teamMemberRepository.existsByTeamAndUser(team, user)) {
+            // 필요시 TeamErrorCode.NOT_TEAM_MEMBER 등으로 교체
+            throw new GeneralException(TeamErrorCode.TEAM_NOT_FOUND);
+        }
+    }
+
+    private Project getProjectOrThrow(Long projectId) {
+        return projectRepository.findById(projectId)
+                .orElseThrow(() -> new GeneralException(ProjectErrorCode.PROJECT_NOT_FOUND));
+    }
+
+    private Team getTeamOrThrow(Long teamId) {
+        return teamRepository.findById(teamId)
+                .orElseThrow(() -> new GeneralException(TeamErrorCode.TEAM_NOT_FOUND));
+    }
+
+    private User getUserOrThrow(Long userId) {
+        // Auth/User 예외 코드 활용 권장
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(UserErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,7 +7,7 @@ spring:
     password: ${DB_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -34,6 +34,12 @@ spring:
           connectiontimeout: 5000
           timeout: 5000
           writetimeout: 5000
+scheduler:
+  team-invite:
+    cron: "0 0 * * * *"
+    zone: Asia/Seoul
+    valid-days: 7
+
 jwt:
   secret: TEMPKEYTEMPKEYTEMPKEYTEMPKEY1234567890abcdefghijklmnopqrstuvw1234
   access-token-expiration: 3600000


### PR DESCRIPTION
## <i>PULL REQUEST</i>

## 🎋 작업 브랜치
- feature/3 -> develop
- #9

## 💡 작업동기

* 프로젝트(Project) 하위에서 실제 협업과 Q&A가 이루어지는 핵심 단위인 **팀(Team) 도메인**의 기반 인프라 및 비즈니스 로직을 구축하기 위함.
* 프로젝트 정식 멤버 간의 안전한 팀 구성과 데이터 무결성을 보장하기 위해, 권한 검증과 초대장 생명주기(Lifecycle) 관리가 포함된 체계적인 팀 멤버십 시스템이 필요함.

## 🔑 주요 변경사항

* **팀 도메인 엔티티 설계:** `Team`, `TeamMember`, `TeamInvite` 엔티티 생성 및 데이터 무결성을 위한 복합 유니크 키(`UK_TEAM_USER`) 제약조건 적용.
* **서비스 분리:** 트랜잭션 경계와 가독성을 명확히 하기 위해 데이터 변경(`TeamCommandService`)과 단순 조회(`TeamQueryService`) 비즈니스 로직을 분리.
* **프로젝트 멤버십 교차 검증:** 팀 생성 및 초대 발송 시, 요청자와 대상자가 해당 프로젝트의 정식 가입자(`JOINED`)인지 팩트 체크하는 방어 로직 적용.
* **초대장 생명주기(Lifecycle) 및 만료(Expire) 시스템 구축:**
* 수락/거절 시점의 유효기간(7일) 실시간 검증 로직(Lazy Evaluation) 구현.
* 매 시간, 기한이 지난 `PENDING` 상태의 초대장을 일괄 `EXPIRED` 처리하는 Spring Batch Scheduler(`TeamInviteScheduler`) 도입.

* **권한 관리 및 벌크 삭제 최적화:** 마지막 남은 팀 리더(LEADER)의 강등 및 탈퇴를 막는 방어 로직 구현, 팀 삭제 시 연관 데이터 N+1 쿼리 방지를 위한 벌크 삭제(Bulk Delete) 쿼리 적용.

## 🏞 스크린샷 (선택)
> 스크린샷을 첨부해주세요.

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
