### PR TITLE
[Feat] Daily 녹음 파일 다운로드 및 OpenAI Whisper STT 구현

### DIFF
--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/code/MeetingErrorCode.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/code/MeetingErrorCode.java
@@ -23,7 +23,8 @@ public enum MeetingErrorCode implements BaseErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEETING404_2", "존재하지 않는 유저입니다."),
     TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "MEETING404_3", "존재하지 않는 팀입니다."),
     // 500 Internal Server Error: 외부 연동 장애
-    WEBRTC_ROOM_CREATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "MEETING500_1", "WebRTC 방 생성 중 오류가 발생했습니다.");
+    WEBRTC_ROOM_CREATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "MEETING500_1", "WebRTC 방 생성 중 오류가 발생했습니다."),
+    WEBRTC_ROOM_CREATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "MEETING500_2", "WebRTC 방 생성 중 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/code/MeetingErrorCode.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/code/MeetingErrorCode.java
@@ -23,8 +23,7 @@ public enum MeetingErrorCode implements BaseErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEETING404_2", "존재하지 않는 유저입니다."),
     TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "MEETING404_3", "존재하지 않는 팀입니다."),
     // 500 Internal Server Error: 외부 연동 장애
-    WEBRTC_ROOM_CREATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "MEETING500_1", "WebRTC 방 생성 중 오류가 발생했습니다."),
-    WEBRTC_ROOM_CREATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "MEETING500_2", "WebRTC 방 생성 중 오류가 발생했습니다.");
+    WEBRTC_ROOM_CREATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "MEETING500_1", "WebRTC 방 생성 중 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/entity/Meeting.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/entity/Meeting.java
@@ -49,8 +49,6 @@ public class Meeting extends BaseEntity {
     //webRTC 방 ID LAZY 방식으로 주입(회의 시작 버튼을 눌러야 회의가 열림)
     private String roomName;
     private String recordingId;
-    @Lob
-    private String transcriptText;
 
     @Builder
     public Meeting(Team team, String title, User createdBy) {
@@ -98,7 +96,6 @@ public class Meeting extends BaseEntity {
     }
     public void completeAiProcessing(String transcriptText) {
         this.aiStatus = AiStatus.COMPLETED;
-        this.transcriptText = transcriptText;
     }
 
     public void failAiProcessing() {

--- a/src/main/java/com/_penLearning/Noddi/domain/summary/code/SummaryErrorCode.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/summary/code/SummaryErrorCode.java
@@ -1,0 +1,17 @@
+package com._penLearning.Noddi.domain.summary.code;
+
+import com._penLearning.Noddi.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SummaryErrorCode implements BaseErrorCode {
+    STT_PROCESSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "MEETING500_1", "회의 전문 텍스트 생성 중 오류가 발생했습니다."),
+    SUMMARY_PROCESSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "MEETING500_1", "전문 요약 생성 중 오류가 발생했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/summary/code/SummaryErrorCode.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/summary/code/SummaryErrorCode.java
@@ -8,8 +8,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum SummaryErrorCode implements BaseErrorCode {
-    STT_PROCESSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "MEETING500_1", "회의 전문 텍스트 생성 중 오류가 발생했습니다."),
-    SUMMARY_PROCESSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "MEETING500_1", "전문 요약 생성 중 오류가 발생했습니다.");
+    STT_PROCESSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SUMMARY500_1", "회의 전문 텍스트 생성 중 오류가 발생했습니다."),
+    SUMMARY_PROCESSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SUMMARY500_2", "전문 요약 생성 중 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/_penLearning/Noddi/domain/summary/entity/MeetingSummary.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/summary/entity/MeetingSummary.java
@@ -27,6 +27,10 @@ public class MeetingSummary {
     @Column(nullable = false)
     private String summaryText;
 
+    @Lob
+    @Column(nullable = false)
+    private String rawTranscript;
+
     // List<String>을 JSON 직렬화하여 저장
     private String decisions;
 
@@ -36,11 +40,12 @@ public class MeetingSummary {
     private LocalDateTime createdAt;
 
     @Builder
-    public MeetingSummary(Meeting meeting, String summaryText, String decisions, String issues) {
+    public MeetingSummary(Meeting meeting, String summaryText, String decisions, String issues, String rawTranscript) {
         this.meeting = meeting;
         this.summaryText = summaryText;
         this.decisions = decisions;
         this.issues = issues;
         this.createdAt = LocalDateTime.now();
+        this.rawTranscript = rawTranscript;
     }
 }

--- a/src/main/java/com/_penLearning/Noddi/global/config/OpenAiConfig.java
+++ b/src/main/java/com/_penLearning/Noddi/global/config/OpenAiConfig.java
@@ -8,7 +8,7 @@ import org.springframework.web.client.RestClient;
 
 @Configuration
 public class OpenAiConfig {
-    @Value("${oepnai.api-key:}")
+    @Value("${openai.api-key:}")
     private String openAiApiKey;
 
     @Bean(name = "openAiRestClient")

--- a/src/main/java/com/_penLearning/Noddi/global/config/OpenAiConfig.java
+++ b/src/main/java/com/_penLearning/Noddi/global/config/OpenAiConfig.java
@@ -8,7 +8,7 @@ import org.springframework.web.client.RestClient;
 
 @Configuration
 public class OpenAiConfig {
-    @Value("${openai.api-key:}")
+    @Value("${openai.api-key}")
     private String openAiApiKey;
 
     @Bean(name = "openAiRestClient")

--- a/src/main/java/com/_penLearning/Noddi/global/config/OpenAiConfig.java
+++ b/src/main/java/com/_penLearning/Noddi/global/config/OpenAiConfig.java
@@ -1,0 +1,25 @@
+package com._penLearning.Noddi.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class OpenAiConfig {
+    @Value("${oepnai.api-key:}")
+    private String oepnAiApiKey;
+
+    @Bean(name = "openAiRestClient")
+    public RestClient openAiRestClient() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(30000); //30초
+        factory.setReadTimeout(120000); //2분
+        return RestClient.builder()
+                .baseUrl("https://api.openai.com/v1")
+                .requestFactory(factory)
+                .defaultHeader("Authorization", "Bearer " + oepnAiApiKey)
+                .build();
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/global/config/OpenAiConfig.java
+++ b/src/main/java/com/_penLearning/Noddi/global/config/OpenAiConfig.java
@@ -9,7 +9,7 @@ import org.springframework.web.client.RestClient;
 @Configuration
 public class OpenAiConfig {
     @Value("${oepnai.api-key:}")
-    private String oepnAiApiKey;
+    private String openAiApiKey;
 
     @Bean(name = "openAiRestClient")
     public RestClient openAiRestClient() {
@@ -19,7 +19,7 @@ public class OpenAiConfig {
         return RestClient.builder()
                 .baseUrl("https://api.openai.com/v1")
                 .requestFactory(factory)
-                .defaultHeader("Authorization", "Bearer " + oepnAiApiKey)
+                .defaultHeader("Authorization", "Bearer " + openAiApiKey)
                 .build();
     }
 }

--- a/src/main/java/com/_penLearning/Noddi/global/infrastructure/openAi/OpenAiClient.java
+++ b/src/main/java/com/_penLearning/Noddi/global/infrastructure/openAi/OpenAiClient.java
@@ -25,7 +25,7 @@ import java.util.Map;
 public class OpenAiClient {
 
     @Qualifier("openAiRestClient")
-    private final RestClient restClient;
+    private final RestClient openAiRestClient;
 
     @SuppressWarnings("unchecked")
     public String transcribeAudio(String audioUrl) {
@@ -49,7 +49,7 @@ public class OpenAiClient {
             body.add("model", "whisper-1");
             body.add("language", "ko");
             // 5. 드디어 OpenAI 서버로 HTTP 요청을 쏩니다!
-            Map<String, Object> response = restClient.post()
+            Map<String, Object> response = openAiRestClient.post()
                     .uri("/audio/transcriptions")
                     .contentType(MediaType.MULTIPART_FORM_DATA)
                     .body(body)
@@ -71,7 +71,7 @@ public class OpenAiClient {
         log.info("[OpenAI ChatGPT] 회의록 JSON 요약 시작");
         try {
             //프롬포트 작성
-            String systemPrompt = "너는 비즈니스 회의 요약 전문가야. 제공되는 회의 대화록을 바탕으로 프론트엔드 UI에 직접 매핑될 수 있도록 반드시 완벽한 JSON 형식으로만 응답해줘. 다른 설명은 절대 덧붙이지 마.\n\n" +
+            String systemPrompt = "너는 비즈니스 회의 요약 전문가야. 제공되는 회의 대화록을 바탕으로 반드시 완벽한 JSON 형식으로만 응답해.\n\n" +
                     "【JSON 구조 필수 조건】\n" +
                     "{\n" +
                     "  \"summary\": \"회의 전체 핵심 요약 (3~4줄)\",\n" +
@@ -80,7 +80,7 @@ public class OpenAiClient {
                     "    { \"title\": \"이슈 내용\", \"status\": \"미해결/검토 중/완료 중 택 1\" }\n" +
                     "  ],\n" +
                     "  \"tasks\": [\n" +
-                    "    { \"assignee\": \"담당자 이름(없으면 미정)\", \"task\": \"할 일 내용\", \"deadline\": \"기한(MM/DD 형식, 모르면 미정)\", \"status\": \"대기/진행 중/완료 중 택 1\" }\n" +
+                    "    { \"assignee\": \"담당자 이름(없으면 미정)\", \"task\": \"할 일 내용\", \"deadline\": \"마감기한(반드시 YYYY-MM-DD 형식. 연도를 모르면 올해 연도 사용. 도저히 파악 불가면 문자열 \\\"null\\\")\" }\n" +
                     "  ]\n" +
                     "}";
             // 시스템 명령(system)과 사용자의 원문(user)을 묶어서 채팅 기록(messages)을 생성
@@ -96,7 +96,7 @@ public class OpenAiClient {
                     "response_format", Map.of("type", "json_object")
             );
             // OpenAI 챗봇 서버로 요청 (응답 대기 최대 2분)
-            Map<String, Object> response = restClient.post()
+            Map<String, Object> response = openAiRestClient.post()
                     .uri("/chat/completions")
                     .contentType(MediaType.APPLICATION_JSON)
                     .body(requestBody)

--- a/src/main/java/com/_penLearning/Noddi/global/infrastructure/openAi/OpenAiClient.java
+++ b/src/main/java/com/_penLearning/Noddi/global/infrastructure/openAi/OpenAiClient.java
@@ -1,0 +1,119 @@
+package com._penLearning.Noddi.global.infrastructure.openAi;
+
+import com._penLearning.Noddi.domain.meeting.code.MeetingErrorCode;
+import com._penLearning.Noddi.domain.summary.code.SummaryErrorCode;
+import com._penLearning.Noddi.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OpenAiClient {
+
+    @Qualifier("openAiRestClient")
+    private final RestClient restClient;
+
+    @SuppressWarnings("unchecked")
+    public String transcribeAudio(String audioUrl) {
+        log.info("[OpenAI Whisper] STT 변환 시작");
+        try {
+            URL url = new URI(audioUrl).toURL();
+            //실제 audio 데이터가 담길 바구니
+            byte[] audioBytes;
+
+            try (InputStream in = url.openStream()) {
+                audioBytes = in.readAllBytes(); // 빨대를 통해 모든 오디오 바이트 데이터를 RAM 메모리로 쭉 빨아들입니다!
+            }
+            // 메모리에 있는 바이트 데이터를 "recording.mp4"라는 이름을 가진 '가짜 실물 파일' 객체로 포장합니다.
+            ByteArrayResource audioResource = new ByteArrayResource(audioBytes) {
+                @Override
+                public String getFilename() { return "recording.mp4"; }
+            };
+            // 4. HTTP POST 요청에 보낼 Body(폼 데이터)를 박스에 차곡차곡 담습니다.
+            MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+            body.add("file", audioResource);
+            body.add("model", "whisper-1");
+            body.add("language", "ko");
+            // 5. 드디어 OpenAI 서버로 HTTP 요청을 쏩니다!
+            Map<String, Object> response = restClient.post()
+                    .uri("/audio/transcriptions")
+                    .contentType(MediaType.MULTIPART_FORM_DATA)
+                    .body(body)
+                    .retrieve()
+                    .body(Map.class);
+            // 응답에서 "text"라는 열쇠(Key)가 있으면, 그 안에 든 원문 문자열을 빼서 리턴
+            if (response != null && response.containsKey("text")) {
+                return (String) response.get("text");
+            }
+            throw new GeneralException(SummaryErrorCode.STT_PROCESSING_FAILED); // 만약 "text"가 없으면 에러를 냅니다.
+        } catch (Exception e) {
+            log.error("[OpenAI Whisper] STT 변환 실패", e);
+            throw new GeneralException(SummaryErrorCode.STT_PROCESSING_FAILED);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public String summarizeText(String rawTranscript) {
+        log.info("[OpenAI ChatGPT] 회의록 JSON 요약 시작");
+        try {
+            //프롬포트 작성
+            String systemPrompt = "너는 비즈니스 회의 요약 전문가야. 제공되는 회의 대화록을 바탕으로 프론트엔드 UI에 직접 매핑될 수 있도록 반드시 완벽한 JSON 형식으로만 응답해줘. 다른 설명은 절대 덧붙이지 마.\n\n" +
+                    "【JSON 구조 필수 조건】\n" +
+                    "{\n" +
+                    "  \"summary\": \"회의 전체 핵심 요약 (3~4줄)\",\n" +
+                    "  \"decisions\": [\"결정사항 1\", \"결정사항 2\"],\n" +
+                    "  \"issues\": [\n" +
+                    "    { \"title\": \"이슈 내용\", \"status\": \"미해결/검토 중/완료 중 택 1\" }\n" +
+                    "  ],\n" +
+                    "  \"tasks\": [\n" +
+                    "    { \"assignee\": \"담당자 이름(없으면 미정)\", \"task\": \"할 일 내용\", \"deadline\": \"기한(MM/DD 형식, 모르면 미정)\", \"status\": \"대기/진행 중/완료 중 택 1\" }\n" +
+                    "  ]\n" +
+                    "}";
+            // 시스템 명령(system)과 사용자의 원문(user)을 묶어서 채팅 기록(messages)을 생성
+            List<Map<String, String>> messages = List.of(
+                    Map.of("role", "system", "content", systemPrompt),
+                    Map.of("role", "user", "content", "다음 회의 대화록을 JSON으로 요약해줘:\n\n" + rawTranscript)
+            );
+            // ChatGPT에게 보낼 옵션들을 세팅
+            Map<String, Object> requestBody = Map.of(
+                    "model", "gpt-4o-mini", // 사용할 싸고 빠른 모델
+                    "messages", messages,
+                    "temperature", 0.3, // 창의성 수치 (낮을수록 보수적이고 정확한 요약을 함)
+                    "response_format", Map.of("type", "json_object")
+            );
+            // OpenAI 챗봇 서버로 요청 (응답 대기 최대 2분)
+            Map<String, Object> response = restClient.post()
+                    .uri("/chat/completions")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(requestBody)
+                    .retrieve()
+                    .body(Map.class);
+
+            if (response != null && response.containsKey("choices")) {
+                List<Map<String, Object>> choices = (List<Map<String, Object>>) response.get("choices");
+                if (!choices.isEmpty()) {
+                    Map<String, Object> message = (Map<String, Object>) choices.get(0).get("message");
+                    return (String) message.get("content");
+                }
+            }
+            throw new GeneralException(SummaryErrorCode.SUMMARY_PROCESSING_FAILED);
+        } catch (Exception e) {
+            log.error("[OpenAI ChatGPT] 요약 실패", e);
+            throw new GeneralException(SummaryErrorCode.SUMMARY_PROCESSING_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/global/infrastructure/openAi/OpenAiClient.java
+++ b/src/main/java/com/_penLearning/Noddi/global/infrastructure/openAi/OpenAiClient.java
@@ -3,6 +3,7 @@ package com._penLearning.Noddi.global.infrastructure.openAi;
 import com._penLearning.Noddi.domain.meeting.code.MeetingErrorCode;
 import com._penLearning.Noddi.domain.summary.code.SummaryErrorCode;
 import com._penLearning.Noddi.global.exception.GeneralException;
+import com._penLearning.Noddi.global.infrastructure.openAi.dto.OpenApiResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -11,6 +12,7 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestClient;
 
 import java.io.InputStream;
@@ -27,7 +29,6 @@ public class OpenAiClient {
     @Qualifier("openAiRestClient")
     private final RestClient openAiRestClient;
 
-    @SuppressWarnings("unchecked")
     public String transcribeAudio(String audioUrl) {
         log.info("[OpenAI Whisper] STT 변환 시작");
         try {
@@ -36,28 +37,28 @@ public class OpenAiClient {
             byte[] audioBytes;
 
             try (InputStream in = url.openStream()) {
-                audioBytes = in.readAllBytes(); // 빨대를 통해 모든 오디오 바이트 데이터를 RAM 메모리로 쭉 빨아들입니다!
+                audioBytes = in.readAllBytes();
             }
-            // 메모리에 있는 바이트 데이터를 "recording.mp4"라는 이름을 가진 '가짜 실물 파일' 객체로 포장합니다.
+            // 메모리에 있는 바이트 데이터를 "recording.mp4"라는 이름을 가진 '가짜 실물 파일' 객체로 포장
             ByteArrayResource audioResource = new ByteArrayResource(audioBytes) {
                 @Override
                 public String getFilename() { return "recording.mp4"; }
             };
-            // 4. HTTP POST 요청에 보낼 Body(폼 데이터)를 박스에 차곡차곡 담습니다.
+            // HTTP POST 요청에 보낼 Body(폼 데이터)를 박스 담음
             MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
             body.add("file", audioResource);
             body.add("model", "whisper-1");
             body.add("language", "ko");
-            // 5. 드디어 OpenAI 서버로 HTTP 요청을 쏩니다!
-            Map<String, Object> response = openAiRestClient.post()
+            // OpenAI 서버로 HTTP 요청
+            OpenApiResponseDto.Transcription response = openAiRestClient.post()
                     .uri("/audio/transcriptions")
                     .contentType(MediaType.MULTIPART_FORM_DATA)
                     .body(body)
                     .retrieve()
-                    .body(Map.class);
+                    .body(OpenApiResponseDto.Transcription.class);
             // 응답에서 "text"라는 열쇠(Key)가 있으면, 그 안에 든 원문 문자열을 빼서 리턴
-            if (response != null && response.containsKey("text")) {
-                return (String) response.get("text");
+            if (response != null && StringUtils.hasText(response.text())) {
+                return response.text();
             }
             throw new GeneralException(SummaryErrorCode.STT_PROCESSING_FAILED); // 만약 "text"가 없으면 에러를 냅니다.
         } catch (Exception e) {

--- a/src/main/java/com/_penLearning/Noddi/global/infrastructure/openAi/OpenAiClient.java
+++ b/src/main/java/com/_penLearning/Noddi/global/infrastructure/openAi/OpenAiClient.java
@@ -4,10 +4,10 @@ import com._penLearning.Noddi.domain.meeting.code.MeetingErrorCode;
 import com._penLearning.Noddi.domain.summary.code.SummaryErrorCode;
 import com._penLearning.Noddi.global.exception.GeneralException;
 import com._penLearning.Noddi.global.infrastructure.openAi.dto.OpenApiResponseDto;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.FileSystemResource;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
@@ -15,55 +15,155 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestClient;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.URI;
-import java.net.URL;
+import java.net.URLConnection;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class OpenAiClient {
 
-    @Qualifier("openAiRestClient")
+    // 다운로드할 때 한 번에 읽고 쓰는 데이터 크기다
+    private static final int DOWNLOAD_BUFFER_SIZE = 8 * 1024;
     private final RestClient openAiRestClient;
+    // OpenAI의 파일 전사 업로드 상한
+    private final long maxAudioFileSizeBytes;
+    // Daily 녹음 파일 서버와 TCP 연결이 만들어질 때까지 기다릴 최대 시간
+    private final int audioDownloadConnectTimeoutMs;
+    // 연결 이후 파일 데이터가 들어오지 않을 때 기다릴 최대 시간
+    private final int audioDownloadReadTimeoutMs;
+
+    public OpenAiClient(
+            @Qualifier("openAiRestClient")
+            RestClient openAiRestClient,
+            // 기본값은 OpenAI 공식 파일 전사 제한인 25,000,000 bytes
+            @Value("${openai.audio.max-file-size-bytes:25000000}")
+            long maxAudioFileSizeBytes,
+            // 다운로드 서버 연결이 10초 동안 만들어지지 않으면 실패 처리
+            @Value("${openai.audio.download-connect-timeout-ms:10000}")
+            int audioDownloadConnectTimeoutMs,
+            // 다운로드 도중 60초 동안 데이터가 들어오지 않으면 실패 처리
+            @Value("${openai.audio.download-read-timeout-ms:60000}")
+            int audioDownloadReadTimeoutMs
+    ) {
+        this.openAiRestClient = openAiRestClient;
+        this.maxAudioFileSizeBytes = maxAudioFileSizeBytes;
+        this.audioDownloadConnectTimeoutMs = audioDownloadConnectTimeoutMs;
+        this.audioDownloadReadTimeoutMs = audioDownloadReadTimeoutMs;
+    }
 
     public String transcribeAudio(String audioUrl) {
         log.info("[OpenAI Whisper] STT 변환 시작");
-        try {
-            URL url = new URI(audioUrl).toURL();
-            //실제 audio 데이터가 담길 바구니
-            byte[] audioBytes;
 
-            try (InputStream in = url.openStream()) {
-                audioBytes = in.readAllBytes();
-            }
-            // 메모리에 있는 바이트 데이터를 "recording.mp4"라는 이름을 가진 '가짜 실물 파일' 객체로 포장
-            ByteArrayResource audioResource = new ByteArrayResource(audioBytes) {
-                @Override
-                public String getFilename() { return "recording.mp4"; }
-            };
-            // HTTP POST 요청에 보낼 Body(폼 데이터)를 박스 담음
-            MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
-            body.add("file", audioResource);
-            body.add("model", "whisper-1");
-            body.add("language", "ko");
-            // OpenAI 서버로 HTTP 요청
-            OpenApiResponseDto.Transcription response = openAiRestClient.post()
-                    .uri("/audio/transcriptions")
-                    .contentType(MediaType.MULTIPART_FORM_DATA)
-                    .body(body)
-                    .retrieve()
-                    .body(OpenApiResponseDto.Transcription.class);
-            // 응답에서 "text"라는 열쇠(Key)가 있으면, 그 안에 든 원문 문자열을 빼서 리턴
-            if (response != null && StringUtils.hasText(response.text())) {
-                return response.text();
-            }
-            throw new GeneralException(SummaryErrorCode.STT_PROCESSING_FAILED); // 만약 "text"가 없으면 에러를 냅니다.
+        Path temporaryAudioFile = null;
+
+        try {
+            // 1단계: Daily 다운로드 URL의 녹음 파일을 서버의 임시 디렉터리에 스트리밍 방식으로 저장
+            temporaryAudioFile = downloadAudioToTemporaryFile(audioUrl);
+            // 2단계: 저장된 임시 파일을 multipart/form-data 요청으로 Whisper API에 전달
+            return requestWhisperTranscription(temporaryAudioFile);
         } catch (Exception e) {
             log.error("[OpenAI Whisper] STT 변환 실패", e);
             throw new GeneralException(SummaryErrorCode.STT_PROCESSING_FAILED);
+        } finally {
+            // 성공과 실패 여부에 상관없이 다운로드한 녹음 파일을 서버 디스크에서 삭제
+            deleteTemporaryFile(temporaryAudioFile);
+        }
+    }
+
+    private Path downloadAudioToTemporaryFile(String audioUrl) throws Exception {
+        URI audioUri = new URI(audioUrl);
+
+        // 외부에서 전달된 file:// 등의 주소로 서버 내부 파일을 읽지 못하도록 HTTPS 주소만 허용
+        if (!"https".equalsIgnoreCase(audioUri.getScheme())) {
+            throw new IOException("녹음 파일 다운로드 URL은 HTTPS 형식이어야 합니다.");
+        }
+
+        URLConnection connection = audioUri.toURL().openConnection();
+        connection.setConnectTimeout(audioDownloadConnectTimeoutMs);
+        connection.setReadTimeout(audioDownloadReadTimeoutMs);
+
+        // 서버가 Content-Length를 제공했다면 실제 다운로드 전에 파일이 너무 큰지 빠르게 확인
+        long declaredFileSize = connection.getContentLengthLong();
+        if (declaredFileSize > maxAudioFileSizeBytes) {
+            throw new IOException("녹음 파일이 허용 크기를 초과했습니다. size=" + declaredFileSize);
+        }
+
+        // 운영체제의 임시 디렉터리에 저장될 파일을 만든다.
+        Path temporaryFile = Files.createTempFile("noddi-recording-", ".mp4");
+        // 다운로드 도중 실패한 경우 불완전한 임시 파일을 삭제하기 위한 완료 여부 표시
+        boolean downloadCompleted = false;
+
+        try (
+                InputStream inputStream = connection.getInputStream();
+                OutputStream outputStream = Files.newOutputStream(temporaryFile)
+        ) {
+            // 매 반복마다 최대 8KB만 메모리에 올라오는 작은 버퍼
+            byte[] buffer = new byte[DOWNLOAD_BUFFER_SIZE];
+            long downloadedBytes = 0L;
+            int bytesRead;
+
+            // 파일 끝에 도달하면 read()가 -1을 반환하므로 그때 반복을 종료
+            while ((bytesRead = inputStream.read(buffer)) != -1) {
+                // 현재까지 받은 크기에 이번에 받은 크기를 더한다.
+                downloadedBytes += bytesRead;
+                // 실제 다운로드 크기가 제한을 넘는 즉시 중단해 디스크와 OpenAI 업로드를 보호한다.
+                if (downloadedBytes > maxAudioFileSizeBytes) {
+                    throw new IOException("녹음 파일이 허용 크기를 초과했습니다. size>" + maxAudioFileSizeBytes);
+                }
+                outputStream.write(buffer, 0, bytesRead);
+            }
+            downloadCompleted = true;
+            return temporaryFile;
+        } finally {
+            // 다운로드가 중간에 실패했다면 호출자에게 경로가 반환되지 않으므로 여기서 직접 삭제
+            if (!downloadCompleted) {
+                Files.deleteIfExists(temporaryFile);
+            }
+        }
+    }
+
+    private String requestWhisperTranscription(Path audioFile) {
+        // FileSystemResource는 디스크 파일을 multipart의 file 항목으로 전달할 수 있게 포장
+        FileSystemResource audioResource = new FileSystemResource(audioFile);
+        MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+
+        body.add("file", audioResource);
+        body.add("model", "whisper-1");
+        body.add("language", "ko");
+
+        OpenApiResponseDto.Transcription response = openAiRestClient.post()
+                .uri("/audio/transcriptions")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(body)
+                .retrieve()
+                .body(OpenApiResponseDto.Transcription.class);
+
+        if (response != null && StringUtils.hasText(response.text())) {
+            return response.text();
+        }
+
+        throw new GeneralException(SummaryErrorCode.STT_PROCESSING_FAILED);
+    }
+
+    private void deleteTemporaryFile(Path temporaryAudioFile) {
+        // 다운로드 전에 실패해 파일이 생성되지 않았다면 삭제할 것이 없으므로 바로 종료
+        if (temporaryAudioFile == null) {
+            return;
+        }
+
+        try {
+            // 파일이 존재할 때만 삭제하고, 이미 없어진 경우에는 정상적으로 진행
+            Files.deleteIfExists(temporaryAudioFile);
+        } catch (IOException e) {
+            // 전사는 끝났으므로 삭제 실패가 전체 STT 결과를 실패시키지는 않게 하고 로그로 추적
+            log.warn("[OpenAI Whisper] 임시 녹음 파일 삭제 실패. path={}", temporaryAudioFile, e);
         }
     }
 

--- a/src/main/java/com/_penLearning/Noddi/global/infrastructure/openAi/dto/OpenApiResponseDto.java
+++ b/src/main/java/com/_penLearning/Noddi/global/infrastructure/openAi/dto/OpenApiResponseDto.java
@@ -1,0 +1,10 @@
+package com._penLearning.Noddi.global.infrastructure.openAi.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+public class OpenApiResponseDto {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Transcription(String text) {
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/global/infrastructure/webRtc/DailyCoWebRtcClient.java
+++ b/src/main/java/com/_penLearning/Noddi/global/infrastructure/webRtc/DailyCoWebRtcClient.java
@@ -19,7 +19,7 @@ import java.util.UUID;
 public class DailyCoWebRtcClient implements WebRtcClient{
 
     @Qualifier("dailyRestClient")
-    private final RestClient restClient;
+    private final RestClient dailyRestClient;
 
     @Override
     public String createRoom() {
@@ -29,7 +29,7 @@ public class DailyCoWebRtcClient implements WebRtcClient{
         //현재 시각 + 10분(600초) 후 Unix Timestamp(초 단위) 계산
         long exp = (System.currentTimeMillis() / 1000) + 600;
         try {
-            DailyCreateRoomResponseDto response = restClient.post()
+            DailyCreateRoomResponseDto response = dailyRestClient.post()
                     .uri("/rooms")
                     .body(Map.of(
                             "name", roomName,
@@ -62,7 +62,7 @@ public class DailyCoWebRtcClient implements WebRtcClient{
      */
     public String getRecordingAccessLink(String recordingId) {
         try {
-            DailyAccessLinkResponseDto response = restClient.get()
+            DailyAccessLinkResponseDto response = dailyRestClient.get()
                     .uri("/recordings/{recordingId}/access-link", recordingId)
                     .retrieve()
                     .body(DailyAccessLinkResponseDto.class);
@@ -79,7 +79,7 @@ public class DailyCoWebRtcClient implements WebRtcClient{
 
     @Override
     public void deleteRoom(String roomName) {
-        restClient.delete()
+        dailyRestClient.delete()
                 .uri("/rooms/{roomName}", roomName)
                 .retrieve()
                 .toBodilessEntity();

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -55,3 +55,6 @@ daily:
 
 springdoc:
   use-fqn: true #스웨거 클래스명 충돌 방지
+
+openai:
+  api-key: ${OPENAI_API_KEY}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -58,3 +58,10 @@ springdoc:
 
 openai:
   api-key: ${OPENAI_API_KEY}
+  audio:
+    # OpenAI 파일 전사 API의 25MB 업로드 제한을 넘기기 전에 백엔드에서 다운로드를 중단한다.
+    max-file-size-bytes: ${OPENAI_AUDIO_MAX_FILE_SIZE_BYTES:25000000}
+    # Daily 녹음 파일 서버와 연결이 만들어질 때까지 기다리는 최대 시간(ms)이다.
+    download-connect-timeout-ms: ${OPENAI_AUDIO_DOWNLOAD_CONNECT_TIMEOUT_MS:10000}
+    # 연결 이후 파일 데이터 수신이 멈췄을 때 기다리는 최대 시간(ms)이다.
+    download-read-timeout-ms: ${OPENAI_AUDIO_DOWNLOAD_READ_TIMEOUT_MS:60000}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -33,3 +33,5 @@ daily:
     key: test-daily-key
   webhook:
     secret: test-webhook-secret
+openai:
+  api-key: ${OPENAI_API_KEY:test-openai-key}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -35,3 +35,8 @@ daily:
     secret: test-webhook-secret
 openai:
   api-key: ${OPENAI_API_KEY:test-openai-key}
+  audio:
+    # 운영 설정과 같은 기본값을 사용해 테스트 컨텍스트에서도 설정 주입 여부를 확인한다.
+    max-file-size-bytes: 25000000
+    download-connect-timeout-ms: 10000
+    download-read-timeout-ms: 60000


### PR DESCRIPTION
## <i>PULL REQUEST</i>

## 🎋 작업 브랜치
- feat/#18-transcript -> develop
- #18  (관련이슈 번호)

## 💡 작업동기
- Whisper Api를 연동하고 데일리코 녹음 파일을 통해 정상적으로 전사되는 것까지 확인합니다

## 🔑 주요 변경사항
- OpenAI Whisper API 연동 및 한국어 음성 전사 기능 구현
- Daily 녹음 다운로드 URL을 통해 음성 파일을 서버 임시 파일로 스트리밍하도록 구현
- 녹음 파일 전체를 메모리에 적재하지 않도록 개선
- OpenAI 업로드 제한에 맞춰 최대 파일 크기를 25MB로 제한
- 녹음 파일 다운로드 연결 및 읽기 타임아웃 설정
- Whisper 요청 로직을 별도 메서드로 분리하고 전사 응답 DTO 적용
- STT 처리 성공·실패 여부와 관계없이 임시 파일이 삭제되도록 처리
- 실제 Daily 녹음본을 이용해 Whisper API 연동 및 한국어 전사 결과 확인

## 🏞 스크린샷 (선택)
> 스크린샷을 첨부해주세요.

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
