### PR TITLE
[feat] QaAnswer,QaQuestion 기본 CRUD 구현

### DIFF
--- a/src/main/java/com/_penLearning/Noddi/domain/qa/code/QaApi.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/code/QaApi.java
@@ -1,0 +1,49 @@
+package com._penLearning.Noddi.domain.qa.code;
+
+import com._penLearning.Noddi.domain.auth.entity.AuthMember;
+import com._penLearning.Noddi.domain.qa.dto.QaRequestDto;
+import com._penLearning.Noddi.domain.qa.dto.QaResponseDto;
+import com._penLearning.Noddi.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.List;
+
+@Tag(name = "Q&A API", description = "팀 간 Q&A(질문/답변) 관리 API")
+public interface QaApi {
+
+    @Operation(summary = "질문 등록", description = "특정 팀에게 질문을 등록합니다. (질문자는 대상 팀과 같은 프로젝트 멤버여야 합니다.)")
+    ApiResponse<QaResponseDto.CreateQuestion> createQuestion(
+            QaRequestDto.CreateQuestion request,
+            @Parameter(hidden = true) AuthMember authMember
+    );
+
+    @Operation(summary = "내가 작성한 질문 목록 조회", description = "현재 로그인한 유저가 작성한 질문 목록을 최신순으로 조회합니다.")
+    ApiResponse<Page<QaResponseDto.QuestionInfo>> getMyQuestions(
+            @Parameter(hidden = true) AuthMember authMember,
+            Pageable pageable
+    );
+
+    @Operation(summary = "특정 팀의 질문 목록 조회", description = "특정 팀에 등록된 질문 목록을 최신순으로 조회합니다.")
+    ApiResponse<Page<QaResponseDto.QuestionInfo>> getTeamQuestions(
+            @Parameter(description = "대상 팀 ID") @PathVariable Long teamId,
+            @Parameter(hidden = true) AuthMember authMember,
+            Pageable pageable
+    );
+
+    @Operation(summary = "질문 상세 조회", description = "단건 질문의 상세 내용과 (존재할 경우) 답변을 조회합니다.")
+    ApiResponse<QaResponseDto.QuestionDetail> getQuestionDetail(
+            @Parameter(description = "질문 ID") @PathVariable Long questionId, @Parameter(hidden = true) AuthMember authMember
+    );
+
+    @Operation(summary = "직접 답변 등록", description = "질문에 대한 직접 답변을 등록합니다. (대상 팀 멤버만 작성 가능)")
+    ApiResponse<QaResponseDto.CreateAnswer> createAnswer(
+            @Parameter(description = "질문 ID") @PathVariable Long questionId,
+            QaRequestDto.CreateAnswer request,
+            @Parameter(hidden = true) AuthMember authMember
+    );
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/code/QaErrorCode.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/code/QaErrorCode.java
@@ -1,0 +1,23 @@
+package com._penLearning.Noddi.domain.qa.code;
+
+import com._penLearning.Noddi.global.apiPayload.code.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum QaErrorCode implements BaseErrorCode {
+
+    QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "QA404_1", "질문을 찾을 수 없습니다."),
+    ANSWER_NOT_FOUND(HttpStatus.NOT_FOUND, "QA404_2", "답변을 찾을 수 없습니다."),
+
+    NOT_PROJECT_MEMBER(HttpStatus.FORBIDDEN, "QA403_1", "해당 프로젝트의 멤버가 아닙니다."),
+    NOT_TARGET_TEAM_MEMBER(HttpStatus.FORBIDDEN, "QA403_2", "질문 대상 팀의 멤버만 답변할 수 있습니다."),
+
+    ALREADY_ANSWERED(HttpStatus.CONFLICT, "QA409_1", "이미 답변이 완료된 질문입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/code/QaErrorCode.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/code/QaErrorCode.java
@@ -9,6 +9,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum QaErrorCode implements BaseErrorCode {
 
+    INVALID_ANSWER_TYPE(HttpStatus.BAD_REQUEST, "QA400_1", "답변 유형이 올바르지 않습니다."),
+    INVALID_ANSWERER(HttpStatus.BAD_REQUEST, "QA400_2", "답변 유형과 답변자 정보가 일치하지 않습니다."),
+
     QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "QA404_1", "질문을 찾을 수 없습니다."),
     ANSWER_NOT_FOUND(HttpStatus.NOT_FOUND, "QA404_2", "답변을 찾을 수 없습니다."),
 

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/controller/QaController.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/controller/QaController.java
@@ -1,0 +1,82 @@
+package com._penLearning.Noddi.domain.qa.controller;
+
+import com._penLearning.Noddi.domain.auth.entity.AuthMember;
+import com._penLearning.Noddi.domain.qa.code.QaApi;
+import com._penLearning.Noddi.domain.qa.dto.QaRequestDto;
+import com._penLearning.Noddi.domain.qa.dto.QaResponseDto;
+import com._penLearning.Noddi.domain.qa.service.QaCommandService;
+import com._penLearning.Noddi.domain.qa.service.QaQueryService;
+import com._penLearning.Noddi.global.apiPayload.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class QaController implements QaApi {
+
+    private final QaCommandService qaCommandService;
+    private final QaQueryService qaQueryService;
+
+    // 질문 등록
+    @Override
+    @PostMapping("/api/v1/qa/questions")
+    public ApiResponse<QaResponseDto.CreateQuestion> createQuestion(
+            @RequestBody @Valid QaRequestDto.CreateQuestion request,
+            @AuthenticationPrincipal AuthMember authMember) {
+
+        QaResponseDto.CreateQuestion response = qaCommandService.createQuestion(authMember.getUserId(), request);
+        return ApiResponse.onSuccess("질문이 성공적으로 등록되었습니다.", response);
+    }
+
+    // 내가 작성한 질문 목록 조회
+    @Override
+    @GetMapping("/api/v1/qa/questions/me")
+    public ApiResponse<Page<QaResponseDto.QuestionInfo>> getMyQuestions(
+            @AuthenticationPrincipal AuthMember authMember,
+            Pageable pageable) {
+
+        Page<QaResponseDto.QuestionInfo> response = qaQueryService.getMyQuestions(authMember.getUserId(), pageable);
+        return ApiResponse.onSuccess("내 질문 목록 조회에 성공했습니다.", response);
+    }
+
+    // 특정 팀의 질문 목록 조회 (경로 다름)
+    @Override
+    @GetMapping("/api/v1/teams/{teamId}/qa/questions")
+    public ApiResponse<Page<QaResponseDto.QuestionInfo>> getTeamQuestions(
+            @PathVariable Long teamId,
+            @AuthenticationPrincipal AuthMember authMember,
+            Pageable pageable) {
+
+        Page<QaResponseDto.QuestionInfo> response = qaQueryService.getTeamQuestions(authMember.getUserId(),teamId, pageable);
+        return ApiResponse.onSuccess("팀 질문 목록 조회에 성공했습니다.", response);
+    }
+
+    // 질문 상세 단건 조회
+    @Override
+    @GetMapping("/api/v1/qa/questions/{questionId}")
+    public ApiResponse<QaResponseDto.QuestionDetail> getQuestionDetail(
+            @PathVariable Long questionId,
+            @AuthenticationPrincipal AuthMember authMember) {
+
+        QaResponseDto.QuestionDetail response = qaQueryService.getQuestionDetail(authMember.getUserId(), questionId);
+        return ApiResponse.onSuccess("질문 상세 조회에 성공했습니다.", response);
+    }
+
+    // 직접 답변 등록
+    @Override
+    @PostMapping("/api/v1/qa/questions/{questionId}/answers")
+    public ApiResponse<QaResponseDto.CreateAnswer> createAnswer(
+            @PathVariable Long questionId,
+            @RequestBody @Valid QaRequestDto.CreateAnswer request,
+            @AuthenticationPrincipal AuthMember authMember) {
+
+        QaResponseDto.CreateAnswer response = qaCommandService.createAnswer(questionId, authMember.getUserId(), request);
+        return ApiResponse.onSuccess("답변이 성공적으로 등록되었습니다.", response);
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/dto/QaRequestDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/dto/QaRequestDto.java
@@ -2,6 +2,7 @@ package com._penLearning.Noddi.domain.qa.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -14,6 +15,7 @@ public class QaRequestDto {
         private Long targetTeamId;
 
         @NotBlank(message = "질문 내용을 입력해주세요.")
+        @Size(max = 500, message = "질문 내용은 최대 500자까지 입력 가능합니다.")
         private String content;
     }
 
@@ -21,6 +23,7 @@ public class QaRequestDto {
     @NoArgsConstructor
     public static class CreateAnswer {
         @NotBlank(message = "답변 내용을 입력해주세요.")
+        @Size(max = 1000, message = "답변 내용은 최대 1000자까지 입력 가능합니다.")
         private String content;
     }
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/dto/QaRequestDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/dto/QaRequestDto.java
@@ -1,0 +1,26 @@
+package com._penLearning.Noddi.domain.qa.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class QaRequestDto {
+
+    @Getter
+    @NoArgsConstructor
+    public static class CreateQuestion {
+        @NotNull(message = "대상 팀 ID를 입력해주세요.")
+        private Long targetTeamId;
+
+        @NotBlank(message = "질문 내용을 입력해주세요.")
+        private String content;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class CreateAnswer {
+        @NotBlank(message = "답변 내용을 입력해주세요.")
+        private String content;
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/dto/QaResponseDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/dto/QaResponseDto.java
@@ -98,12 +98,14 @@ public class QaResponseDto {
         private String answeredByName;
 
         public static AnswerInfo from(QaAnswer answer) {
+            boolean isAiAnswer = answer.getAnswerType() == AnswerType.AI;
+
             return AnswerInfo.builder()
                     .answerId(answer.getAnswerId())
                     .content(answer.getContent())
                     .answerType(answer.getAnswerType())
-                    .answeredById(answer.getAnsweredBy() != null ? answer.getAnsweredBy().getUserId() : null)
-                    .answeredByName(answer.getAnsweredBy() != null ? answer.getAnsweredBy().getName() : "AI")
+                    .answeredById(isAiAnswer ? null : answer.getAnsweredBy().getUserId())
+                    .answeredByName(isAiAnswer ? "AI" : answer.getAnsweredBy().getName())
                     .build();
         }
     }

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/dto/QaResponseDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/dto/QaResponseDto.java
@@ -1,0 +1,110 @@
+package com._penLearning.Noddi.domain.qa.dto;
+
+import com._penLearning.Noddi.domain.qa.entity.AnswerType;
+import com._penLearning.Noddi.domain.qa.entity.QaAnswer;
+import com._penLearning.Noddi.domain.qa.entity.QaQuestion;
+import com._penLearning.Noddi.domain.qa.entity.QaStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+public class QaResponseDto {
+
+    @Getter
+    @Builder
+    public static class CreateQuestion{
+        private Long questionId;
+
+        public static CreateQuestion from(Long questionId){
+            return CreateQuestion.builder()
+                    .questionId(questionId)
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class CreateAnswer{
+        private Long answerId;
+
+        public static CreateAnswer from(Long answerId){
+            return CreateAnswer.builder()
+                    .answerId(answerId)
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class QuestionInfo {
+        private Long questionId;
+        private Long targetTeamId;
+        private String targetTeamName;
+        private Long questionerId;
+        private String questionerName;
+
+        private String content;
+        private QaStatus status;
+        private LocalDateTime createdAt;
+
+        public static QuestionInfo from(QaQuestion question) {
+            return QuestionInfo.builder()
+                    .questionId(question.getQuestionId())
+                    .targetTeamId(question.getTargetTeam().getTeamId())
+                    .targetTeamName(question.getTargetTeam().getName())
+                    .questionerId(question.getQuestioner().getUserId())
+                    .questionerName(question.getQuestioner().getName())
+                    .content(question.getContent())
+                    .status(question.getStatus())
+                    .createdAt(question.getCreatedAt())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class QuestionDetail {
+        private Long questionId;
+        private String content;
+        private QaStatus status;
+        private String targetTeamName;
+        private LocalDateTime createdAt;
+        private Long questionerId;
+        private String questionerName;
+        private AnswerInfo answer; // 답변이 없으면 null 반환
+
+        public static QuestionDetail of(QaQuestion question, QaAnswer answer) {
+            return QuestionDetail.builder()
+                    .questionId(question.getQuestionId())
+                    .content(question.getContent())
+                    .status(question.getStatus())
+                    .targetTeamName(question.getTargetTeam().getName())
+                    .createdAt(question.getCreatedAt())
+                    .questionerId(question.getQuestioner().getUserId())
+                    .questionerName(question.getQuestioner().getName())
+                    .answer(answer != null ? AnswerInfo.from(answer) : null)
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class AnswerInfo {
+        private Long answerId;
+        private String content;
+        private AnswerType answerType;
+        private Long answeredById;
+        private String answeredByName;
+
+        public static AnswerInfo from(QaAnswer answer) {
+            return AnswerInfo.builder()
+                    .answerId(answer.getAnswerId())
+                    .content(answer.getContent())
+                    .answerType(answer.getAnswerType())
+                    .answeredById(answer.getAnsweredBy() != null ? answer.getAnsweredBy().getUserId() : null)
+                    .answeredByName(answer.getAnsweredBy() != null ? answer.getAnsweredBy().getName() : "AI")
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/entity/AnswerType.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/entity/AnswerType.java
@@ -1,0 +1,5 @@
+package com._penLearning.Noddi.domain.qa.entity;
+
+public enum AnswerType {
+    AI, HUMAN
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/entity/QaAnswer.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/entity/QaAnswer.java
@@ -1,18 +1,18 @@
 package com._penLearning.Noddi.domain.qa.entity;
 
+import com._penLearning.Noddi.domain.user.entity.User;
+import com._penLearning.Noddi.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "QaAnswer")
-public class QaAnswer {
+public class QaAnswer extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -22,24 +22,22 @@ public class QaAnswer {
     @JoinColumn(name = "questionId", nullable = false, unique = true)
     private QaQuestion question;
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
-    // 최신 수정본 ID (null이면 수정 없음)
-    private Long latestRevisionId;
-
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private LocalDateTime createdAt;
+    private AnswerType answerType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "answeredById")
+    private User answeredBy;
 
     @Builder
-    public QaAnswer(QaQuestion question, String content) {
+    public QaAnswer(QaQuestion question, String content, User answeredBy, AnswerType answerType) {
         this.question = question;
         this.content = content;
-        this.createdAt = LocalDateTime.now();
-    }
-
-    public void updateLatestRevision(Long revisionId) {
-        this.latestRevisionId = revisionId;
+        this.answeredBy = answeredBy;
+        this.answerType = answerType;
     }
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/entity/QaAnswer.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/entity/QaAnswer.java
@@ -1,7 +1,9 @@
 package com._penLearning.Noddi.domain.qa.entity;
 
+import com._penLearning.Noddi.domain.qa.code.QaErrorCode;
 import com._penLearning.Noddi.domain.user.entity.User;
 import com._penLearning.Noddi.global.common.BaseEntity;
+import com._penLearning.Noddi.global.exception.GeneralException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -35,9 +37,28 @@ public class QaAnswer extends BaseEntity {
 
     @Builder
     public QaAnswer(QaQuestion question, String content, User answeredBy, AnswerType answerType) {
+        validateAnswerer(answerType, answeredBy);
         this.question = question;
         this.content = content;
         this.answeredBy = answeredBy;
         this.answerType = answerType;
+    }
+
+    @PrePersist
+    @PreUpdate
+    private void validateAnswerer() {
+        validateAnswerer(answerType, answeredBy);
+    }
+
+    private static void validateAnswerer(AnswerType answerType, User answeredBy) {
+        if (answerType == null) {
+            throw new GeneralException(QaErrorCode.INVALID_ANSWER_TYPE);
+        }
+        if (answerType == AnswerType.AI && answeredBy != null) {
+            throw new GeneralException(QaErrorCode.INVALID_ANSWERER);
+        }
+        if (answerType == AnswerType.HUMAN && answeredBy == null) {
+            throw new GeneralException(QaErrorCode.INVALID_ANSWERER);
+        }
     }
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/entity/QaQuestion.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/entity/QaQuestion.java
@@ -2,19 +2,18 @@ package com._penLearning.Noddi.domain.qa.entity;
 
 import com._penLearning.Noddi.domain.team.entity.Team;
 import com._penLearning.Noddi.domain.user.entity.User;
+import com._penLearning.Noddi.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "QaQuestion")
-public class QaQuestion {
+public class QaQuestion extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,16 +27,12 @@ public class QaQuestion {
     @JoinColumn(name = "targetTeamId", nullable = false)
     private Team targetTeam;
 
-    @Lob
-    @Column(nullable = false)
+    @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private QaStatus status;
-
-    @Column(nullable = false)
-    private LocalDateTime createdAt;
 
     @Builder
     public QaQuestion(User questioner, Team targetTeam, String content) {
@@ -45,14 +40,9 @@ public class QaQuestion {
         this.targetTeam = targetTeam;
         this.content = content;
         this.status = QaStatus.PENDING;
-        this.createdAt = LocalDateTime.now();
     }
 
-    public void markAnswered() {
+    public void markAsAnswered() {
         this.status = QaStatus.ANSWERED;
-    }
-
-    public void markFailed() {
-        this.status = QaStatus.FAILED;
     }
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/entity/QaStatus.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/entity/QaStatus.java
@@ -1,5 +1,6 @@
 package com._penLearning.Noddi.domain.qa.entity;
 
 public enum QaStatus {
-    PENDING, ANSWERED, FAILED
+    PENDING, // 질문 등록 완료
+    ANSWERED // 답변 완료
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/repository/QaAnswerRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/repository/QaAnswerRepository.java
@@ -1,10 +1,15 @@
 package com._penLearning.Noddi.domain.qa.repository;
 
 import com._penLearning.Noddi.domain.qa.entity.QaAnswer;
+import com._penLearning.Noddi.domain.qa.entity.QaQuestion;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface QaAnswerRepository extends JpaRepository<QaAnswer, Long> {
-    Optional<QaAnswer> findByQuestion_QuestionId(Long questionId);
+    // 이미 답변이 존재하는지 검증
+    boolean existsByQuestion(QaQuestion question);
+
+    // 특정 질문의 답변 조회
+    Optional<QaAnswer> findByQuestion(QaQuestion question);
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/repository/QaQuestionRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/repository/QaQuestionRepository.java
@@ -2,12 +2,64 @@ package com._penLearning.Noddi.domain.qa.repository;
 
 import com._penLearning.Noddi.domain.qa.entity.QaQuestion;
 import com._penLearning.Noddi.domain.qa.entity.QaStatus;
+import com._penLearning.Noddi.domain.team.entity.Team;
+import com._penLearning.Noddi.domain.user.entity.User;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface QaQuestionRepository extends JpaRepository<QaQuestion, Long> {
-    List<QaQuestion> findByQuestioner_UserIdOrderByCreatedAtDesc(Long userId);
-    List<QaQuestion> findByTargetTeam_TeamIdOrderByCreatedAtDesc(Long teamId);
-    List<QaQuestion> findByStatus(QaStatus status);
+    // 동시성 제어를 위한 비관적 쓰기 잠금
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT q FROM QaQuestion q WHERE q.questionId = :questionId")
+    Optional<QaQuestion> findByIdWithLock(@Param("questionId") Long questionId);
+
+    // 질문 목록 페이징 적용 (List -> Page)
+    @Query(
+            value = """
+        SELECT q
+        FROM QaQuestion q
+        JOIN FETCH q.targetTeam
+        JOIN FETCH q.questioner
+        WHERE q.questioner = :questioner
+        ORDER BY q.createdAt DESC
+        """,
+            countQuery = """
+        SELECT COUNT(q)
+        FROM QaQuestion q
+        WHERE q.questioner = :questioner
+        """
+    )
+    Page<QaQuestion> findAllByQuestionerWithTeam(
+            @Param("questioner") User questioner,
+            Pageable pageable
+    );
+
+    // 특정 팀에 들어온 질문 목록 조회 (N+1 방지)
+    @Query(
+            value = """
+        SELECT q
+        FROM QaQuestion q
+        JOIN FETCH q.questioner
+        WHERE q.targetTeam = :targetTeam
+        ORDER BY q.createdAt DESC
+        """,
+            countQuery = """
+        SELECT COUNT(q)
+        FROM QaQuestion q
+        WHERE q.targetTeam = :targetTeam
+        """
+    )
+    Page<QaQuestion> findAllByTargetTeamWithUser(@Param("targetTeam") Team targetTeam, Pageable pageable);
+
+    // 단건 상세 조회 (팀 정보 포함)
+    @Query("SELECT q FROM QaQuestion q JOIN FETCH q.targetTeam WHERE q.questionId = :questionId")
+    Optional<QaQuestion> findByIdWithTeam(@Param("questionId") Long questionId);
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaCommandService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaCommandService.java
@@ -1,0 +1,95 @@
+package com._penLearning.Noddi.domain.qa.service;
+
+import com._penLearning.Noddi.domain.project.repository.ProjectMemberRepository;
+import com._penLearning.Noddi.domain.qa.code.QaErrorCode;
+import com._penLearning.Noddi.domain.qa.dto.QaRequestDto;
+import com._penLearning.Noddi.domain.qa.dto.QaResponseDto;
+import com._penLearning.Noddi.domain.qa.entity.AnswerType;
+import com._penLearning.Noddi.domain.qa.entity.QaAnswer;
+import com._penLearning.Noddi.domain.qa.entity.QaQuestion;
+import com._penLearning.Noddi.domain.qa.entity.QaStatus;
+import com._penLearning.Noddi.domain.qa.repository.QaAnswerRepository;
+import com._penLearning.Noddi.domain.qa.repository.QaQuestionRepository;
+import com._penLearning.Noddi.domain.team.code.TeamErrorCode;
+import com._penLearning.Noddi.domain.team.entity.Team;
+import com._penLearning.Noddi.domain.team.repository.TeamMemberRepository;
+import com._penLearning.Noddi.domain.team.repository.TeamRepository;
+import com._penLearning.Noddi.domain.user.code.UserErrorCode;
+import com._penLearning.Noddi.domain.user.entity.User;
+import com._penLearning.Noddi.domain.user.repository.UserRepository;
+import com._penLearning.Noddi.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class QaCommandService {
+
+    private final QaQuestionRepository qaQuestionRepository;
+    private final QaAnswerRepository qaAnswerRepository;
+    private final UserRepository userRepository;
+    private final TeamRepository teamRepository;
+    private final ProjectMemberRepository projectMemberRepository;
+    private final TeamMemberRepository teamMemberRepository;
+
+    // 질문 등록
+    public QaResponseDto.CreateQuestion createQuestion(Long questionerId, QaRequestDto.CreateQuestion request) {
+        User questioner = userRepository.findById(questionerId)
+                .orElseThrow(() -> new GeneralException(UserErrorCode.USER_NOT_FOUND));
+
+        Team targetTeam = teamRepository.findById(request.getTargetTeamId())
+                .orElseThrow(() -> new GeneralException(TeamErrorCode.TEAM_NOT_FOUND));
+
+        // 방어 로직: 질문자는 대상 팀이 속한 '프로젝트'의 멤버여야 함
+        if (!projectMemberRepository.existsByProjectAndUser(targetTeam.getProject(), questioner)) {
+            throw new GeneralException(QaErrorCode.NOT_PROJECT_MEMBER);
+        }
+
+        QaQuestion question = QaQuestion.builder()
+                .questioner(questioner)
+                .targetTeam(targetTeam)
+                .content(request.getContent())
+                .build();
+
+        return QaResponseDto.CreateQuestion.from(qaQuestionRepository.save(question).getQuestionId());
+    }
+
+    // 직접 답변 등록
+    public QaResponseDto.CreateAnswer createAnswer(Long questionId, Long answererId, QaRequestDto.CreateAnswer request) {
+        QaQuestion question = qaQuestionRepository.findByIdWithLock(questionId)
+                .orElseThrow(() -> new GeneralException(QaErrorCode.QUESTION_NOT_FOUND));
+
+        // 방어 로직: 이미 답변이 달렸거나 PENDING 상태가 아닌 경우
+        if (question.getStatus() != QaStatus.PENDING) {
+            throw new GeneralException(QaErrorCode.ALREADY_ANSWERED);
+        }
+
+        User answerer = userRepository.findById(answererId)
+                .orElseThrow(() -> new GeneralException(UserErrorCode.USER_NOT_FOUND));
+
+        // 방어 로직: 답변자는 질문 대상 '팀'의 멤버여야 함
+        if (!teamMemberRepository.existsByTeamAndUser(question.getTargetTeam(), answerer)) {
+            throw new GeneralException(QaErrorCode.NOT_TARGET_TEAM_MEMBER);
+        }
+
+        // 방어 로직: 혹시 모를 중복 답변 생성 방지
+        if (qaAnswerRepository.existsByQuestion(question)) {
+            throw new GeneralException(QaErrorCode.ALREADY_ANSWERED);
+        }
+
+        QaAnswer answer = QaAnswer.builder()
+                .question(question)
+                .content(request.getContent())
+                .answerType(AnswerType.HUMAN) // HUMAN 명시
+                .answeredBy(answerer)
+                .build();
+
+        QaAnswer savedAnswer = qaAnswerRepository.save(answer);
+
+        // 질문 상태를 ANSWERED로 업데이트 (더티 체킹)
+        question.markAsAnswered();
+        return QaResponseDto.CreateAnswer.from(savedAnswer.getAnswerId());
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaQueryService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaQueryService.java
@@ -1,0 +1,74 @@
+package com._penLearning.Noddi.domain.qa.service;
+
+import com._penLearning.Noddi.domain.project.repository.ProjectMemberRepository;
+import com._penLearning.Noddi.domain.qa.code.QaErrorCode;
+import com._penLearning.Noddi.domain.qa.dto.QaResponseDto;
+import com._penLearning.Noddi.domain.qa.entity.QaAnswer;
+import com._penLearning.Noddi.domain.qa.entity.QaQuestion;
+import com._penLearning.Noddi.domain.qa.repository.QaAnswerRepository;
+import com._penLearning.Noddi.domain.qa.repository.QaQuestionRepository;
+import com._penLearning.Noddi.domain.team.code.TeamErrorCode;
+import com._penLearning.Noddi.domain.team.entity.Team;
+import com._penLearning.Noddi.domain.team.repository.TeamRepository;
+import com._penLearning.Noddi.domain.user.code.UserErrorCode;
+import com._penLearning.Noddi.domain.user.entity.User;
+import com._penLearning.Noddi.domain.user.repository.UserRepository;
+import com._penLearning.Noddi.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class QaQueryService {
+
+    private final QaQuestionRepository qaQuestionRepository;
+    private final QaAnswerRepository qaAnswerRepository;
+    private final UserRepository userRepository;
+    private final TeamRepository teamRepository;
+    private final ProjectMemberRepository projectMemberRepository;
+
+    // 내가 작성한 질문 목록 조회
+    public Page<QaResponseDto.QuestionInfo> getMyQuestions(Long userId, Pageable pageable) {
+        User questioner = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(UserErrorCode.USER_NOT_FOUND));
+
+        return qaQuestionRepository.findAllByQuestionerWithTeam(questioner, pageable)
+                .map(QaResponseDto.QuestionInfo::from);
+    }
+
+    // 특정 팀에 등록된 질문 조회
+    public Page<QaResponseDto.QuestionInfo> getTeamQuestions(Long requesterId, Long teamId, Pageable pageable) {
+        Team targetTeam = teamRepository.findById(teamId)
+                .orElseThrow(() -> new GeneralException(TeamErrorCode.TEAM_NOT_FOUND));
+
+        validateProjectMembership(requesterId, targetTeam);
+
+        return qaQuestionRepository.findAllByTargetTeamWithUser(targetTeam, pageable)
+                .map(QaResponseDto.QuestionInfo::from);
+    }
+
+    // 질문 상세 조회
+    public QaResponseDto.QuestionDetail getQuestionDetail(Long requesterId, Long questionId) {
+        QaQuestion question = qaQuestionRepository.findByIdWithTeam(questionId)
+                .orElseThrow(() -> new GeneralException(QaErrorCode.QUESTION_NOT_FOUND));
+
+        validateProjectMembership(requesterId, question.getTargetTeam());
+
+        QaAnswer answer = qaAnswerRepository.findByQuestion(question).orElse(null);
+        return QaResponseDto.QuestionDetail.of(question, answer);
+    }
+
+    // 공통 프로젝트 권한 검증 로직
+    private void validateProjectMembership(Long requesterId, Team targetTeam) {
+        User requester = userRepository.findById(requesterId)
+                .orElseThrow(() -> new GeneralException(UserErrorCode.USER_NOT_FOUND));
+
+        if (!projectMemberRepository.existsByProjectAndUser(targetTeam.getProject(), requester)) {
+            throw new GeneralException(QaErrorCode.NOT_PROJECT_MEMBER);
+        }
+    }
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

## 🎋 작업 브랜치
- feat/17-qa-crud  -> develop
- #17

## 💡 작업동기
- 프로젝트 내 팀 간 질문과 답변을 주고받을 수 있는 Q&A 기능을 제공하기 위해 기본 CRUD를 구현했습니다.
- 추후 AI 기반 답변 생성, 답변 수정 이력, 피드백 및 출처 기능을 확장할 수 있도록 질문·답변 도메인 구조를 정리했습니다.

## 🔑 주요 변경사항
- 프로젝트 멤버가 특정 팀에 질문을 등록하는 기능을 구현했습니다.
- 내가 작성한 질문 및 팀별 질문 목록을 페이징하여 조회하도록 구현했습니다.
- 질문 상세 정보와 등록된 답변을 조회하는 기능을 구현했습니다.
- 질문 대상 팀의 멤버가 직접 답변을 등록할 수 있도록 구현했습니다.
- 질문 및 답변 생성 시 생성된 ID를 반환하도록 응답 DTO를 구성했습니다.
- 프로젝트·팀 멤버십에 따른 질문 조회 및 답변 작성 권한 검증을 추가했습니다.
- 비관적 락과 유니크 제약을 이용해 동일 질문에 대한 중복 답변 생성을 방지했습니다.

## 🏞 스크린샷 (선택)
> 스크린샷을 첨부해주세요.

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
