### PR TITLE
[refactor] Team 및 Project 코드 리펙토링

### DIFF
--- a/src/main/java/com/_penLearning/Noddi/domain/project/code/ProjectErrorCode.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/code/ProjectErrorCode.java
@@ -13,18 +13,21 @@ public enum ProjectErrorCode implements BaseErrorCode {
     INVALID_PROJECT_REQUEST(HttpStatus.BAD_REQUEST, "PROJECT400_1", "잘못된 프로젝트 요청입니다."),
     NOT_SAME_ORGANIZATION(HttpStatus.BAD_REQUEST, "PROJECT400_2", "다른 조직 멤버에게는 초대를 전송할 수 없습니다."),
     CANNOT_REMOVE_LAST_LEADER(HttpStatus.BAD_REQUEST, "PROJECT400_3", "프로젝트의 마지막 리더는 탈퇴하거나 권한을 강등할 수 없습니다."),
+    INVITE_NOT_PENDING(HttpStatus.BAD_REQUEST, "PROJECT400_4", "이미 처리되었거나 만료된 초대장입니다."),
+    INVITE_EXPIRED(HttpStatus.BAD_REQUEST, "PROJECT400_5", "만료된 초대장입니다."),
 
     // 403 FORBIDDEN (권한 없음)
     NOT_PROJECT_LEADER(HttpStatus.FORBIDDEN, "PROJECT403_1", "프로젝트 관리자(LEADER) 권한이 필요합니다."),
-    NO_PERMISSION_TO_UPDATE(HttpStatus.FORBIDDEN, "PROJECT403_2", "프로젝트를 수정/삭제할 권한이 없습니다."),
+    NOT_INVITEE(HttpStatus.FORBIDDEN, "PROJECT403_2", "해당 초대의 대상자가 아닙니다."),
 
     // 404 NOT_FOUND (존재하지 않음)
     PROJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "PROJECT404_1", "해당 프로젝트를 찾을 수 없습니다."),
     PROJECT_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "PROJECT404_2", "해당 프로젝트의 멤버가 아닙니다."),
+    INVITE_NOT_FOUND(HttpStatus.NOT_FOUND, "PROJECT404_3", "초대장을 찾을 수 없습니다."),
 
     // 409 CONFLICT (충돌/중복)
     ALREADY_PROJECT_MEMBER(HttpStatus.CONFLICT, "PROJECT409_1", "이미 프로젝트에 참여 중인 유저입니다."),
-    ALREADY_INVITED_USER(HttpStatus.CONFLICT, "PROJECT_409_2", "이미 초대를 받고 대기 중인 유저입니다.");
+    ALREADY_INVITED_USER(HttpStatus.CONFLICT, "PROJECT409_2", "이미 초대를 받고 대기 중인 유저입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/_penLearning/Noddi/domain/project/code/ProjectMemberApi.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/code/ProjectMemberApi.java
@@ -30,12 +30,12 @@ public interface ProjectMemberApi {
 
     @Operation(summary = "프로젝트 초대 수락/거절", description = "받은 초대에 대해 수락(true) 또는 거절(false)을 처리합니다.")
     ApiResponse<Void> respondToInvitation(
-            @PathVariable Long projectId,
+            @PathVariable Long inviteId,
             @Parameter(hidden = true) @AuthenticationPrincipal AuthMember authMember,
             @RequestBody ProjectMemberRequestDto.Respond request
     );
 
-    @Operation(summary = "프로젝트 정식 멤버 조회", description = "해당 프로젝트에 가입 완료된(JOINED) 멤버 목록을 조회합니다.")
+    @Operation(summary = "프로젝트 멤버 조회", description = "해당 프로젝트에 가입된 멤버 목록을 조회합니다.")
     ApiResponse<List<ProjectMemberResponseDto.MemberInfo>> getMembers(
             @PathVariable Long projectId,
             @Parameter(hidden = true) @AuthenticationPrincipal AuthMember authMember

--- a/src/main/java/com/_penLearning/Noddi/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/controller/ProjectController.java
@@ -45,7 +45,7 @@ public class ProjectController implements ProjectApi {
             @PathVariable Long projectId,
             @Valid @RequestBody ProjectRequestDto.Update request,
             @AuthenticationPrincipal AuthMember authMember){
-            projectService.updateProject(authMember.getUserId(), projectId, request);
+            projectService.updateProject(projectId, authMember.getUserId(), request);
 
             return ApiResponse.onSuccess("프로젝트 정보 수정을 성공했습니다.");
     }

--- a/src/main/java/com/_penLearning/Noddi/domain/project/controller/ProjectMemberController.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/controller/ProjectMemberController.java
@@ -5,7 +5,6 @@ import com._penLearning.Noddi.domain.project.code.ProjectMemberApi;
 import com._penLearning.Noddi.domain.project.dto.ProjectMemberRequestDto;
 import com._penLearning.Noddi.domain.project.dto.ProjectMemberResponseDto;
 import com._penLearning.Noddi.domain.project.service.ProjectMemberService;
-import com._penLearning.Noddi.domain.project.service.ProjectService;
 import com._penLearning.Noddi.global.apiPayload.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +19,6 @@ import java.util.List;
 public class ProjectMemberController implements ProjectMemberApi {
 
     private final ProjectMemberService projectMemberService;
-    private final ProjectService projectService;
 
     @Override
     @PostMapping("/{projectId}/members/invite")
@@ -44,13 +42,13 @@ public class ProjectMemberController implements ProjectMemberApi {
     }
 
     @Override
-    @PostMapping("/{projectId}/invitations/respond")
+    @PostMapping("/invitations/{inviteId}/respond")
     public ApiResponse<Void> respondToInvitation(
-            @PathVariable Long projectId,
+            @PathVariable Long inviteId,
             @AuthenticationPrincipal AuthMember authMember,
             @RequestBody @Valid ProjectMemberRequestDto.Respond request) {
 
-        projectMemberService.respondToInvitation(projectId, authMember.getUserId(), request.getIsAccepted());
+        projectMemberService.respondToInvitation(inviteId, authMember.getUserId(), request.getIsAccepted());
         String message = request.getIsAccepted() ? "초대를 수락하여 프로젝트에 가입되었습니다." : "초대를 거절했습니다.";
 
         return ApiResponse.onSuccess(message);

--- a/src/main/java/com/_penLearning/Noddi/domain/project/dto/ProjectMemberResponseDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/dto/ProjectMemberResponseDto.java
@@ -1,5 +1,6 @@
 package com._penLearning.Noddi.domain.project.dto;
 
+import com._penLearning.Noddi.domain.project.entity.ProjectInvite;
 import com._penLearning.Noddi.domain.project.entity.ProjectMember;
 import com._penLearning.Noddi.domain.project.entity.ProjectRole;
 import lombok.Builder;
@@ -30,17 +31,23 @@ public class ProjectMemberResponseDto {
     @Getter
     @Builder
     public static class InvitationInfo {
+        private Long inviteId;
         private Long projectId;
         private String projectName;
         private String projectDescription;
-        private ProjectRole offeredRole; // 어떤 권한으로 초대받았는지 명시
+        private Long inviterId;
+        private String inviterName;
+        private ProjectRole offeredRole;
 
-        public static InvitationInfo from(ProjectMember projectMember) {
+        public static InvitationInfo from(ProjectInvite invite) {
             return InvitationInfo.builder()
-                    .projectId(projectMember.getProject().getProjectId())
-                    .projectName(projectMember.getProject().getName()) // N:1 연관관계(Fetch Join)로 가져온 프로젝트 이름
-                    .projectDescription(projectMember.getProject().getDescription())
-                    .offeredRole(projectMember.getRole())
+                    .inviteId(invite.getInviteId())
+                    .projectId(invite.getProject().getProjectId())
+                    .projectName(invite.getProject().getName())
+                    .projectDescription(invite.getProject().getDescription())
+                    .inviterId(invite.getInviter().getUserId())
+                    .inviterName(invite.getInviter().getName())
+                    .offeredRole(ProjectRole.MEMBER)
                     .build();
         }
     }

--- a/src/main/java/com/_penLearning/Noddi/domain/project/entity/InviteStatus.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/entity/InviteStatus.java
@@ -1,0 +1,5 @@
+package com._penLearning.Noddi.domain.project.entity;
+
+public enum InviteStatus {
+    PENDING, ACCEPTED, REJECTED, EXPIRED
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/project/entity/JoinStatus.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/entity/JoinStatus.java
@@ -1,7 +1,0 @@
-package com._penLearning.Noddi.domain.project.entity;
-
-public enum JoinStatus {
-    INVITED,  // 초대를 받고 대기 중인 상태
-    JOINED,   // 수락 완료 (정식 멤버)
-    REJECTED  // 초대 거절
-}

--- a/src/main/java/com/_penLearning/Noddi/domain/project/entity/ProjectInvite.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/entity/ProjectInvite.java
@@ -1,0 +1,70 @@
+package com._penLearning.Noddi.domain.project.entity;
+
+import com._penLearning.Noddi.domain.user.entity.User;
+import com._penLearning.Noddi.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "ProjectInvite")
+public class ProjectInvite extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long inviteId;
+
+    @Version
+    private Long version;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "projectId", nullable = false)
+    private Project project;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "inviterId", nullable = false)
+    private User inviter;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "inviteeId", nullable = false)
+    private User invitee;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private InviteStatus status;
+
+    private LocalDateTime respondedAt;
+
+    @Builder
+    public ProjectInvite(Project project, User inviter, User invitee) {
+        this.project = project;
+        this.inviter = inviter;
+        this.invitee = invitee;
+        this.status = InviteStatus.PENDING;
+    }
+
+    public void accept() {
+        this.status = InviteStatus.ACCEPTED;
+        this.respondedAt = LocalDateTime.now();
+    }
+
+    public void reject() {
+        this.status = InviteStatus.REJECTED;
+        this.respondedAt = LocalDateTime.now();
+    }
+
+    public boolean isExpired(int validDays) {
+        // BaseEntity의 createdAt을 활용
+        return this.getCreatedAt().plusDays(validDays).isBefore(LocalDateTime.now());
+    }
+
+    public void expire() {
+        this.status = InviteStatus.EXPIRED;
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/project/entity/ProjectMember.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/entity/ProjectMember.java
@@ -32,35 +32,19 @@ public class ProjectMember extends BaseEntity {
     @Column(nullable = false)
     private ProjectRole role;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private JoinStatus status; // 상태 필드 추가
-
     @Builder
-    public ProjectMember(Project project, User user, ProjectRole role, JoinStatus status) {
+    public ProjectMember(Project project, User user, ProjectRole role) {
         this.project = project;
         this.user = user;
         this.role = role;
-        this.status = status;
     }
 
-    // 객체 생성 책임을 캡슐화한 정적 팩토리 메서드
-    public static ProjectMember create(Project project, User user, ProjectRole role, JoinStatus status) {
+    public static ProjectMember create(Project project, User user, ProjectRole role) {
         return ProjectMember.builder()
                 .project(project)
                 .user(user)
                 .role(role)
-                .status(status)
                 .build();
-    }
-
-    // 상태 변경 로직 캡슐화
-    public void acceptInvitation() {
-        this.status = JoinStatus.JOINED;
-    }
-
-    public void rejectInvitation() {
-        this.status = JoinStatus.REJECTED;
     }
 
     public void updateRole(ProjectRole newRole) {

--- a/src/main/java/com/_penLearning/Noddi/domain/project/repository/ProjectInviteRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/repository/ProjectInviteRepository.java
@@ -1,0 +1,42 @@
+package com._penLearning.Noddi.domain.project.repository;
+
+import com._penLearning.Noddi.domain.project.entity.InviteStatus;
+import com._penLearning.Noddi.domain.project.entity.Project;
+import com._penLearning.Noddi.domain.project.entity.ProjectInvite;
+import com._penLearning.Noddi.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface ProjectInviteRepository extends JpaRepository<ProjectInvite, Long> {
+
+    // 1. 중복 초대 방어
+    boolean existsByProjectAndInviteeAndStatus(Project project, User invitee, InviteStatus status);
+
+    // 2. 초대장 단건 조회 (N+1 방지)
+    @Query("SELECT pi FROM ProjectInvite pi JOIN FETCH pi.project JOIN FETCH pi.invitee WHERE pi.inviteId = :inviteId")
+    Optional<ProjectInvite> findByIdWithProject(@Param("inviteId") Long inviteId);
+
+    // 3. 내 초대장 목록 조회 (N+1 방지)
+    @Query("SELECT pi FROM ProjectInvite pi JOIN FETCH pi.project JOIN FETCH pi.inviter WHERE pi.invitee = :invitee AND pi.status = :status")
+    List<ProjectInvite> findByInviteeAndStatusWithProject(@Param("invitee") User invitee, @Param("status") InviteStatus status);
+
+    // 4. 프로젝트 삭제 시 연관 초대장 일괄 삭제 (벌크 연산)
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM ProjectInvite p WHERE p.project = :project")
+    void deleteBulkByProject(@Param("project") Project project);
+
+    // 5. 유효기간 만료 초대장 일괄 처리 (벌크 연산)
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE ProjectInvite p SET p.status = :expiredStatus, p.version = p.version + 1 WHERE p.status = :pendingStatus AND p.createdAt < :expirationThreshold")
+    int bulkExpireInvitations(
+            @Param("expirationThreshold") LocalDateTime expirationThreshold,
+            @Param("pendingStatus") InviteStatus pendingStatus,
+            @Param("expiredStatus") InviteStatus expiredStatus
+    );
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/project/repository/ProjectMemberRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/repository/ProjectMemberRepository.java
@@ -1,7 +1,5 @@
 package com._penLearning.Noddi.domain.project.repository;
 
-import com._penLearning.Noddi.domain.project.dto.ProjectMemberResponseDto;
-import com._penLearning.Noddi.domain.project.entity.JoinStatus;
 import com._penLearning.Noddi.domain.project.entity.Project;
 import com._penLearning.Noddi.domain.project.entity.ProjectMember;
 import com._penLearning.Noddi.domain.project.entity.ProjectRole;
@@ -16,24 +14,23 @@ import java.util.Optional;
 
 public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Long> {
 
-    // 특정 프로젝트에 특정 유저가 존재하는지 확인 (중복 초대 방지)
+    // 1. 특정 프로젝트에 특정 유저가 존재하는지 확인 (중복 초대 방지 등)
     boolean existsByProjectAndUser(Project project, User user);
 
-    // 단건 조회 (권한 검증 및 탈퇴 로직에 사용)
+    // 2. 단건 조회 (권한 검증 및 탈퇴 로직에 사용)
     Optional<ProjectMember> findByProjectAndUser(Project project, User user);
 
-    // 프로젝트의 정식 멤버 목록 조회 (상태가 JOINED인 사람만)
-    @Query("SELECT pm FROM ProjectMember pm JOIN FETCH pm.user WHERE pm.project = :project AND pm.status = 'JOINED'")
-    List<ProjectMember> findJoinedMembersByProject(@Param("project") Project project);
+    // 3. 프로젝트의 멤버 목록 조회 (N+1 방지)
+    // 팩트: 상태 검증이 필요 없으므로 기존 findJoinedMembersByProject를 삭제하고 이것으로 통합
+    @Query("SELECT pm FROM ProjectMember pm JOIN FETCH pm.user WHERE pm.project = :project")
+    List<ProjectMember> findAllByProjectWithUser(@Param("project") Project project);
 
-    // 내가 받은 초대장 목록 조회 (N+1 방지를 위해 Project 패치 조인)
-    @Query("SELECT pm FROM ProjectMember pm JOIN FETCH pm.project WHERE pm.user = :user AND pm.status = 'INVITED'")
-    List<ProjectMember> findInvitationsByUser(@Param("user") User user);
+    // 4. 특정 권한을 가진 멤버 수 카운트 (마지막 리더 검증용)
+    // 팩트: Status 조건이 포함되었던 countByProjectAndRoleAndStatus 쿼리 대체
+    long countByProjectAndRole(Project project, ProjectRole role);
 
-    long countByProjectAndRoleAndStatus(Project project, ProjectRole role, JoinStatus status);
-
-    void deleteAllByProject(Project project);
-
+    // 5. 프로젝트 삭제 시 멤버 일괄 삭제 (벌크 연산)
+    // 팩트: N+1 문제를 유발하는 기존 deleteAllByProject 메서드는 완전 삭제
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM ProjectMember pm WHERE pm.project = :project")
     void bulkDeleteByProject(@Param("project") Project project);

--- a/src/main/java/com/_penLearning/Noddi/domain/project/scheduler/ProjectInviteScheduler.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/scheduler/ProjectInviteScheduler.java
@@ -1,0 +1,44 @@
+package com._penLearning.Noddi.domain.project.scheduler;
+
+import com._penLearning.Noddi.domain.project.entity.InviteStatus;
+import com._penLearning.Noddi.domain.project.repository.ProjectInviteRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProjectInviteScheduler {
+    private final ProjectInviteRepository projectInviteRepository;
+
+    @Value("${scheduler.invite.valid-days:7}")
+    private int validDays;
+
+    // 기본값은 매시간 정각 실행
+    @Scheduled(
+            cron = "${scheduler.invite.cron:0 0 * * * *}",
+            zone = "${scheduler.invite.zone:Asia/Seoul}"
+    )
+    @Transactional
+    public void expireOldInvitations() {
+        // 설정된 유효기간을 기준으로 만료 기준 시각 계산
+        LocalDateTime threshold = LocalDateTime.now().minusDays(validDays);
+
+        // 기준선 이전에 생성된 PENDING 상태 초대장을 EXPIRED로 일괄 변경
+        int expiredCount = projectInviteRepository.bulkExpireInvitations(
+                threshold,
+                InviteStatus.PENDING,
+                InviteStatus.EXPIRED
+        );
+
+        if (expiredCount > 0) {
+            log.info("[ProjectInviteScheduler] 유효기간({}일)이 지난 초대장 {}건을 EXPIRED 상태로 일괄 변경했습니다.", validDays, expiredCount);
+        }
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/project/service/ProjectInviteExpirationService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/service/ProjectInviteExpirationService.java
@@ -1,0 +1,24 @@
+package com._penLearning.Noddi.domain.project.service;
+
+import com._penLearning.Noddi.domain.project.code.ProjectErrorCode;
+import com._penLearning.Noddi.domain.project.entity.ProjectInvite;
+import com._penLearning.Noddi.domain.project.repository.ProjectInviteRepository;
+import com._penLearning.Noddi.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ProjectInviteExpirationService {
+
+    private final ProjectInviteRepository projectInviteRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void expire(Long inviteId) {
+        ProjectInvite invite = projectInviteRepository.findById(inviteId)
+                .orElseThrow(() -> new GeneralException(ProjectErrorCode.INVITE_NOT_FOUND));
+        invite.expire();
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/project/service/ProjectMemberService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/service/ProjectMemberService.java
@@ -2,10 +2,8 @@ package com._penLearning.Noddi.domain.project.service;
 
 import com._penLearning.Noddi.domain.project.code.ProjectErrorCode;
 import com._penLearning.Noddi.domain.project.dto.ProjectMemberResponseDto;
-import com._penLearning.Noddi.domain.project.entity.JoinStatus;
-import com._penLearning.Noddi.domain.project.entity.Project;
-import com._penLearning.Noddi.domain.project.entity.ProjectMember;
-import com._penLearning.Noddi.domain.project.entity.ProjectRole;
+import com._penLearning.Noddi.domain.project.entity.*;
+import com._penLearning.Noddi.domain.project.repository.ProjectInviteRepository;
 import com._penLearning.Noddi.domain.project.repository.ProjectMemberRepository;
 import com._penLearning.Noddi.domain.project.repository.ProjectRepository;
 import com._penLearning.Noddi.domain.user.code.UserErrorCode;
@@ -13,6 +11,7 @@ import com._penLearning.Noddi.domain.user.entity.User;
 import com._penLearning.Noddi.domain.user.repository.UserRepository;
 import com._penLearning.Noddi.global.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,78 +23,105 @@ import java.util.List;
 public class ProjectMemberService {
 
     private final ProjectMemberRepository projectMemberRepository;
+    private final ProjectInviteRepository projectInviteRepository;
     private final ProjectRepository projectRepository;
     private final UserRepository userRepository;
+    private final ProjectInviteExpirationService projectInviteExpirationService;
+
+    @Value("${scheduler.invite.valid-days:7}")
+    private int inviteValidDays;
 
     // 관리자가 유저를 초대
     @Transactional
     public void inviteUser(Long projectId, Long requesterId, Long targetUserId) {
         Project project = getProjectOrThrow(projectId);
-        validateLeaderPermission(project, requesterId); // 리더만 초대 가능
-
         User targetUser = getUserOrThrow(targetUserId);
 
-        if (!project.getOrganization().getOrganizationId().equals(targetUser.getOrganization().getOrganizationId())) {
+        validateProjectLeader(project, requesterId);
+
+        if (!project.getOrganization().getOrganizationId()
+                .equals(targetUser.getOrganization().getOrganizationId())) {
             throw new GeneralException(ProjectErrorCode.NOT_SAME_ORGANIZATION);
         }
 
-        projectMemberRepository.findByProjectAndUser(project, targetUser)
-                .ifPresent(existingMember -> {
-                    if (existingMember.getStatus() == JoinStatus.JOINED) {
-                        throw new GeneralException(ProjectErrorCode.ALREADY_PROJECT_MEMBER);
-                    } else if (existingMember.getStatus() == JoinStatus.INVITED) {
-                        throw new GeneralException(ProjectErrorCode.ALREADY_INVITED_USER);
-                    }
-                });
+        // ProjectMember가 존재하면 이미 가입된 사용자다.
+        if (projectMemberRepository.existsByProjectAndUser(project, targetUser)) {
+            throw new GeneralException(ProjectErrorCode.ALREADY_PROJECT_MEMBER);
+        }
 
-        // 데이터가 없을 경우에만 새로운 초대 레코드 생성
-        ProjectMember newMember = ProjectMember.create(project, targetUser, ProjectRole.MEMBER, JoinStatus.INVITED);
-        projectMemberRepository.save(newMember);
+        // 2. 중복 초대 방어
+        if (projectInviteRepository.existsByProjectAndInviteeAndStatus(project, targetUser, InviteStatus.PENDING)) {
+            throw new GeneralException(ProjectErrorCode.ALREADY_INVITED_USER);
+        }
+
+        User requester = getUserOrThrow(requesterId);
+        ProjectInvite invite = ProjectInvite.builder()
+                .project(project)
+                .inviter(requester)
+                .invitee(targetUser)
+                .build();
+        projectInviteRepository.save(invite);
     }
 
     // 받은 초대장 조회
-    public List<ProjectMemberResponseDto .InvitationInfo> getMyInvitations(Long userId) {
+    public List<ProjectMemberResponseDto.InvitationInfo> getMyInvitations(Long userId) {
         User user = getUserOrThrow(userId);
-        return projectMemberRepository.findInvitationsByUser(user).stream()
+
+        return projectInviteRepository.findByInviteeAndStatusWithProject(user, InviteStatus.PENDING).stream()
                 .map(ProjectMemberResponseDto.InvitationInfo::from)
                 .toList();
     }
 
     // 초대장 응답 처리
     @Transactional
-    public void respondToInvitation(Long projectId, Long userId, boolean isAccepted) {
-        Project project = getProjectOrThrow(projectId);
-        User user = getUserOrThrow(userId);
+    public void respondToInvitation(Long inviteId, Long userId, boolean isAccepted) {
+        ProjectInvite invite = projectInviteRepository.findByIdWithProject(inviteId)
+                .orElseThrow(() -> new GeneralException(ProjectErrorCode.INVITE_NOT_FOUND));
 
-        ProjectMember invitation = getProjectMemberOrThrow(project, user);
+        if (!invite.getInvitee().getUserId().equals(userId)) {
+            throw new GeneralException(ProjectErrorCode.NOT_INVITEE);
+        }
 
-        // 이미 가입했거나 다른 상태인지 팩트 체크
-        if (invitation.getStatus() != JoinStatus.INVITED) {
-            throw new GeneralException(ProjectErrorCode.INVALID_PROJECT_REQUEST);
+        if (invite.getStatus() != InviteStatus.PENDING) {
+            throw new GeneralException(ProjectErrorCode.INVITE_NOT_PENDING);
+        }
+
+        // 스케줄러 실행 전이라도 응답 시점에 만료 여부를 다시 검증한다.
+        if (invite.isExpired(inviteValidDays)) {
+            projectInviteExpirationService.expire(inviteId);
+            throw new GeneralException(ProjectErrorCode.INVITE_EXPIRED);
         }
 
         if (isAccepted) {
-            invitation.acceptInvitation(); // 상태를 JOINED로 UPDATE (JPA 더티 체킹)
+            if (!invite.getProject().getOrganization().getOrganizationId()
+                    .equals(invite.getInvitee().getOrganization().getOrganizationId())) {
+                throw new GeneralException(ProjectErrorCode.NOT_SAME_ORGANIZATION);
+            }
+
+            if (projectMemberRepository.existsByProjectAndUser(invite.getProject(), invite.getInvitee())) {
+                throw new GeneralException(ProjectErrorCode.ALREADY_PROJECT_MEMBER);
+            }
+
+            invite.accept();
+            ProjectMember newMember = ProjectMember.builder()
+                    .project(invite.getProject())
+                    .user(invite.getInvitee())
+                    .role(ProjectRole.MEMBER)
+                    .build();
+            projectMemberRepository.save(newMember);
         } else {
-            projectMemberRepository.delete(invitation); // 거절 시 데이터를 삭제하여 다시 초대받을 수 있게 처리
+            invite.reject();
         }
     }
 
     // 프로젝트 멤버 조회
-    public List<ProjectMemberResponseDto.MemberInfo> getMembers(
-            Long projectId, Long requesterId
-    ) {
+    public List<ProjectMemberResponseDto.MemberInfo> getMembers(Long projectId, Long requesterId) {
         Project project = getProjectOrThrow(projectId);
         User requester = getUserOrThrow(requesterId);
 
-        ProjectMember requesterMember =
-                getProjectMemberOrThrow(project, requester);
+        getProjectMemberOrThrow(project, requester);
 
-        if (requesterMember.getStatus() != JoinStatus.JOINED) {
-            throw new GeneralException(ProjectErrorCode.PROJECT_MEMBER_NOT_FOUND);
-        }
-
-        return projectMemberRepository.findJoinedMembersByProject(project).stream()
+        return projectMemberRepository.findAllByProjectWithUser(project).stream()
                 .map(ProjectMemberResponseDto.MemberInfo::from)
                 .toList();
     }
@@ -104,15 +130,11 @@ public class ProjectMemberService {
     @Transactional
     public void updateMemberRole(Long projectId, Long requesterId, Long targetUserId, ProjectRole newRole) {
         Project project = getProjectOrThrow(projectId);
-        validateLeaderPermission(project, requesterId);
+        validateProjectLeader(project, requesterId);
 
         User targetUser = getUserOrThrow(targetUserId);
         ProjectMember targetMember = getProjectMemberOrThrow(project, targetUser);
 
-        // 방어 로직: 아직 수락하지 않은(INVITED) 사람은 권한 변경 불가
-        if (targetMember.getStatus() != JoinStatus.JOINED) {
-            throw new GeneralException(ProjectErrorCode.INVALID_PROJECT_REQUEST);
-        }
         // 방어 로직: 마지막 리더는 권한 강등 불가
         if (targetMember.getRole() == ProjectRole.LEADER && newRole == ProjectRole.MEMBER) {
             validateNotLastLeader(project, targetMember);
@@ -129,7 +151,7 @@ public class ProjectMemberService {
 
         // 본인이 스스로 탈퇴하는 경우이거나, 리더가 남을 강퇴하는 경우만 허용
         if (!requesterId.equals(targetUserId)) {
-            validateLeaderPermission(project, requesterId);
+            validateProjectLeader(project, requesterId);
         }
 
         // 마지막 리더 탈퇴 방어
@@ -139,8 +161,7 @@ public class ProjectMemberService {
 
     // --- 내부 검증 및 조회 편의 메서드 ---
 
-    // 리더인지 확인
-    private void validateLeaderPermission(Project project, Long userId) {
+    private void validateProjectLeader(Project project, Long userId) {
         User user = getUserOrThrow(userId);
         ProjectMember member = getProjectMemberOrThrow(project, user);
 
@@ -152,7 +173,7 @@ public class ProjectMemberService {
     // 마지막 리더 탈퇴 방지 위한 헬퍼 메서드
     private void validateNotLastLeader(Project project, ProjectMember targetMember) {
         if (targetMember.getRole() == ProjectRole.LEADER) {
-            long leaderCount = projectMemberRepository.countByProjectAndRoleAndStatus(project, ProjectRole.LEADER, JoinStatus.JOINED);
+            long leaderCount = projectMemberRepository.countByProjectAndRole(project, ProjectRole.LEADER);
             if (leaderCount <= 1) {
                 throw new GeneralException(ProjectErrorCode.CANNOT_REMOVE_LAST_LEADER);
             }

--- a/src/main/java/com/_penLearning/Noddi/domain/project/service/ProjectService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/service/ProjectService.java
@@ -3,10 +3,10 @@ package com._penLearning.Noddi.domain.project.service;
 import com._penLearning.Noddi.domain.project.code.ProjectErrorCode;
 import com._penLearning.Noddi.domain.project.dto.ProjectRequestDto;
 import com._penLearning.Noddi.domain.project.dto.ProjectResponseDto;
-import com._penLearning.Noddi.domain.project.entity.JoinStatus;
 import com._penLearning.Noddi.domain.project.entity.Project;
 import com._penLearning.Noddi.domain.project.entity.ProjectMember;
 import com._penLearning.Noddi.domain.project.entity.ProjectRole;
+import com._penLearning.Noddi.domain.project.repository.ProjectInviteRepository;
 import com._penLearning.Noddi.domain.project.repository.ProjectMemberRepository;
 import com._penLearning.Noddi.domain.project.repository.ProjectRepository;
 import com._penLearning.Noddi.domain.team.repository.TeamInviteRepository;
@@ -30,6 +30,7 @@ public class ProjectService {
 
     private final ProjectRepository projectRepository;
     private final ProjectMemberRepository projectMemberRepository;
+    private final ProjectInviteRepository projectInviteRepository;
     private final UserRepository userRepository;
     private final TeamRepository teamRepository;
     private final TeamInviteRepository teamInviteRepository;
@@ -57,8 +58,7 @@ public class ProjectService {
         ProjectMember leaderMember = ProjectMember.create(
                 project,
                 user,
-                ProjectRole.LEADER,
-                JoinStatus.JOINED
+                ProjectRole.LEADER
         );
 
         projectMemberRepository.save(leaderMember);
@@ -95,7 +95,11 @@ public class ProjectService {
         // 1. 요청자가 해당 프로젝트의 LEADER인지 검증
         validateProjectLeader(project, requesterId);
 
-        // 2. 연관된 프로젝트 멤버 데이터 단일 쿼리로 벌크 삭제 (팀 도메인 로직 제외)
+        // FK 제약조건을 고려해 팀의 하위 데이터부터 삭제한다.
+        teamInviteRepository.bulkDeleteByProject(project);
+        teamMemberRepository.bulkDeleteByProject(project);
+        teamRepository.bulkDeleteByProject(project);
+        projectInviteRepository.deleteBulkByProject(project);
         projectMemberRepository.bulkDeleteByProject(project);
 
         // 3. 프로젝트 삭제
@@ -109,7 +113,7 @@ public class ProjectService {
         ProjectMember member = projectMemberRepository.findByProjectAndUser(project, user)
                 .orElseThrow(() -> new GeneralException(ProjectErrorCode.PROJECT_MEMBER_NOT_FOUND));
 
-        if (member.getRole() != ProjectRole.LEADER || member.getStatus() != JoinStatus.JOINED) {
+        if (member.getRole() != ProjectRole.LEADER) {
             throw new GeneralException(ProjectErrorCode.NOT_PROJECT_LEADER);
         }
     }

--- a/src/main/java/com/_penLearning/Noddi/domain/team/code/TeamErrorCode.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/team/code/TeamErrorCode.java
@@ -22,6 +22,7 @@ public enum TeamErrorCode implements BaseErrorCode {
     // 404 NOT_FOUND (조회 실패)
     TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "TEAM404_1", "팀을 찾을 수 없습니다."),
     INVITE_NOT_FOUND(HttpStatus.NOT_FOUND, "TEAM404_2", "초대장을 찾을 수 없습니다."),
+    TEAM_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "TEAM404_3", "해당 팀의 멤버가 아닙니다."),
 
     // 409 CONFLICT (중복 방지)
     ALREADY_TEAM_MEMBER(HttpStatus.CONFLICT, "TEAM409_1", "이미 해당 팀에 가입된 유저입니다."),

--- a/src/main/java/com/_penLearning/Noddi/domain/team/dto/TeamMemberRequestDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/team/dto/TeamMemberRequestDto.java
@@ -1,4 +1,0 @@
-package com._penLearning.Noddi.domain.team.dto;
-
-public class TeamMemberRequestDto {
-}

--- a/src/main/java/com/_penLearning/Noddi/domain/team/dto/TeamMemberResponseDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/team/dto/TeamMemberResponseDto.java
@@ -1,4 +1,0 @@
-package com._penLearning.Noddi.domain.team.dto;
-
-public class TeamMemberResponseDto {
-}

--- a/src/main/java/com/_penLearning/Noddi/domain/team/repository/TeamInviteRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/team/repository/TeamInviteRepository.java
@@ -1,5 +1,6 @@
 package com._penLearning.Noddi.domain.team.repository;
 
+import com._penLearning.Noddi.domain.project.entity.Project;
 import com._penLearning.Noddi.domain.team.entity.InviteStatus;
 import com._penLearning.Noddi.domain.team.entity.Team;
 import com._penLearning.Noddi.domain.team.entity.TeamInvite;
@@ -51,4 +52,8 @@ public interface TeamInviteRepository extends JpaRepository<TeamInvite, Long> {
 
     // 팀 삭제 전 연관된 초대장 일괄 삭제용
     void deleteAllByTeam(Team team);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM TeamInvite ti WHERE ti.team.project = :project")
+    void bulkDeleteByProject(@Param("project") Project project);
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/team/repository/TeamMemberRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/team/repository/TeamMemberRepository.java
@@ -1,10 +1,12 @@
 package com._penLearning.Noddi.domain.team.repository;
 
+import com._penLearning.Noddi.domain.project.entity.Project;
 import com._penLearning.Noddi.domain.team.entity.Team;
 import com._penLearning.Noddi.domain.team.entity.TeamMember;
 import com._penLearning.Noddi.domain.team.entity.TeamRole;
 import com._penLearning.Noddi.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -32,4 +34,8 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
 
     // 팀 내 특정 권한(LEADER)을 가진 멤버 수 카운트 (마지막 리더 검증용)
     long countByTeamAndRole(Team team, TeamRole role);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM TeamMember tm WHERE tm.team.project = :project")
+    void bulkDeleteByProject(@Param("project") Project project);
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/team/scheduler/TeamInviteScheduler.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/team/scheduler/TeamInviteScheduler.java
@@ -19,8 +19,8 @@ public class TeamInviteScheduler {
 
     // 매일 자정(00:00:00)에 실행되도록 Cron 표현식 설정
     @Scheduled(
-            cron = "${scheduler.team-invite.cron:0 0 * * * *}",
-            zone = "${scheduler.team-invite.zone:Asia/Seoul}"
+            cron = "${scheduler.invite.cron:0 0 * * * *}",
+            zone = "${scheduler.invite.zone:Asia/Seoul}"
     )    @Transactional
     public void expireOldInvitations() {
         // 기준선: 시스템 현재 시간으로부터 정확히 7일 전

--- a/src/main/java/com/_penLearning/Noddi/domain/team/service/TeamCommandService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/team/service/TeamCommandService.java
@@ -1,14 +1,12 @@
 package com._penLearning.Noddi.domain.team.service;
 
 import com._penLearning.Noddi.domain.project.code.ProjectErrorCode;
-import com._penLearning.Noddi.domain.project.entity.JoinStatus;
 import com._penLearning.Noddi.domain.project.entity.Project;
 import com._penLearning.Noddi.domain.project.entity.ProjectMember;
 import com._penLearning.Noddi.domain.project.repository.ProjectMemberRepository;
 import com._penLearning.Noddi.domain.project.repository.ProjectRepository;
 import com._penLearning.Noddi.domain.team.code.TeamErrorCode;
 import com._penLearning.Noddi.domain.team.dto.TeamRequestDto;
-import com._penLearning.Noddi.domain.team.dto.TeamResponseDto;
 import com._penLearning.Noddi.domain.team.entity.*;
 import com._penLearning.Noddi.domain.team.repository.TeamInviteRepository;
 import com._penLearning.Noddi.domain.team.repository.TeamMemberRepository;
@@ -20,8 +18,6 @@ import com._penLearning.Noddi.global.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -77,7 +73,7 @@ public class TeamCommandService {
             throw new GeneralException(TeamErrorCode.ALREADY_TEAM_MEMBER);
         }
 
-        if (teamInviteRepository.existsByTeamAndInviteeAndStatus(team, targetUser, InviteStatus.PENDING)) {
+        if (teamInviteRepository.existsByTeamAndInviteeAndStatus(team, targetUser, com._penLearning.Noddi.domain.team.entity.InviteStatus.PENDING)) {
             throw new GeneralException(TeamErrorCode.ALREADY_INVITED);
         }
 
@@ -99,7 +95,7 @@ public class TeamCommandService {
             throw new GeneralException(TeamErrorCode.NOT_INVITEE);
         }
 
-        if (invite.getStatus() != InviteStatus.PENDING) {
+        if (invite.getStatus() != com._penLearning.Noddi.domain.team.entity.InviteStatus.PENDING) {
             throw new GeneralException(TeamErrorCode.INVITE_NOT_PENDING);
         }
 
@@ -172,7 +168,7 @@ public class TeamCommandService {
         validateTeamLeader(team, requester);
 
         TeamMember targetMember = teamMemberRepository.findByTeamAndUser(team, targetUser)
-                .orElseThrow(() -> new GeneralException(TeamErrorCode.TEAM_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(TeamErrorCode.TEAM_MEMBER_NOT_FOUND));
 
         // 자신이 리더인데 MEMBER로 강등하려는 경우 방어
         if (targetMember.getRole() == TeamRole.LEADER && newRole == TeamRole.MEMBER) {
@@ -205,12 +201,8 @@ public class TeamCommandService {
     // --- 내부 검증 헬퍼 메서드 ---
 
     private void validateProjectMember(Project project, User user) {
-        ProjectMember projectMember = projectMemberRepository.findByProjectAndUser(project, user)
+        projectMemberRepository.findByProjectAndUser(project, user)
                 .orElseThrow(() -> new GeneralException(TeamErrorCode.NOT_PROJECT_MEMBER));
-
-        if (projectMember.getStatus() != JoinStatus.JOINED) {
-            throw new GeneralException(TeamErrorCode.NOT_PROJECT_MEMBER);
-        }
     }
 
     private void validateTeamLeader(Team team, User user) {

--- a/src/main/java/com/_penLearning/Noddi/domain/team/service/TeamQueryService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/team/service/TeamQueryService.java
@@ -1,14 +1,12 @@
 package com._penLearning.Noddi.domain.team.service;
 
 import com._penLearning.Noddi.domain.project.code.ProjectErrorCode;
-import com._penLearning.Noddi.domain.project.entity.JoinStatus;
 import com._penLearning.Noddi.domain.project.entity.Project;
 import com._penLearning.Noddi.domain.project.entity.ProjectMember;
 import com._penLearning.Noddi.domain.project.repository.ProjectMemberRepository;
 import com._penLearning.Noddi.domain.project.repository.ProjectRepository;
 import com._penLearning.Noddi.domain.team.code.TeamErrorCode;
 import com._penLearning.Noddi.domain.team.dto.TeamResponseDto;
-import com._penLearning.Noddi.domain.team.entity.InviteStatus;
 import com._penLearning.Noddi.domain.team.entity.Team;
 import com._penLearning.Noddi.domain.team.entity.TeamMember;
 import com._penLearning.Noddi.domain.team.entity.TeamRole;
@@ -27,7 +25,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class TeamQueryService {
     private final TeamRepository teamRepository;
     private final TeamMemberRepository teamMemberRepository;
@@ -75,7 +73,7 @@ public class TeamQueryService {
         User user = getUserOrThrow(userId);
 
         // PENDING 상태인 초대장만, Team 정보와 함께 페치 조인으로 가져옴
-        return teamInviteRepository.findByInviteeAndStatusWithTeam(user, InviteStatus.PENDING).stream()
+        return teamInviteRepository.findByInviteeAndStatusWithTeam(user, com._penLearning.Noddi.domain.team.entity.InviteStatus.PENDING).stream()
                 .map(TeamResponseDto.InvitationInfo::from)
                 .toList();
     }
@@ -83,12 +81,8 @@ public class TeamQueryService {
     // --- 내부 검증 헬퍼 메서드 ---
 
     private void validateProjectMember(Project project, User user) {
-        ProjectMember projectMember = projectMemberRepository.findByProjectAndUser(project, user)
+        projectMemberRepository.findByProjectAndUser(project, user)
                 .orElseThrow(() -> new GeneralException(TeamErrorCode.NOT_PROJECT_MEMBER));
-
-        if (projectMember.getStatus() != JoinStatus.JOINED) {
-            throw new GeneralException(TeamErrorCode.NOT_PROJECT_MEMBER);
-        }
     }
 
     private void validateTeamLeader(Team team, User user) {
@@ -101,16 +95,6 @@ public class TeamQueryService {
 
         if (teamMember.getRole() != TeamRole.LEADER) {
             throw new GeneralException(TeamErrorCode.NOT_TEAM_LEADER);
-        }
-    }
-
-    // 마지막 리더인지 검증하는 헬퍼 메서드
-    private void validateNotLastLeader(Team team, TeamMember targetMember) {
-        if (targetMember.getRole() == TeamRole.LEADER) {
-            long leaderCount = teamMemberRepository.countByTeamAndRole(team, TeamRole.LEADER);
-            if (leaderCount <= 1) {
-                throw new IllegalArgumentException("팀의 마지막 리더는 탈퇴하거나 권한을 강등할 수 없습니다.");
-            }
         }
     }
 

--- a/src/main/java/com/_penLearning/Noddi/global/config/TestDataInitializer.java
+++ b/src/main/java/com/_penLearning/Noddi/global/config/TestDataInitializer.java
@@ -3,6 +3,9 @@ package com._penLearning.Noddi.global.config;
 import com._penLearning.Noddi.domain.organization.entity.Organization;
 import com._penLearning.Noddi.domain.organization.repository.OrganizationRepository;
 import com._penLearning.Noddi.domain.project.entity.Project;
+import com._penLearning.Noddi.domain.project.entity.ProjectMember;
+import com._penLearning.Noddi.domain.project.entity.ProjectRole;
+import com._penLearning.Noddi.domain.project.repository.ProjectMemberRepository;
 import com._penLearning.Noddi.domain.project.repository.ProjectRepository;
 import com._penLearning.Noddi.domain.team.entity.Team;
 import com._penLearning.Noddi.domain.team.entity.TeamMember;
@@ -30,6 +33,7 @@ public class TestDataInitializer implements CommandLineRunner {
     private final OrganizationRepository organizationRepository;
     private final UserRepository userRepository;
     private final ProjectRepository projectRepository;
+    private final ProjectMemberRepository projectMemberRepository;
     private final TeamRepository teamRepository;
     private final TeamMemberRepository teamMemberRepository;
     private final BCryptPasswordEncoder passwordEncoder;
@@ -38,47 +42,13 @@ public class TestDataInitializer implements CommandLineRunner {
     @Transactional
     public void run(String... args) {
         if (organizationRepository.count() == 0 && userRepository.count() == 0) {
-
-            // 1. 조직 생성
-        // 💡 유저 데이터가 없을 때 더미 생성을 확실히 실행!
-        if (userRepository.count() == 0) {
-
-            // 1. 조직(Organization) 더미 생성
-            Organization hongik = Organization.builder()
-                    .name("홍익대학교")
-                    .emailDomain("g.hongik.ac.kr")
-                    .build();
-
             Organization testOrg = Organization.builder()
                     .name("테스트 조직(Gmail)")
                     .emailDomain("gmail.com")
                     .build();
+            organizationRepository.save(testOrg);
 
-            organizationRepository.saveAll(List.of(hongik, testOrg));
-
-            String encodedPassword = passwordEncoder.encode("1234");
-
-            User user1 = User.builder()
-                    .name("김철수")
-                    .email("chulsoo@g.hongik.ac.kr")
-                    .password(encodedPassword)
-                    .organization(hongik)
-                    .build();
-
-            User user2 = User.builder()
-                    .name("김영희")
-                    .email("younghee@gmail.com")
-                    .password(encodedPassword)
-                    .organization(testOrg)
-                    .build();
-
-            userRepository.saveAll(List.of(user1, user2));
-
-            log.info("[TestDataInitializer] 초기 테스트 데이터 주입 완료: 조직 2개, 유저 2명");
-            // 비밀번호 'test' 암호화
             String encodedPassword = passwordEncoder.encode("test");
-
-            // 2. 유저(User) 3명 더미 생성
             User user1 = User.builder()
                     .organization(testOrg)
                     .email("test1@gmail.com")
@@ -102,7 +72,6 @@ public class TestDataInitializer implements CommandLineRunner {
 
             userRepository.saveAll(List.of(user1, user2, user3));
 
-            // 3. 프로젝트(Project) 더미 생성
             Project testProject = Project.builder()
                     .organization(testOrg)
                     .name("Noddi 협업 캡스톤 프로젝트")
@@ -112,7 +81,12 @@ public class TestDataInitializer implements CommandLineRunner {
 
             projectRepository.save(testProject);
 
-            // 4. 팀(Team) 더미 생성 (1번 팀)
+            projectMemberRepository.save(ProjectMember.create(
+                    testProject,
+                    user1,
+                    ProjectRole.LEADER
+            ));
+
             Team testTeam = Team.builder()
                     .project(testProject)
                     .name("Noddi 백엔드 개발팀")
@@ -121,11 +95,10 @@ public class TestDataInitializer implements CommandLineRunner {
 
             teamRepository.save(testTeam);
 
-            // 5. 1번 팀에 유저 3명 모두 팀원으로 매핑 (TeamMember)
             TeamMember tm1 = TeamMember.builder()
                     .team(testTeam)
                     .user(user1)
-                    .role(TeamRole.OWNER)
+                    .role(TeamRole.LEADER)
                     .build();
 
             TeamMember tm2 = TeamMember.builder()

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,7 +7,7 @@ spring:
     password: ${DB_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: true
     properties:
       hibernate:
@@ -35,7 +35,7 @@ spring:
           timeout: 5000
           writetimeout: 5000
 scheduler:
-  team-invite:
+  invite:
     cron: "0 0 * * * *"
     zone: Asia/Seoul
     valid-days: 7

--- a/src/test/java/com/_penLearning/Noddi/NoddiApplicationTests.java
+++ b/src/test/java/com/_penLearning/Noddi/NoddiApplicationTests.java
@@ -2,8 +2,10 @@ package com._penLearning.Noddi;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class NoddiApplicationTests {
 
 	@Test

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -1,0 +1,17 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:noddi;MODE=MySQL;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: false
+  mail:
+    username: test@example.com
+    password: test-password
+
+daily:
+  api:
+    key: test-key


### PR DESCRIPTION
## <i>PULL REQUEST</i>

## 🎋 작업 브랜치
- feature/3 -> develop
- #13

## 💡 작업동기
- 기존에는 프로젝트 초대 상태를 `ProjectMember` 엔티티에서 함께 관리하고 있어, 실제 가입 멤버와 초대 대기 사용자의 책임이 명확하게 분리되지 않았습니다.
- 팀 초대 구조와 동일하게 프로젝트 초대도 별도 엔티티로 관리하여 초대 발송, 수락, 거절, 만료 흐름을 명확하게 처리하고자 리팩터링했습니다.

## 🔑 주요 변경사항
- `ProjectInvite` 엔티티를 추가하여 프로젝트 초대 정보를 별도로 관리하도록 변경했습니다.
- `ProjectMember`에서 초대 상태 필드를 제거하고 가입 완료된 프로젝트 멤버만 관리하도록 역할을 분리했습니다.
- 프로젝트 초대 상태를 `PENDING`, `ACCEPTED`, `REJECTED`, `EXPIRED`로 구분했습니다.
- 초대 발송 시 동일 조직 여부, 기존 프로젝트 멤버 여부 및 중복 초대 여부를 검증하도록 추가했습니다.
- 초대 응답 API가 `projectId` 대신 `inviteId`를 기준으로 동작하도록 변경했습니다.
- 초대 수락 시 `ProjectMember`가 생성되고, 거절 시 초대 상태만 변경되도록 구현했습니다.
- 스케줄러와 응답 시점 검증을 통해 유효기간이 지난 초대를 만료 처리하도록 구현했습니다.
- 동시 초대 응답 충돌 방지를 위해 낙관적 락을 적용했습니다.
- 프로젝트 삭제 시 프로젝트 초대 및 관련 팀·멤버 데이터를 벌크 삭제하도록 정리했습니다.
- 변경된 `ProjectMember` 구조에 맞게 팀의 프로젝트 멤버 검증 로직을 수정했습니다.

## 🏞 스크린샷 (선택)
> 스크린샷을 첨부해주세요.

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
