### PR TITLE
[Feat] 미팅 - 녹음본 다운 링크 확인 기능

### DIFF
--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/code/MeetingApi.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/code/MeetingApi.java
@@ -32,6 +32,28 @@ public interface MeetingApi {
             Long meetingId,
             @AuthenticationPrincipal AuthMember authMember
     );
+
+    @Operation(summary = "회의 녹음본 다운로드 URL 조회", description = "종료된 회의의 1시간 유효한 최신 S3 녹음본 다운로드 URL을 동적으로 생성하여 반환합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "녹음본 URL 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "녹음본이 아직 준비되지 않음 (웹훅 수신 전이거나 녹음본 없음)",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "해당 팀의 팀원이 아님",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "회의를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    ApiResponse<MeetingResponseDto.RecordingUrlDto> getRecordingUrl(
+            Long meetingId,
+            @AuthenticationPrincipal AuthMember authMember
+    );
+
     @Operation(summary = "팀별 회의 목록 조회", description = "특정 팀의 모든 회의(예약/진행/종료) 목록을 조회합니다.")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/controller/MeetingController.java
@@ -29,6 +29,15 @@ public class MeetingController implements MeetingApi {
     }
 
     @Override
+    @GetMapping("/{meetingId}/recording-url")
+    public ApiResponse<MeetingResponseDto.RecordingUrlDto> getRecordingUrl(
+            @PathVariable Long meetingId,
+            @AuthenticationPrincipal AuthMember authMember) {
+        MeetingResponseDto.RecordingUrlDto response = meetingService.getRecordingUrl(meetingId, authMember.getUserId());
+        return ApiResponse.onSuccess("녹음 다운로드 링크 조회가 완료되었습니다.", response);
+    }
+
+    @Override
     @GetMapping
     public ApiResponse<List<MeetingResponseDto.Info>> getMeetingsByTeam(
             @RequestParam Long teamId, @AuthenticationPrincipal AuthMember authMember) {

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/controller/MeetingWebHookController.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/controller/MeetingWebHookController.java
@@ -50,21 +50,25 @@ public class MeetingWebHookController {
 
             DailyWebhookPayloadDto payload = objectMapper.readValue(rawPayload, DailyWebhookPayloadDto.class);
 
-            log.info("[Daily.co Webhook] 이벤트 수신: action={}, roomName={}", payload.getAction(), payload.getRoomName());
+            log.info("[Daily.co Webhook] 이벤트 수신: action={}, roomName={}", payload.getType(), payload.getRoomName());
 
-            if (payload.getAction() != null) {
-                switch (payload.getAction()) {
+            if (payload.getType() != null) {
+                switch (payload.getType()) {
                     case "recording.ready-to-download" -> {
-                        String recordingUrl = buildS3Url(payload.getS3Bucket(), payload.getS3Key());
-                        log.info("[Daily.co Webhook] 녹음본 준비 완료: url={}", recordingUrl);
-                        meetingService.updateRecordingUrl(payload.getRoomName(), recordingUrl);
+                        String roomName = payload.getRoomName();
+                        String recordingId = payload.getRecordingId();
+                        log.info("[MeetingWebHook] 녹음 완료 알림 수신: roomName={}, recordingId={}", roomName, recordingId);
+
+                        if (roomName != null && recordingId != null) {
+                            meetingService.updateRecordingId(roomName, recordingId);
+                        }
                     }
                     case "meeting.ended" -> {
                         log.info("[Daily.co Webhook] 회의 자동 종료 처리: roomName={}", payload.getRoomName());
                         meetingService.endMeetingByRoomName(payload.getRoomName());
                     }
                     default ->
-                            log.debug("[Daily.co Webhook] 처리하지 않는 이벤트: {}", payload.getAction());
+                            log.debug("[Daily.co Webhook] 처리하지 않는 이벤트: {}", payload.getType());
                 }
             }
             return ResponseEntity.ok().build();

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/controller/MeetingWebHookController.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/controller/MeetingWebHookController.java
@@ -59,9 +59,12 @@ public class MeetingWebHookController {
                         String recordingId = payload.getRecordingId();
                         log.info("[MeetingWebHook] 녹음 완료 알림 수신: roomName={}, recordingId={}", roomName, recordingId);
 
-                        if (roomName != null && recordingId != null) {
-                            meetingService.updateRecordingId(roomName, recordingId);
+                        // 필수 데이터가 누락되었다면 400 Bad Request를 반환하여 Daily.co가 재시도하도록 유도
+                        if (roomName == null || roomName.isBlank() || recordingId == null || recordingId.isBlank()) {
+                            log.error("[Daily.co Webhook] 녹음본 수신 필수 데이터 누락! roomName={}, recordingId={}", roomName, recordingId);
+                            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
                         }
+                        meetingService.updateRecordingId(roomName, recordingId);
                     }
                     case "meeting.ended" -> {
                         log.info("[Daily.co Webhook] 회의 자동 종료 처리: roomName={}", payload.getRoomName());

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/dto/MeetingResponseDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/dto/MeetingResponseDto.java
@@ -81,4 +81,10 @@ public class MeetingResponseDto {
                     .build();
         }
     }
+
+    @Getter
+    @AllArgsConstructor
+    public static class RecordingUrlDto {
+        private String url;
+    }
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/entity/Meeting.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/entity/Meeting.java
@@ -48,7 +48,7 @@ public class Meeting extends BaseEntity {
 
     //webRTC 방 ID LAZY 방식으로 주입(회의 시작 버튼을 눌러야 회의가 열림)
     private String roomName;
-    private String recordingUrl;
+    private String recordingId;
     @Lob
     private String transcriptText;
 
@@ -79,19 +79,19 @@ public class Meeting extends BaseEntity {
     }
 
     /**
-     * 3. 녹음본 URL 업데이트
-     * - 시점: WebRTC Webhook(room.empty 등)으로 S3 업로드 완료 알림 수신 시
+     * Daily.co 녹음 ID 업데이트
      */
-    public void updateRecordingUrl(String recordingUrl) {
-        this.recordingUrl = recordingUrl;
+    public void updateRecordingId(String recordingId) {
+        this.recordingId = recordingId;
     }
+
 
     //Ai 요약 관련 메소드
     public void startAiProcessing() {
         if (this.status != MeetingStatus.ENDED) {
             throw new GeneralException(MeetingErrorCode.INVALID_STATUS_FOR_SUMMARY);
         }
-        if (this.recordingUrl == null) {
+        if (this.recordingId == null) {
             throw new GeneralException(MeetingErrorCode.RECORDING_NOT_READY);
         }
         this.aiStatus = AiStatus.PROCESSING;

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingService.java
@@ -61,6 +61,19 @@ public class MeetingService {
                 .map(MeetingResponseDto.ParticipantInfo::from)
                 .toList();
     }
+
+    public MeetingResponseDto.RecordingUrlDto getRecordingUrl(Long meetingId, Long currentUserId) {
+        Meeting meeting = getMeetingOrThrow(meetingId);
+        User user = getUserOrThrow(currentUserId);
+        validateTeamMember(meeting.getTeam(), user);
+
+        if (meeting.getRecordingId() == null) {
+            throw new GeneralException(MeetingErrorCode.RECORDING_NOT_READY);
+        }
+
+        String accessLink = webRtcClient.getRecordingAccessLink(meeting.getRecordingId());
+        return new MeetingResponseDto.RecordingUrlDto(accessLink);
+    }
     //회의 예약 생성 (SCHEDULED)
     @Transactional
     public MeetingResponseDto.Info createMeeting(MeetingRequestDto.Create request, Long currentUserId) {
@@ -158,13 +171,12 @@ public class MeetingService {
         }
     }
 
-    //웹훅 수신: 녹음본 S3 업로드 완료 시 URL 갱신
+    //웹훅 수신: 녹음본 S3 업로드 완료 시 recordingId 갱신
     @Transactional
-    public void updateRecordingUrl(String roomName, String recordingUrl) {
+    public void updateRecordingId(String roomName, String recordingId) {
         Meeting meeting = getMeetingByRoomNameOrThrow(roomName);
-        meeting.updateRecordingUrl(recordingUrl);
-        log.info("[MeetingService] Webhook 녹음본 URL 갱신 완료: meetingId={}, url={}",
-                meeting.getMeetingId(), recordingUrl);
+        meeting.updateRecordingId(recordingId);
+        log.info("[MeetingService] DB 녹음 ID 업데이트 완료: meetingId={}, recordingId={}", meeting.getMeetingId(), recordingId);
     }
 
     @Transactional
@@ -182,7 +194,7 @@ public class MeetingService {
             throw new GeneralException(MeetingErrorCode.ALREADY_PROCESSING_SUMMARY);
         }
 
-        if (meeting.getRecordingUrl() == null) {
+        if (meeting.getRecordingId() == null) {
             throw new GeneralException(MeetingErrorCode.RECORDING_NOT_READY);
         }
         meeting.startAiProcessing();

--- a/src/main/java/com/_penLearning/Noddi/global/infrastructure/webRtc/DailyCoWebRtcClient.java
+++ b/src/main/java/com/_penLearning/Noddi/global/infrastructure/webRtc/DailyCoWebRtcClient.java
@@ -2,6 +2,7 @@ package com._penLearning.Noddi.global.infrastructure.webRtc;
 
 import com._penLearning.Noddi.domain.meeting.code.MeetingErrorCode;
 import com._penLearning.Noddi.global.exception.GeneralException;
+import com._penLearning.Noddi.global.infrastructure.webRtc.dto.DailyAccessLinkResponseDto;
 import com._penLearning.Noddi.global.infrastructure.webRtc.dto.DailyCreateRoomResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,14 +35,14 @@ public class DailyCoWebRtcClient implements WebRtcClient{
                             "name", roomName,
                             "privacy", "public",
                             "properties", Map.of(
-                                    "enable_recording", "cloud",
-                                    "enable_hand_raising", true,     // 1. 손들기 기능 켜기
-                                    "enable_emoji_reactions", true,  // 2. 이모지 리액션 켜기
-                                    "enable_chat", true,             // 3. 텍스트 채팅창 켜기
-                                    "lang", "ko",                     // 4. 한국어 UI 설정
-                                    "max_participants", 10,           // 5. 최대 정원 10명 제한
-                                    "exp", exp,                       // 6. 10분 후 방 만료
-                                    "eject_at_room_exp", true         // 7. 만료 시 자동 강퇴
+                                    "enable_recording", "cloud-audio-only", // 1. 클라우드 오디오 전용 녹음
+                                    "enable_hand_raising", true,     // 2. 손들기 기능 켜기
+                                    "enable_emoji_reactions", true,  // 3. 이모지 리액션 켜기
+                                    "enable_chat", true,             // 4. 텍스트 채팅창 켜기
+                                    "lang", "ko",                     // 5. 한국어 UI 설정
+                                    "max_participants", 10,           // 6. 최대 정원 10명 제한
+                                    "exp", exp,                       // 7. 10분 후 방 만료
+                                    "eject_at_room_exp", true         // 8. 만료 시 자동 강퇴
                             )
                     ))
                     .retrieve()
@@ -53,6 +54,26 @@ public class DailyCoWebRtcClient implements WebRtcClient{
             // 💡 타임아웃이나 Daily.co API 에러 발생 시 예쁜 커스텀 에러로 변환!
             log.error("[Daily.co] 방 생성 통신 실패/타임아웃 발생: {}", e.getMessage());
             throw new GeneralException(MeetingErrorCode.WEBRTC_ROOM_CREATE_FAILED);
+        }
+    }
+
+    /**
+     * Daily.co 녹음 ID로 1시간 유효한 S3 서명 다운로드 URL(download_url) 가져오기
+     */
+    public String getRecordingAccessLink(String recordingId) {
+        try {
+            DailyAccessLinkResponseDto response = restClient.get()
+                    .uri("/recordings/{recordingId}/access-link", recordingId)
+                    .retrieve()
+                    .body(DailyAccessLinkResponseDto.class);
+
+            if (response != null && response.getDownloadLink() != null) {
+                return (String) response.getDownloadLink();
+            }
+            throw new GeneralException(MeetingErrorCode.RECORDING_NOT_READY);
+        } catch (Exception e) {
+            log.error("[Daily.co] 녹음본 다운로드 링크 조회 실패: recordingId={}", recordingId, e);
+            throw new GeneralException(MeetingErrorCode.RECORDING_NOT_READY);
         }
     }
 

--- a/src/main/java/com/_penLearning/Noddi/global/infrastructure/webRtc/DailyCoWebRtcClient.java
+++ b/src/main/java/com/_penLearning/Noddi/global/infrastructure/webRtc/DailyCoWebRtcClient.java
@@ -68,7 +68,7 @@ public class DailyCoWebRtcClient implements WebRtcClient{
                     .body(DailyAccessLinkResponseDto.class);
 
             if (response != null && response.getDownloadLink() != null) {
-                return (String) response.getDownloadLink();
+                return response.getDownloadLink();
             }
             throw new GeneralException(MeetingErrorCode.RECORDING_NOT_READY);
         } catch (Exception e) {

--- a/src/main/java/com/_penLearning/Noddi/global/infrastructure/webRtc/WebRtcClient.java
+++ b/src/main/java/com/_penLearning/Noddi/global/infrastructure/webRtc/WebRtcClient.java
@@ -12,4 +12,6 @@ public interface WebRtcClient {
      * @param roomName 삭제할 방 이름
      */
     void deleteRoom(String roomName);
+
+    String getRecordingAccessLink(String recordingId);
 }

--- a/src/main/java/com/_penLearning/Noddi/global/infrastructure/webRtc/dto/DailyAccessLinkResponseDto.java
+++ b/src/main/java/com/_penLearning/Noddi/global/infrastructure/webRtc/dto/DailyAccessLinkResponseDto.java
@@ -1,0 +1,12 @@
+package com._penLearning.Noddi.global.infrastructure.webRtc.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DailyAccessLinkResponseDto {
+    @JsonProperty("download_link")
+    private String downloadLink;
+}

--- a/src/main/java/com/_penLearning/Noddi/global/infrastructure/webRtc/dto/DailyWebhookPayloadDto.java
+++ b/src/main/java/com/_penLearning/Noddi/global/infrastructure/webRtc/dto/DailyWebhookPayloadDto.java
@@ -13,8 +13,6 @@ public class DailyWebhookPayloadDto {
     @JsonProperty("type")
     private String type;
 
-    private String action; // 하위 호환성용
-
     // 세부 데이터는 "payload" 중첩 객체 안에 있음
     @JsonProperty("payload")
     private EventDetail payload;
@@ -28,6 +26,9 @@ public class DailyWebhookPayloadDto {
         @JsonProperty("room_name")
         private String roomName;
 
+        @JsonProperty("recording_id")
+        private String recordingId;
+
         @JsonProperty("s3_key")
         private String s3Key;
 
@@ -40,12 +41,18 @@ public class DailyWebhookPayloadDto {
     }
 
     // 💡 기존 컨트롤러 코드와의 호환성을 위한 헬퍼 메서드들
-    public String getAction() {
-        return type != null ? type : action;
+    public String getType() {
+        return type;
     }
+
+
 
     public String getRoomName() {
         return payload != null ? payload.getRoomName() : null;
+    }
+
+    public String getRecordingId() {
+        return payload != null ? payload.getRecordingId() : null;
     }
 
     public String getS3Bucket() {


### PR DESCRIPTION
## <i>PULL REQUEST</i>

## 🎋 작업 브랜치
- feat/#14 -> develop
- #14 (관련이슈 번호)

## 💡 작업동기
- 기존 문제점: Daily.co 기본 저장소 모드 사용 시 웹훅으로 전달되는 S3 주소(https://null.s3.amazonaws.com/...)에 직접 접근하면 NoSuchBucket 에러가 발생함.
- 원인 분석: Daily.co의 실제 녹음 파일은 비공개(Private) S3에 보관되며, 보안을 위해 Daily.co API를 통해 발급받은 **1시간 유효한 임시 서명 주소(Pre-signed URL)**로만 다운로드 및 재생이 가능함.
- 해결 방안: 고정된 URL을 DB에 저장하는 대신, 웹훅 수신 시 recordingId를 DB에 보관하고, 사용자가 요청하는 그 순간 Daily.co API를 호출하여 100% 유효한 최신 다운로드 링크(download_link)를 동적으로 발급하는 아키텍처 구축.

## 🔑 주요 변경사항
오디오 전용 녹음 모드 설정 (DailyCoWebRtcClient)

방 생성(POST /v1/rooms) 시 "enable_recording": "cloud-audio-only" 프로퍼티를 적용하여 영상 제외 가벼운 오디오 전용 파일로 녹음하도록 설정. (용량 절감 및 처리 속도 향상)
웹훅 수신 및 recordingId DB 저장 (MeetingWebHookController & MeetingService)

Daily.co 웹훅(recording.ready-to-download) 수신 시 payload.recording_id와 payload.room_name을 추출.
DB의 Meeting 엔티티 recordingId 컬럼에 보관하도록 로직 변경.
1시간 유효 동적 S3 다운로드 링크 발급 API 구현

GET /api/v1/meetings/{meetingId}/recording-url API 구현.
요청 수신 시 Daily.co REST API(GET /v1/recordings/{recordingId}/access-link)를 호출하여 1시간 20분 유효한 최신 S3 서명 주소(download_link)를 획득 후 MeetingResponseDto.RecordingUrlDto 형태로 응답.

## 🏞 스크린샷 (선택)
> 스크린샷을 첨부해주세요.

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
