### PR TITLE
[feat] 조직 조회 및 개인정보(이름, 비밀번호) 변경 기능 추가

### DIFF
--- a/src/main/java/com/_penLearning/Noddi/domain/organization/code/OrganizationApi.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/organization/code/OrganizationApi.java
@@ -1,0 +1,22 @@
+package com._penLearning.Noddi.domain.organization.code;
+
+import com._penLearning.Noddi.domain.organization.dto.OrganizationResponseDto;
+import com._penLearning.Noddi.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.List;
+
+@Tag(name = "Organization API", description = "조직(Organization) 정보 조회 API")
+public interface OrganizationApi {
+
+    @Operation(summary = "단일 조직 정보 조회", description = "조직 ID를 기반으로 해당 조직의 상세 정보를 조회합니다.")
+    ApiResponse<OrganizationResponseDto.Info> getOrganization(
+            @Parameter(description = "조직 ID") @PathVariable Long organizationId
+    );
+
+    @Operation(summary = "전체 조직 목록 조회", description = "회원가입 시 선택할 수 있는 전체 조직(Organization)의 목록을 조회합니다.")
+    ApiResponse<List<OrganizationResponseDto.Info>> getAllOrganizations();
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/organization/controller/OrganizationController.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/organization/controller/OrganizationController.java
@@ -1,0 +1,37 @@
+package com._penLearning.Noddi.domain.organization.controller;
+
+import com._penLearning.Noddi.domain.organization.code.OrganizationApi;
+import com._penLearning.Noddi.domain.organization.dto.OrganizationResponseDto;
+import com._penLearning.Noddi.domain.organization.service.OrganizationService;
+import com._penLearning.Noddi.global.apiPayload.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/organizations")
+@RequiredArgsConstructor
+public class OrganizationController implements OrganizationApi {
+
+    private final OrganizationService organizationService;
+
+    @Override
+    @GetMapping("/{organizationId}")
+    public ApiResponse<OrganizationResponseDto.Info> getOrganization(@PathVariable Long organizationId) {
+
+        OrganizationResponseDto.Info response = organizationService.getOrganization(organizationId);
+        return ApiResponse.onSuccess("조직 정보 조회에 성공했습니다.", response);
+    }
+
+    @Override
+    @GetMapping
+    public ApiResponse<List<OrganizationResponseDto.Info>> getAllOrganizations() {
+
+        List<OrganizationResponseDto.Info> response = organizationService.getAllOrganizations();
+        return ApiResponse.onSuccess("전체 조직 목록 조회에 성공했습니다.", response);
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/organization/dto/OrganizationRequestDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/organization/dto/OrganizationRequestDto.java
@@ -1,0 +1,4 @@
+package com._penLearning.Noddi.domain.organization.dto;
+
+public class OrganizationRequestDto {
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/organization/dto/OrganizationResponseDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/organization/dto/OrganizationResponseDto.java
@@ -1,0 +1,24 @@
+package com._penLearning.Noddi.domain.organization.dto;
+
+import com._penLearning.Noddi.domain.organization.entity.Organization;
+import lombok.Builder;
+import lombok.Getter;
+
+public class OrganizationResponseDto {
+
+    @Getter
+    @Builder
+    public static class Info {
+        private Long organizationId;
+        private String name;
+        private String emailDomain;
+
+        public static Info from(Organization organization) {
+            return Info.builder()
+                    .organizationId(organization.getOrganizationId())
+                    .name(organization.getName())
+                    .emailDomain(organization.getEmailDomain())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/organization/service/OrganizationService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/organization/service/OrganizationService.java
@@ -1,0 +1,33 @@
+package com._penLearning.Noddi.domain.organization.service;
+
+import com._penLearning.Noddi.domain.organization.code.OrganizationErrorCode;
+import com._penLearning.Noddi.domain.organization.dto.OrganizationResponseDto;
+import com._penLearning.Noddi.domain.organization.entity.Organization;
+import com._penLearning.Noddi.domain.organization.repository.OrganizationRepository;
+import com._penLearning.Noddi.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrganizationService {
+
+    private final OrganizationRepository organizationRepository;
+
+    public OrganizationResponseDto.Info getOrganization(Long organizationId) {
+        Organization organization = organizationRepository.findById(organizationId)
+                .orElseThrow(() -> new GeneralException(OrganizationErrorCode.ORGANIZATION_NOT_FOUND));
+
+        return OrganizationResponseDto.Info.from(organization);
+    }
+
+    public List<OrganizationResponseDto.Info> getAllOrganizations() {
+        return organizationRepository.findAll().stream()
+                .map(OrganizationResponseDto.Info::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/user/code/UserApi.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/user/code/UserApi.java
@@ -1,0 +1,30 @@
+package com._penLearning.Noddi.domain.user.code;
+
+import com._penLearning.Noddi.domain.auth.entity.AuthMember;
+import com._penLearning.Noddi.domain.user.dto.UserRequestDto;
+import com._penLearning.Noddi.domain.user.dto.UserResponseDto;
+import com._penLearning.Noddi.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "User API", description = "유저 프로필 및 개인정보 관리 API")
+public interface UserApi {
+
+    @Operation(summary = "내 프로필 및 조직 정보 조회", description = "현재 로그인한 유저의 개인 프로필과 소속된 조직(Organization) 정보를 조회합니다.")
+    ApiResponse<UserResponseDto.ProfileInfo> getMyProfile(
+            @Parameter(hidden = true) AuthMember authMember
+    );
+
+    @Operation(summary = "내 프로필 수정", description = "현재 로그인한 유저의 프로필(이름 등)을 수정합니다.")
+    ApiResponse<Void> updateProfile(
+            UserRequestDto.UpdateProfile request,
+            @Parameter(hidden = true) AuthMember authMember
+    );
+
+    @Operation(summary = "비밀번호 변경", description = "기존 비밀번호를 확인한 후 새로운 비밀번호로 변경합니다.")
+    ApiResponse<Void> updatePassword(
+            UserRequestDto.UpdatePassword request,
+            @Parameter(hidden = true) AuthMember authMember
+    );
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/user/code/UserErrorCode.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/user/code/UserErrorCode.java
@@ -10,6 +10,10 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum UserErrorCode implements BaseErrorCode {
 
+
+    INVALID_CURRENT_PASSWORD(HttpStatus.BAD_REQUEST, "USER400_1", "현재 비밀번호가 일치하지 않습니다."),
+    SAME_AS_OLD_PASSWORD(HttpStatus.BAD_REQUEST, "USER400_2", "새로운 비밀번호는 기존 비밀번호와 달라야 합니다."),
+
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER404", "사용자를 찾을 수 없습니다." );
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/_penLearning/Noddi/domain/user/controller/UserController.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/user/controller/UserController.java
@@ -1,0 +1,51 @@
+package com._penLearning.Noddi.domain.user.controller;
+
+import com._penLearning.Noddi.domain.auth.entity.AuthMember;
+import com._penLearning.Noddi.domain.user.code.UserApi;
+import com._penLearning.Noddi.domain.user.dto.UserRequestDto;
+import com._penLearning.Noddi.domain.user.dto.UserResponseDto;
+import com._penLearning.Noddi.domain.user.service.UserService;
+import com._penLearning.Noddi.global.apiPayload.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UserController implements UserApi {
+
+    private final UserService userService;
+
+    // 내 프로필 조회
+    @Override
+    @GetMapping("/me")
+    public ApiResponse<UserResponseDto.ProfileInfo> getMyProfile(
+            @AuthenticationPrincipal AuthMember authMember) {
+        UserResponseDto.ProfileInfo response = userService.getMyProfile(authMember.getUserId());
+        return ApiResponse.onSuccess("프로필 조회에 성공했습니다.", response);
+    }
+
+    // 내 프로필 수정
+    @Override
+    @PatchMapping("/me")
+    public ApiResponse<Void> updateProfile(
+            @RequestBody @Valid UserRequestDto.UpdateProfile request,
+            @AuthenticationPrincipal AuthMember authMember) {
+
+        userService.updateProfile(authMember.getUserId(), request.getName());
+        return ApiResponse.onSuccess("프로필이 성공적으로 수정되었습니다.", null);
+    }
+
+    // 비밀번호 변경
+    @Override
+    @PatchMapping("/me/password")
+    public ApiResponse<Void> updatePassword(
+            @RequestBody @Valid UserRequestDto.UpdatePassword request,
+            @AuthenticationPrincipal AuthMember authMember) {
+
+        userService.updatePassword(authMember.getUserId(), request);
+        return ApiResponse.onSuccess("비밀번호가 성공적으로 변경되었습니다.", null);
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/user/dto/UserRequestDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/user/dto/UserRequestDto.java
@@ -1,6 +1,7 @@
 package com._penLearning.Noddi.domain.user.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -21,7 +22,9 @@ public class UserRequestDto {
         private String currentPassword;
 
         @NotBlank(message = "새로운 비밀번호를 입력해주세요.")
-        // 정규식이 필요하다면 @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)...") 추가
-        private String newPassword;
+        @Pattern(
+                regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,20}$",
+                message = "비밀번호는 8~20자의 영문, 숫자, 특수문자를 포함해야 합니다."
+        )        private String newPassword;
     }
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/user/dto/UserRequestDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/user/dto/UserRequestDto.java
@@ -1,0 +1,27 @@
+package com._penLearning.Noddi.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class UserRequestDto {
+
+    @Getter
+    @NoArgsConstructor
+    public static class UpdateProfile {
+        @NotBlank(message = "변경할 이름을 입력해주세요.")
+        private String name;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class UpdatePassword {
+
+        @NotBlank(message = "현재 비밀번호를 입력해주세요.")
+        private String currentPassword;
+
+        @NotBlank(message = "새로운 비밀번호를 입력해주세요.")
+        // 정규식이 필요하다면 @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)...") 추가
+        private String newPassword;
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/user/dto/UserResponseDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/user/dto/UserResponseDto.java
@@ -1,0 +1,28 @@
+package com._penLearning.Noddi.domain.user.dto;
+
+import com._penLearning.Noddi.domain.user.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+
+public class UserResponseDto {
+
+    @Getter
+    @Builder
+    public static class ProfileInfo {
+        private Long userId;
+        private String email;
+        private String name;
+        private Long organizationId;
+        private String organizationName;
+
+        public static ProfileInfo from(User user) {
+            return ProfileInfo.builder()
+                    .userId(user.getUserId())
+                    .email(user.getEmail())
+                    .name(user.getName())
+                    .organizationId(user.getOrganization().getOrganizationId())
+                    .organizationName(user.getOrganization().getName())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/user/entity/User.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/user/entity/User.java
@@ -31,19 +31,19 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private String password;
 
-    @Column(nullable = false)
-    private Boolean isActive = true;
-
     @Builder
     public User(Organization organization, String email, String name, String password) {
         this.organization = organization;
         this.email = email;
         this.name = name;
         this.password = password;
-        this.isActive = true;
     }
 
-    public void deactivate() {
-        this.isActive = false;
+    public void updateProfile(String name) {
+        this.name = name;
+    }
+
+    public void updatePassword(String encodedPassword) {
+        this.password = encodedPassword;
     }
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/user/repository/UserRepository.java
@@ -2,10 +2,16 @@ package com._penLearning.Noddi.domain.user.repository;
 
 import com._penLearning.Noddi.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     boolean existsByEmail(String email);
+
+    // 유저 정보와 소속 조직 정보를 한 번의 쿼리로 조회 (N+1 방어)
+    @Query("SELECT u FROM User u JOIN FETCH u.organization WHERE u.userId = :userId")
+    Optional<User> findByIdWithOrganization(@Param("userId") Long userId);
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/user/service/UserService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/user/service/UserService.java
@@ -1,0 +1,62 @@
+package com._penLearning.Noddi.domain.user.service;
+
+
+import com._penLearning.Noddi.domain.user.code.UserErrorCode;
+import com._penLearning.Noddi.domain.user.dto.UserRequestDto;
+import com._penLearning.Noddi.domain.user.dto.UserResponseDto;
+import com._penLearning.Noddi.domain.user.entity.User;
+import com._penLearning.Noddi.domain.user.repository.UserRepository;
+import com._penLearning.Noddi.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+     // 내 프로필 및 조직 정보 조회
+    @Transactional(readOnly = true)
+    public UserResponseDto.ProfileInfo getMyProfile(Long userId) {
+        User user = userRepository.findByIdWithOrganization(userId)
+                .orElseThrow(() -> new GeneralException(UserErrorCode.USER_NOT_FOUND));
+
+        return UserResponseDto.ProfileInfo.from(user);
+    }
+
+    // 내 프로필 수정
+    @Transactional
+    public void updateProfile(Long userId, String newName) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(UserErrorCode.USER_NOT_FOUND));
+
+        user.updateProfile(newName);
+    }
+
+    // 비번 변경
+    @Transactional
+    public void updatePassword(Long userId, UserRequestDto.UpdatePassword request) {
+        User user = userRepository.findById(userId)
+                // 실제 적용 시 UserErrorCode.USER_NOT_FOUND 사용 권장
+                .orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다."));
+
+        // 1. 현재 비밀번호 일치 여부 검증
+        if (!passwordEncoder.matches(request.getCurrentPassword(), user.getPassword())) {
+            // 실제 적용 시 UserErrorCode.INVALID_PASSWORD 등 커스텀 예외 사용 권장
+            throw new RuntimeException("현재 비밀번호가 일치하지 않습니다.");
+        }
+
+        // 2. 새 비밀번호와 현재 비밀번호가 같은지 방어 로직 (선택 사항)
+        if (passwordEncoder.matches(request.getNewPassword(), user.getPassword())) {
+            throw new RuntimeException("새로운 비밀번호는 기존 비밀번호와 달라야 합니다.");
+        }
+
+        // 3. 비밀번호 암호화 후 엔티티 업데이트
+        user.updatePassword(passwordEncoder.encode(request.getNewPassword()));
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/user/service/UserService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/user/service/UserService.java
@@ -43,17 +43,17 @@ public class UserService {
     public void updatePassword(Long userId, UserRequestDto.UpdatePassword request) {
         User user = userRepository.findById(userId)
                 // 실제 적용 시 UserErrorCode.USER_NOT_FOUND 사용 권장
-                .orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다."));
+                .orElseThrow(() -> new GeneralException(UserErrorCode.USER_NOT_FOUND));
 
         // 1. 현재 비밀번호 일치 여부 검증
         if (!passwordEncoder.matches(request.getCurrentPassword(), user.getPassword())) {
             // 실제 적용 시 UserErrorCode.INVALID_PASSWORD 등 커스텀 예외 사용 권장
-            throw new RuntimeException("현재 비밀번호가 일치하지 않습니다.");
+            throw new GeneralException(UserErrorCode.INVALID_CURRENT_PASSWORD);
         }
 
         // 2. 새 비밀번호와 현재 비밀번호가 같은지 방어 로직 (선택 사항)
         if (passwordEncoder.matches(request.getNewPassword(), user.getPassword())) {
-            throw new RuntimeException("새로운 비밀번호는 기존 비밀번호와 달라야 합니다.");
+            throw new GeneralException(UserErrorCode.SAME_AS_OLD_PASSWORD);
         }
 
         // 3. 비밀번호 암호화 후 엔티티 업데이트

--- a/src/main/java/com/_penLearning/Noddi/global/security/SecurityConfig.java
+++ b/src/main/java/com/_penLearning/Noddi/global/security/SecurityConfig.java
@@ -50,6 +50,8 @@ public class SecurityConfig {
                                 .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/api-docs/**", "/v3/api-docs/**").permitAll()
                                 // 회원가입, 로그인 API 허용
                                 .requestMatchers("/api/v1/auth/**").permitAll()
+                                // 조직 조회 관련 API 전체 허용
+                                .requestMatchers("/api/v1/organizations/**").permitAll()
                                 // Daily.co 웹훅 수신 주소 허용 (JWT 무인증 외부 알림)
                                 .requestMatchers("/webhooks/**").permitAll()
                                 // 그 외 모든 요청은 인증 필요 (테스트 시 필요시 permitAll로 변경 가능)


### PR DESCRIPTION
## <i>PULL REQUEST</i>

## 🎋 작업 브랜치
- feature/3 -> develop
- #21

## 💡 작업동기

* 회원가입 과정에서 사용자가 본인의 소속 기관(학교, 회사 등)을 검색하고 선택할 수 있도록 조직(Organization) 조회 기능이 필요
* 로그인한 사용자가 자신의 프로필(이름, 이메일, 소속 조직)을 확인하고, 개인정보(이름)와 비밀번호를 안전하게 수정할 수 있는 마이페이지 기능이 요구됨
* 이메일 수정은 조직이랑 연관되어 있어서 구현하지 않음

## 🔑 주요 변경사항

* **Organization(조직) 도메인 구축:**
* 조직 전체 목록 조회 및 단일 조회 API 구현 (`GET /api/v1/organizations`).
* 비회원도 회원가입 시 조직을 검색할 수 있도록 SecurityConfig에서 `/api/v1/organizations/**` 경로 `permitAll` 처리.

* **User(유저) 프로필 및 정보 수정 기능 구현:**
* 내 프로필 조회 API 구현 (조직 정보를 한 번에 가져오도록 Fetch Join 적용하여 N+1 쿼리 최적화).
* 내 프로필(이름) 변경 API 구현.
* 비밀번호 변경 API 구현 (`PasswordEncoder`를 사용하여 현재 비밀번호 일치 여부를 팩트 체크하는 방어 로직 적용).

## 🏞 스크린샷 (선택)
> 스크린샷을 첨부해주세요.

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
