### PR TITLE
[Feat] 요약 요청/DB 저장 로직 자동화 및 요약 재요청 API 구현

### DIFF
--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/code/MeetingApi.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/code/MeetingApi.java
@@ -154,23 +154,44 @@ public interface MeetingApi {
             @AuthenticationPrincipal AuthMember authMember
     );
 
-    @Operation(summary = "AI 요약 트리거", description = "녹음본이 준비된 종료된 회의에 대해 AI 요약을 수동으로 요청합니다.")
+    @Operation(
+            summary = "AI 회의록 재시도",
+            description = "AI 회의록 생성에 실패한 회의를 다시 처리합니다."
+    )
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "AI 요약 요청 접수 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "AI 회의록 재시도 접수 성공"
+            ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "400",
-                    description = "녹음본 미준비 또는 잘못된 회의 상태",
-                    content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+                    description = "FAILED 상태가 아니거나 녹음본이 준비되지 않음",
+                    content = @Content(
+                            schema = @Schema(
+                                    implementation = ApiResponse.class
+                            )
+                    )
+            ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "403",
-                    description = "해당 팀의 팀원이 아님",
-                    content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+                    description = "해당 회의 팀원이 아님",
+                    content = @Content(
+                            schema = @Schema(
+                                    implementation = ApiResponse.class
+                            )
+                    )
+            ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "404",
                     description = "회의를 찾을 수 없음",
-                    content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+                    content = @Content(
+                            schema = @Schema(
+                                    implementation = ApiResponse.class
+                            )
+                    )
+            )
     })
-    ApiResponse<Void> triggerSummary(
+    ApiResponse<Void> retrySummary(
             Long meetingId,
             @AuthenticationPrincipal AuthMember authMember
     );

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/code/MeetingErrorCode.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/code/MeetingErrorCode.java
@@ -12,8 +12,7 @@ import org.springframework.http.HttpStatus;
 public enum MeetingErrorCode implements BaseErrorCode {
     INVALID_STATUS_FOR_START(HttpStatus.BAD_REQUEST, "MEETING400_1", "예약(SCHEDULED) 상태인 회의만 시작할 수 있습니다."),
     INVALID_STATUS_FOR_END(HttpStatus.BAD_REQUEST, "MEETING400_2", "진행 중(IN_PROGRESS)인 회의만 종료할 수 있습니다."),
-    INVALID_STATUS_FOR_SUMMARY(HttpStatus.BAD_REQUEST, "MEETING400_3", "종료된(ENDED) 회의만 AI 요약을 요청할 수 있습니다."),
-    ALREADY_PROCESSING_SUMMARY(HttpStatus.BAD_REQUEST, "MEETING400_4", "이미 AI 요약이 진행 중이거나 완료된 회의입니다."),
+    AI_RETRY_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "MEETING400_3", "실패(FAILED) 상태인 AI 회의록만 재시도할 수 있습니다."),
     RECORDING_NOT_READY(HttpStatus.BAD_REQUEST, "MEETING400_5", "녹음본 파일이 아직 인코딩 중입니다. 잠시 후 다시 시도해 주세요."),
     // 403 Forbidden: 해당 팀원이 아닌 경우
     NOT_TEAM_MEMBER(HttpStatus.FORBIDDEN, "MEETING403_1", "해당 팀의 팀원만 회의에 접근할 수 있습니다."),

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/controller/MeetingController.java
@@ -78,10 +78,12 @@ public class MeetingController implements MeetingApi {
     }
 
     @Override
-    @PostMapping("/{meetingId}/summary")
-    public ApiResponse<Void> triggerSummary(
+    @PostMapping("/{meetingId}/summary/retry")
+    public ApiResponse<Void> retrySummary(
             @PathVariable Long meetingId, @AuthenticationPrincipal AuthMember authMember) {
-        meetingService.triggerSummary(meetingId, authMember.getUserId());
-        return ApiResponse.onSuccess("AI 요약 요청이 접수되었습니다. 잠시 후 결과를 확인해 주세요.");
+        meetingService.retrySummary(meetingId, authMember.getUserId());
+        return ApiResponse.onSuccess(
+                "AI 회의록 재처리를 시작했습니다."
+        );
     }
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/entity/Meeting.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/entity/Meeting.java
@@ -45,6 +45,7 @@ public class Meeting extends BaseEntity {
 
     private LocalDateTime startedAt;
     private LocalDateTime endedAt;
+    private LocalDateTime aiProcessingStartedAt;
 
     //webRTC 방 ID LAZY 방식으로 주입(회의 시작 버튼을 눌러야 회의가 열림)
     private String roomName;
@@ -95,6 +96,7 @@ public class Meeting extends BaseEntity {
         }
         //회의 종료와 녹음 준비가 모두 완료되었고 PENDING 상태일 때만 변경
         this.aiStatus = AiStatus.PROCESSING;
+        this.aiProcessingStartedAt = LocalDateTime.now();
         return true;
     }
 
@@ -112,6 +114,7 @@ public class Meeting extends BaseEntity {
             throw new GeneralException(MeetingErrorCode.AI_RETRY_NOT_ALLOWED);
         }
         this.aiStatus = AiStatus.PROCESSING;
+        this.aiProcessingStartedAt = LocalDateTime.now();
     }
 
     public void completeAiProcessing() {

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/entity/Meeting.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/entity/Meeting.java
@@ -108,7 +108,7 @@ public class Meeting extends BaseEntity {
         }
         this.aiStatus = AiStatus.PROCESSING;
     }
-    public void completeAiProcessing(String transcriptText) {
+    public void completeAiProcessing() {
         this.aiStatus = AiStatus.COMPLETED;
     }
 

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/entity/Meeting.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/entity/Meeting.java
@@ -99,15 +99,21 @@ public class Meeting extends BaseEntity {
     }
 
     //Ai 요약 관련 메소드
-    public void startAiProcessing() {
+    public void retryAiProcessing() {
         if (this.status != MeetingStatus.ENDED) {
-            throw new GeneralException(MeetingErrorCode.INVALID_STATUS_FOR_SUMMARY);
+            throw new GeneralException(MeetingErrorCode.AI_RETRY_NOT_ALLOWED);
         }
+
         if (this.recordingId == null) {
             throw new GeneralException(MeetingErrorCode.RECORDING_NOT_READY);
         }
+
+        if (this.aiStatus != AiStatus.FAILED) {
+            throw new GeneralException(MeetingErrorCode.AI_RETRY_NOT_ALLOWED);
+        }
         this.aiStatus = AiStatus.PROCESSING;
     }
+
     public void completeAiProcessing() {
         this.aiStatus = AiStatus.COMPLETED;
     }

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/entity/Meeting.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/entity/Meeting.java
@@ -83,6 +83,20 @@ public class Meeting extends BaseEntity {
         this.recordingId = recordingId;
     }
 
+    public boolean tryStartAiProcessing() {
+        if (this.status != MeetingStatus.ENDED) {
+            return false;
+        }
+        if (this.recordingId == null) {
+            return false;
+        }
+        if (this.aiStatus != AiStatus.PENDING) {
+            return false;
+        }
+        //회의 종료와 녹음 준비가 모두 완료되었고 PENDING 상태일 때만 변경
+        this.aiStatus = AiStatus.PROCESSING;
+        return true;
+    }
 
     //Ai 요약 관련 메소드
     public void startAiProcessing() {

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/event/MeetingAiProcessingRequestedEvent.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/event/MeetingAiProcessingRequestedEvent.java
@@ -1,0 +1,4 @@
+package com._penLearning.Noddi.domain.meeting.event;
+
+public record MeetingAiProcessingRequestedEvent(Long meetingId) {
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/repository/MeetingRepository.java
@@ -23,4 +23,9 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
     Optional<Meeting> findByIdWithPessimisticLock(@Param("meetingId") Long meetingId);
     List<Meeting> findAllByTeam(Team team);
     Optional<Meeting> findByRoomName(String roomName);
+
+     //Daily 웹훅 처리 중 동일 회의를 동시에 수정하지 못하도록 잠금을 건다.
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT m FROM Meeting m WHERE m.roomName = :roomName")
+    Optional<Meeting> findByRoomNameWithPessimisticLock(@Param("roomName") String roomName);
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/repository/MeetingRepository.java
@@ -1,13 +1,16 @@
 package com._penLearning.Noddi.domain.meeting.repository;
 
+import com._penLearning.Noddi.domain.meeting.code.AiStatus;
 import com._penLearning.Noddi.domain.meeting.entity.Meeting;
 import com._penLearning.Noddi.domain.team.entity.Team;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -28,4 +31,12 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT m FROM Meeting m WHERE m.roomName = :roomName")
     Optional<Meeting> findByRoomNameWithPessimisticLock(@Param("roomName") String roomName);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE Meeting m SET m.aiStatus = :failedStatus WHERE m.aiStatus = :processingStatus AND m.aiProcessingStartedAt < :threshold")
+    int failStuckAiProcessing(
+            @Param("threshold") LocalDateTime threshold,
+            @Param("processingStatus") AiStatus processingStatus,
+            @Param("failedStatus") AiStatus failedStatus
+    );
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/scheduler/MeetingAiRecoveryScheduler.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/scheduler/MeetingAiRecoveryScheduler.java
@@ -1,0 +1,47 @@
+package com._penLearning.Noddi.domain.meeting.scheduler;
+
+import com._penLearning.Noddi.domain.meeting.code.AiStatus;
+import com._penLearning.Noddi.domain.meeting.repository.MeetingRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MeetingAiRecoveryScheduler {
+
+    private final MeetingRepository meetingRepository;
+
+    @Value("${scheduler.meeting-ai.processing-timeout-minutes:30}")
+    private long processingTimeoutMinutes;
+
+    @Scheduled(
+            cron = "${scheduler.meeting-ai.recovery-cron:0 */5 * * * *}",
+            zone = "${scheduler.meeting-ai.zone:Asia/Seoul}"
+    )
+    @Transactional
+    public void failStuckProcessingMeetings() {
+        LocalDateTime threshold = LocalDateTime.now()
+                .minusMinutes(processingTimeoutMinutes);
+
+        int recoveredCount = meetingRepository.failStuckAiProcessing(
+                threshold,
+                AiStatus.PROCESSING,
+                AiStatus.FAILED
+        );
+
+        if (recoveredCount > 0) {
+            log.warn(
+                    "[MeetingAiRecoveryScheduler] 제한 시간({}분)을 초과한 AI 작업 {}건을 FAILED로 변경했습니다.",
+                    processingTimeoutMinutes,
+                    recoveredCount
+            );
+        }
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingAiProcessingService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingAiProcessingService.java
@@ -5,7 +5,10 @@ import com._penLearning.Noddi.domain.meeting.entity.Meeting;
 import com._penLearning.Noddi.domain.meeting.event.MeetingAiProcessingRequestedEvent;
 import com._penLearning.Noddi.domain.meeting.repository.MeetingRepository;
 import com._penLearning.Noddi.domain.team.repository.TeamMemberRepository;
+import com._penLearning.Noddi.global.infrastructure.openAi.OpenAiClient;
 import com._penLearning.Noddi.global.infrastructure.openAi.dto.OpenAiRequestDto;
+import com._penLearning.Noddi.global.infrastructure.openAi.dto.OpenAiResponseDto;
+import com._penLearning.Noddi.global.infrastructure.webRtc.WebRtcClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
@@ -14,6 +17,7 @@ import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.transaction.support.TransactionTemplate;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Slf4j
@@ -24,24 +28,62 @@ public class MeetingAiProcessingService {
     private final MeetingRepository meetingRepository;
     private final TeamMemberRepository teamMemberRepository;
     private final TransactionTemplate transactionTemplate;
+    private final WebRtcClient webRtcClient;
+    private final OpenAiClient openAiClient;
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void processAfterCommit(MeetingAiProcessingRequestedEvent event) {
 
+        Long meetingId = event.meetingId();
         log.info("[MeetingAiProcessingService] AI 회의록 자동 생성 시작: meetingId={}", event.meetingId());
-        ProcessingContext context = loadProcessingContext(event.meetingId());
 
-        if (context == null) {
-            return;
+        try{
+            ProcessingContext context = loadProcessingContext(event.meetingId());
+
+            if (context == null) {
+                return;
+            }
+            log.info(
+                    "[MeetingAiProcessingService] AI 처리 데이터 조회 완료: meetingId={}, recordingId={}, teamMemberCount={}",
+                    event.meetingId(),
+                    context.recordingId(),
+                    context.teamMembers().size()
+            );
+
+            String recordingAccessLink = webRtcClient.getRecordingAccessLink(context.recordingId());
+            log.info(
+                    "[MeetingAiProcessingService] 녹음 다운로드 URL 발급 완료: meetingId={}",
+                    meetingId
+            );
+
+            String rawTranscript = openAiClient.transcribeAudio(recordingAccessLink);
+            log.info(
+                    "[MeetingAiProcessingService] 회의 음성 전사 완료: meetingId={}, transcriptLength={}",
+                    meetingId,
+                    rawTranscript.length()
+            );
+
+            OpenAiResponseDto.MeetingSummary aiResult = openAiClient.summarizeText(
+                    rawTranscript,
+                    LocalDate.now(),
+                    context.teamMembers()
+            );
+            log.info(
+                    "[MeetingAiProcessingService] 회의 구조화 요약 완료: meetingId={}, actionItemCount={}",
+                    meetingId,
+                    aiResult.actionItems().size()
+            );
+
+        }catch (Exception e) {
+            log.error(
+                    "[MeetingAiProcessingService] AI 회의록 자동 생성 실패: meetingId={}",
+                    meetingId,
+                    e
+            );
+            markAiProcessingFailed(meetingId);
         }
 
-        log.info(
-                "[MeetingAiProcessingService] AI 처리 데이터 조회 완료: meetingId={}, recordingId={}, teamMemberCount={}",
-                event.meetingId(),
-                context.recordingId(),
-                context.teamMembers().size()
-        );
     }
 
     private ProcessingContext loadProcessingContext(Long meetingId)
@@ -82,7 +124,26 @@ public class MeetingAiProcessingService {
         });
     }
 
-    private record ProcessingContext(String recordingId, List<OpenAiRequestDto.TeamMember> teamMembers) {
+    private void markAiProcessingFailed(Long meetingId) {
+        try{
+            transactionTemplate.executeWithoutResult(status -> {
+                meetingRepository.findByIdWithPessimisticLock(meetingId)
+                        .ifPresent(meeting -> {
+                            //완료되지 않은 결과만 덮음
+                            if (meeting.getAiStatus() == AiStatus.PROCESSING) {
+                                meeting.failAiProcessing();
+                            }
+                        });
+            });
+        }catch (Exception statusUpdateException) {
+            log.error(
+                    "[MeetingAiProcessingService] AI 실패 상태 저장 실패: meetingId={}",
+                    meetingId,
+                    statusUpdateException
+            );
+        }
     }
 
+    private record ProcessingContext(String recordingId, List<OpenAiRequestDto.TeamMember> teamMembers) {
+    }
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingAiProcessingService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingAiProcessingService.java
@@ -1,0 +1,88 @@
+package com._penLearning.Noddi.domain.meeting.service;
+
+import com._penLearning.Noddi.domain.meeting.code.AiStatus;
+import com._penLearning.Noddi.domain.meeting.entity.Meeting;
+import com._penLearning.Noddi.domain.meeting.event.MeetingAiProcessingRequestedEvent;
+import com._penLearning.Noddi.domain.meeting.repository.MeetingRepository;
+import com._penLearning.Noddi.domain.team.repository.TeamMemberRepository;
+import com._penLearning.Noddi.global.infrastructure.openAi.dto.OpenAiRequestDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MeetingAiProcessingService {
+
+    private final MeetingRepository meetingRepository;
+    private final TeamMemberRepository teamMemberRepository;
+    private final TransactionTemplate transactionTemplate;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void processAfterCommit(MeetingAiProcessingRequestedEvent event) {
+
+        log.info("[MeetingAiProcessingService] AI 회의록 자동 생성 시작: meetingId={}", event.meetingId());
+        ProcessingContext context = loadProcessingContext(event.meetingId());
+
+        if (context == null) {
+            return;
+        }
+
+        log.info(
+                "[MeetingAiProcessingService] AI 처리 데이터 조회 완료: meetingId={}, recordingId={}, teamMemberCount={}",
+                event.meetingId(),
+                context.recordingId(),
+                context.teamMembers().size()
+        );
+    }
+
+    private ProcessingContext loadProcessingContext(Long meetingId)
+    {
+        return transactionTemplate.execute(status -> {
+            Meeting meeting = meetingRepository.findById(meetingId)
+                    .orElse(null);
+
+            // 이벤트 실행 시점에 회의가 삭제된 경우 작업을 중단
+            if (meeting == null) {
+                log.warn("[MeetingAiProcessingService] 회의를 찾을 수 없어 AI 처리를 중단합니다: meetingId={}", meetingId);
+                return null;
+            }
+
+            // 중복되거나 오래된 이벤트라면 외부 API를 호출하지 않는다.
+            if (meeting.getAiStatus() != AiStatus.PROCESSING) {
+                log.info("[MeetingAiProcessingService] AI 처리 대상 상태가 아닙니다: meetingId={}, aiStatus={}", meetingId, meeting.getAiStatus());
+                return null;
+            }
+
+            // 해당 회의 참석자가 아니라 회의가 속한 팀의 전체 팀원을 전달
+            List<OpenAiRequestDto.TeamMember> teamMembers =
+                    teamMemberRepository
+                            .findAllByTeamWithUser(meeting.getTeam())
+                            .stream()
+                            .map(teamMember ->
+                                    new OpenAiRequestDto.TeamMember(
+                                            teamMember.getUser().getUserId(),
+                                            teamMember.getUser().getName()
+                                    )
+                            )
+                            .toList();
+
+            return new ProcessingContext(
+                    meeting.getRecordingId(),
+                    teamMembers
+            );
+        });
+    }
+
+    private record ProcessingContext(String recordingId, List<OpenAiRequestDto.TeamMember> teamMembers) {
+    }
+
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingAiProcessingService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingAiProcessingService.java
@@ -18,7 +18,6 @@ import com._penLearning.Noddi.global.infrastructure.openAi.OpenAiClient;
 import com._penLearning.Noddi.global.infrastructure.openAi.dto.OpenAiRequestDto;
 import com._penLearning.Noddi.global.infrastructure.openAi.dto.OpenAiResponseDto;
 import com._penLearning.Noddi.global.infrastructure.webRtc.WebRtcClient;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
@@ -85,7 +84,7 @@ public class MeetingAiProcessingService {
                     LocalDate.now(),
                     context.teamMembers()
             );
-            int actionItemCount = aiResult.actionItems() != null ? 0 : aiResult.actionItems().size();
+            int actionItemCount = aiResult.actionItems() == null ? 0 : aiResult.actionItems().size();
             log.info(
                     "[MeetingAiProcessingService] 회의 구조화 요약 완료: meetingId={}, actionItemCount={}",
                     meetingId,
@@ -199,6 +198,7 @@ public class MeetingAiProcessingService {
                     .orElseThrow(() -> new GeneralException(MeetingErrorCode.MEETING_NOT_FOUND));
 
             if (meetingSummaryRepository.findByMeeting_MeetingId(meetingId).isPresent()) {
+                meeting.completeAiProcessing();
                 return;
             }
 

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingAiProcessingService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingAiProcessingService.java
@@ -1,14 +1,24 @@
 package com._penLearning.Noddi.domain.meeting.service;
 
 import com._penLearning.Noddi.domain.meeting.code.AiStatus;
+import com._penLearning.Noddi.domain.meeting.code.MeetingErrorCode;
 import com._penLearning.Noddi.domain.meeting.entity.Meeting;
 import com._penLearning.Noddi.domain.meeting.event.MeetingAiProcessingRequestedEvent;
 import com._penLearning.Noddi.domain.meeting.repository.MeetingRepository;
+import com._penLearning.Noddi.domain.summary.code.SummaryErrorCode;
+import com._penLearning.Noddi.domain.summary.entity.ActionItem;
+import com._penLearning.Noddi.domain.summary.entity.MeetingSummary;
+import com._penLearning.Noddi.domain.summary.repository.ActionItemRepository;
+import com._penLearning.Noddi.domain.summary.repository.MeetingSummaryRepository;
+import com._penLearning.Noddi.domain.team.entity.TeamMember;
 import com._penLearning.Noddi.domain.team.repository.TeamMemberRepository;
+import com._penLearning.Noddi.domain.user.entity.User;
+import com._penLearning.Noddi.global.exception.GeneralException;
 import com._penLearning.Noddi.global.infrastructure.openAi.OpenAiClient;
 import com._penLearning.Noddi.global.infrastructure.openAi.dto.OpenAiRequestDto;
 import com._penLearning.Noddi.global.infrastructure.openAi.dto.OpenAiResponseDto;
 import com._penLearning.Noddi.global.infrastructure.webRtc.WebRtcClient;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
@@ -16,9 +26,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.util.StringUtils;
 
 import java.time.LocalDate;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 @Slf4j
 @Service
@@ -30,6 +44,8 @@ public class MeetingAiProcessingService {
     private final TransactionTemplate transactionTemplate;
     private final WebRtcClient webRtcClient;
     private final OpenAiClient openAiClient;
+    private final MeetingSummaryRepository meetingSummaryRepository;
+    private final ActionItemRepository actionItemRepository;
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
@@ -69,10 +85,16 @@ public class MeetingAiProcessingService {
                     LocalDate.now(),
                     context.teamMembers()
             );
+            int actionItemCount = aiResult.actionItems() != null ? 0 : aiResult.actionItems().size();
             log.info(
                     "[MeetingAiProcessingService] 회의 구조화 요약 완료: meetingId={}, actionItemCount={}",
                     meetingId,
-                    aiResult.actionItems().size()
+                    actionItemCount
+            );
+            saveResultAtomically(meetingId, rawTranscript, aiResult);
+            log.info(
+                    "[MeetingAiProcessingService] AI 회의록 DB 저장 완료: meetingId={}",
+                    meetingId
             );
 
         }catch (Exception e) {
@@ -142,6 +164,72 @@ public class MeetingAiProcessingService {
                     statusUpdateException
             );
         }
+    }
+
+    /**
+     * AI ActionItem을 DB 엔티티로 변환
+     * AI가 반환한 담당자는 현재 팀원 정보와 다시 비교하고,
+     * ID와 이름이 모두 정확히 일치할 때만 실제 사용자와 연결한다.
+     */
+    private ActionItem toActionItem(MeetingSummary meetingSummary, OpenAiResponseDto.ActionItem aiActionItem, Map<Long, User> teamUserById) {
+        User matchedUser = teamUserById.get(aiActionItem.assigneeUserId());
+        boolean isExactAssignee =
+                matchedUser != null
+                        && Objects.equals(matchedUser.getName(), aiActionItem.assigneeName())
+                        && !aiActionItem.isUncertain();
+        User assignee = isExactAssignee ? matchedUser : null;
+        boolean isUncertain = !isExactAssignee;
+
+        if(!StringUtils.hasText(aiActionItem.content())) {
+            throw new GeneralException(SummaryErrorCode.SUMMARY_PROCESSING_FAILED);
+        }
+
+        return ActionItem.builder()
+                .meetingSummary(meetingSummary)
+                .assignee(assignee)
+                .content(aiActionItem.content())
+                .isUncertain(isUncertain)
+                .dueDate(aiActionItem.dueDate())
+                .build();
+    }
+    //MeetingSummary와 ActionItem을 하나의 트랜잭션에서 저장
+    private void saveResultAtomically(Long meetingId, String rawTranscript, OpenAiResponseDto.MeetingSummary aiResult) {
+        transactionTemplate.executeWithoutResult(status -> {
+            Meeting meeting = meetingRepository.findByIdWithPessimisticLock(meetingId)
+                    .orElseThrow(() -> new GeneralException(MeetingErrorCode.MEETING_NOT_FOUND));
+
+            if (meetingSummaryRepository.findByMeeting_MeetingId(meetingId).isPresent()) {
+                return;
+            }
+
+            if (meeting.getAiStatus() != AiStatus.PROCESSING) {
+                throw new GeneralException(SummaryErrorCode.SUMMARY_PROCESSING_FAILED);
+            }
+            MeetingSummary meetingSummary = MeetingSummary.builder()
+                    .meeting(meeting)
+                    .summaryText(aiResult.summary())
+                    .decisions(aiResult.decisions())
+                    .issues(aiResult.issues())
+                    .rawTranscript(rawTranscript)
+                    .build();
+            meetingSummaryRepository.save(meetingSummary);
+
+            Map<Long,User> teamUsersById = new LinkedHashMap<>();
+
+            for (TeamMember teamMember : teamMemberRepository.findAllByTeamWithUser(meeting.getTeam())) {
+                User user = teamMember.getUser();
+                teamUsersById.put(user.getUserId(), user);
+            }
+            // AI가 ActionItem 목록을 null로 반환해도 빈 목록으로 저장
+            List<OpenAiResponseDto.ActionItem> aiActionItems = aiResult.actionItems() != null ? aiResult.actionItems() : List.of();
+
+            //Ai ActionItem을 검증하면서 엔티티로 변환
+            List<ActionItem> actionItems = aiActionItems.stream()
+                    .map(aiActionItem -> toActionItem(meetingSummary, aiActionItem, teamUsersById))
+                    .toList();
+            actionItemRepository.saveAll(actionItems);
+            meeting.completeAiProcessing();
+        });
     }
 
     private record ProcessingContext(String recordingId, List<OpenAiRequestDto.TeamMember> teamMembers) {

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingService.java
@@ -194,7 +194,7 @@ public class MeetingService {
 
         //FAILED 상태인지 확인하고 PROCESSING으로 변경
         meeting.retryAiProcessing();
-        publishAiProcessingEventIfReady(meeting);
+        publishAiProcessingEvent(meeting);
         log.info(
                 "[MeetingService] AI 회의록 재시도 요청: meetingId={}, requestedBy={}",
                 meetingId,

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingService.java
@@ -163,7 +163,7 @@ public class MeetingService {
 
     @Transactional
     public void endMeetingByRoomName(String roomName) {
-        Meeting meeting = getMeetingByRoomNameOrThrow(roomName);
+        Meeting meeting = getMeetingByRoomNameWithLockOrThrow(roomName);
         // 이미 종료된 회의가 아닐 때만 종료 처리
         if (meeting.getStatus() == MeetingStatus.IN_PROGRESS) {
             meeting.end();
@@ -174,7 +174,7 @@ public class MeetingService {
     //웹훅 수신: 녹음본 S3 업로드 완료 시 recordingId 갱신
     @Transactional
     public void updateRecordingId(String roomName, String recordingId) {
-        Meeting meeting = getMeetingByRoomNameOrThrow(roomName);
+        Meeting meeting = getMeetingByRoomNameWithLockOrThrow(roomName);
         meeting.updateRecordingId(recordingId);
         log.info("[MeetingService] DB 녹음 ID 업데이트 완료: meetingId={}, recordingId={}", meeting.getMeetingId(), recordingId);
     }
@@ -229,6 +229,11 @@ public class MeetingService {
 
     private Meeting getMeetingWithLockOrThrow(Long meetingId) {
         return meetingRepository.findByIdWithPessimisticLock(meetingId)
+                .orElseThrow(() -> new GeneralException(MeetingErrorCode.MEETING_NOT_FOUND));
+    }
+
+    private Meeting getMeetingByRoomNameWithLockOrThrow(String roomName) {
+        return meetingRepository.findByRoomNameWithPessimisticLock(roomName)
                 .orElseThrow(() -> new GeneralException(MeetingErrorCode.MEETING_NOT_FOUND));
     }
 

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingService.java
@@ -187,32 +187,35 @@ public class MeetingService {
     }
 
     @Transactional
-    public void triggerSummary(Long meetingId, Long currentUserId) {
+    public void retrySummary(Long meetingId, Long currentUserId) {
         Meeting meeting = getMeetingWithLockOrThrow(meetingId);
         User user = getUserOrThrow(currentUserId);
         validateTeamMember(meeting.getTeam(), user);
 
-        //  ENDED(종료된) 회의만 요약 가능
-        if (meeting.getStatus() != MeetingStatus.ENDED) {
-            throw new GeneralException(MeetingErrorCode.INVALID_STATUS_FOR_SUMMARY);
-        }
-        // 이미 PROCESSING(요약 중)이거나 COMPLETED(완료)면 중복 연타 거부
-        if (meeting.getAiStatus() == AiStatus.PROCESSING || meeting.getAiStatus() == AiStatus.COMPLETED) {
-            throw new GeneralException(MeetingErrorCode.ALREADY_PROCESSING_SUMMARY);
-        }
-
-        if (meeting.getRecordingId() == null) {
-            throw new GeneralException(MeetingErrorCode.RECORDING_NOT_READY);
-        }
-        meeting.startAiProcessing();
-        log.info("[MeetingService] AI 요약 요청 수신 완료: meetingId={}", meetingId);
+        //FAILED 상태인지 확인하고 PROCESSING으로 변경
+        meeting.retryAiProcessing();
+        publishAiProcessingEventIfReady(meeting);
+        log.info(
+                "[MeetingService] AI 회의록 재시도 요청: meetingId={}, requestedBy={}",
+                meetingId,
+                currentUserId
+        );
     }
 
+    //최초 자동 실행 조건을 확인한 뒤 이벤트 발행
     private void publishAiProcessingEventIfReady(Meeting meeting) {
         if (!meeting.tryStartAiProcessing()) {
             return;
         }
-        eventPublisher.publishEvent(new MeetingAiProcessingRequestedEvent(meeting.getMeetingId()));
+        publishAiProcessingEvent(meeting);
+
+    }
+
+    //processing 상태 회의 AI 처리 이벤트 발행
+    private void publishAiProcessingEvent(Meeting meeting) {
+        eventPublisher.publishEvent(
+                new MeetingAiProcessingRequestedEvent(meeting.getMeetingId())
+        );
         log.info("[MeetingService] AI 자동 처리 이벤트 발행: meetingId={}", meeting.getMeetingId());
     }
 

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingService.java
@@ -7,6 +7,7 @@ import com._penLearning.Noddi.domain.meeting.dto.MeetingRequestDto;
 import com._penLearning.Noddi.domain.meeting.dto.MeetingResponseDto;
 import com._penLearning.Noddi.domain.meeting.entity.Meeting;
 import com._penLearning.Noddi.domain.meeting.entity.MeetingParticipant;
+import com._penLearning.Noddi.domain.meeting.event.MeetingAiProcessingRequestedEvent;
 import com._penLearning.Noddi.domain.meeting.repository.MeetingParticipantRepository;
 import com._penLearning.Noddi.domain.meeting.repository.MeetingRepository;
 import com._penLearning.Noddi.domain.team.entity.Team;
@@ -18,6 +19,7 @@ import com._penLearning.Noddi.global.exception.GeneralException;
 import com._penLearning.Noddi.global.infrastructure.webRtc.WebRtcClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -36,6 +38,7 @@ public class MeetingService {
     private final UserRepository userRepository;
     private final WebRtcClient webRtcClient;
     private final TransactionTemplate transactionTemplate;
+    private final ApplicationEventPublisher eventPublisher;
 
     public MeetingResponseDto.Info getMeetingInfo(Long meetingId, Long currentUserId) {
         Meeting meeting = getMeetingOrThrow(meetingId);
@@ -151,7 +154,7 @@ public class MeetingService {
 
             meeting.end();
             log.info("[MeetingService] 회의 종료 완료(DB 업데이트): meetingId={}", meetingId);
-
+            publishAiProcessingEventIfReady(meeting);
             return meeting.getRoomName();
         });
 
@@ -169,6 +172,8 @@ public class MeetingService {
             meeting.end();
             log.info("[MeetingService] Webhook에 의해 회의 자동 종료 완료: roomName={}", roomName);
         }
+
+        publishAiProcessingEventIfReady(meeting);
     }
 
     //웹훅 수신: 녹음본 S3 업로드 완료 시 recordingId 갱신
@@ -177,6 +182,8 @@ public class MeetingService {
         Meeting meeting = getMeetingByRoomNameWithLockOrThrow(roomName);
         meeting.updateRecordingId(recordingId);
         log.info("[MeetingService] DB 녹음 ID 업데이트 완료: meetingId={}, recordingId={}", meeting.getMeetingId(), recordingId);
+
+        publishAiProcessingEventIfReady(meeting);
     }
 
     @Transactional
@@ -199,6 +206,14 @@ public class MeetingService {
         }
         meeting.startAiProcessing();
         log.info("[MeetingService] AI 요약 요청 수신 완료: meetingId={}", meetingId);
+    }
+
+    private void publishAiProcessingEventIfReady(Meeting meeting) {
+        if (!meeting.tryStartAiProcessing()) {
+            return;
+        }
+        eventPublisher.publishEvent(new MeetingAiProcessingRequestedEvent(meeting.getMeetingId()));
+        log.info("[MeetingService] AI 자동 처리 이벤트 발행: meetingId={}", meeting.getMeetingId());
     }
 
     private void validateTeamMember(Team team, User user) {

--- a/src/main/java/com/_penLearning/Noddi/domain/summary/entity/MeetingSummary.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/summary/entity/MeetingSummary.java
@@ -6,8 +6,12 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -31,20 +35,30 @@ public class MeetingSummary {
     @Column(nullable = false)
     private String rawTranscript;
 
-    // List<String>을 JSON 직렬화하여 저장
-    private String decisions;
+    // MySQL JSON배열로 저장
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "JSON",nullable = false)
+    private List<String> decisions;
 
-    private String issues;
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "JSON",nullable = false)
+    private List<String> issues;
 
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
     @Builder
-    public MeetingSummary(Meeting meeting, String summaryText, String decisions, String issues, String rawTranscript) {
+    public MeetingSummary(Meeting meeting, String summaryText, List<String> decisions, List<String> issues, String rawTranscript) {
         this.meeting = meeting;
         this.summaryText = summaryText;
-        this.decisions = decisions;
-        this.issues = issues;
+        // OpenAI가 null을 반환하더라도 DB에는 빈 JSON 배열을 저장한다.
+        this.decisions = decisions != null
+                ? new ArrayList<>(decisions)
+                : new ArrayList<>();
+
+        this.issues = issues != null
+                ? new ArrayList<>(issues)
+                : new ArrayList<>();
         this.createdAt = LocalDateTime.now();
         this.rawTranscript = rawTranscript;
     }

--- a/src/main/java/com/_penLearning/Noddi/global/infrastructure/openAi/OpenAiClient.java
+++ b/src/main/java/com/_penLearning/Noddi/global/infrastructure/openAi/OpenAiClient.java
@@ -1,8 +1,8 @@
 package com._penLearning.Noddi.global.infrastructure.openAi;
 
-import com._penLearning.Noddi.domain.meeting.code.MeetingErrorCode;
 import com._penLearning.Noddi.domain.summary.code.SummaryErrorCode;
 import com._penLearning.Noddi.global.exception.GeneralException;
+import com._penLearning.Noddi.global.infrastructure.openAi.dto.OpenAiRequestDto;
 import com._penLearning.Noddi.global.infrastructure.openAi.dto.OpenApiResponseDto;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -14,6 +14,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestClient;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -22,6 +23,7 @@ import java.net.URI;
 import java.net.URLConnection;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 
@@ -38,10 +40,12 @@ public class OpenAiClient {
     private final int audioDownloadConnectTimeoutMs;
     // 연결 이후 파일 데이터가 들어오지 않을 때 기다릴 최대 시간
     private final int audioDownloadReadTimeoutMs;
+    private final ObjectMapper objectMapper;
 
     public OpenAiClient(
             @Qualifier("openAiRestClient")
             RestClient openAiRestClient,
+            ObjectMapper objectMapper,
             // 기본값은 OpenAI 공식 파일 전사 제한인 25,000,000 bytes
             @Value("${openai.audio.max-file-size-bytes:25000000}")
             long maxAudioFileSizeBytes,
@@ -53,6 +57,7 @@ public class OpenAiClient {
             int audioDownloadReadTimeoutMs
     ) {
         this.openAiRestClient = openAiRestClient;
+        this.objectMapper = objectMapper;
         this.maxAudioFileSizeBytes = maxAudioFileSizeBytes;
         this.audioDownloadConnectTimeoutMs = audioDownloadConnectTimeoutMs;
         this.audioDownloadReadTimeoutMs = audioDownloadReadTimeoutMs;
@@ -167,66 +172,158 @@ public class OpenAiClient {
         }
     }
 
-    @SuppressWarnings("unchecked")
-    public String summarizeText(String rawTranscript) {
-        log.info("[OpenAI ChatGPT] 회의록 JSON 요약 시작");
+    public OpenApiResponseDto.MeetingSummary summarizeText(
+            String rawTranscript,
+            LocalDate currentDate,
+            List<OpenAiRequestDto.TeamMember> teamMembers
+    ) {
+        log.info("[OpenAI ChatGPT] 회의록 구조화 요약 시작");
+
         try {
-            //프롬포트 작성
-            String systemPrompt = "너는 비즈니스 회의 요약 전문가야. 제공되는 회의 대화록을 바탕으로 반드시 완벽한 JSON 형식으로만 응답해.\n\n" +
-                    "【JSON 구조 필수 조건】\n" +
-                    "{\n" +
-                    "  \"summary\": \"회의 전체 핵심 요약 (3~4줄)\",\n" +
-                    "  \"decisions\": [\"결정사항 1\", \"결정사항 2\"],\n" +
-                    "  \"issues\": [\n" +
-                    "    { \"title\": \"이슈 내용\", \"status\": \"미해결/검토 중/완료 중 택 1\" }\n" +
-                    "  ],\n" +
-                    "  \"tasks\": [\n" +
-                    "    { \"assignee\": \"담당자 이름(없으면 미정)\", \"task\": \"할 일 내용\", \"deadline\": \"마감기한(반드시 YYYY-MM-DD 형식. 연도를 모르면 올해 연도 사용. 도저히 파악 불가면 문자열 \\\"null\\\")\" }\n" +
-                    "  ]\n" +
-                    "}";
-            // 시스템 명령(system)과 사용자의 원문(user)을 묶어서 채팅 기록(messages)을 생성
-            List<Map<String, String>> messages = List.of(
-                    Map.of("role", "system", "content", systemPrompt),
-                    Map.of("role", "user", "content", "다음 회의 대화록을 JSON으로 요약해줘:\n\n" + rawTranscript)
+            // 전문이 비어 있으면 OpenAI를 불필요하게 호출하지 않고 즉시 실패 처리
+            if (!StringUtils.hasText(rawTranscript)) {
+                throw new GeneralException(SummaryErrorCode.SUMMARY_PROCESSING_FAILED);
+            }
+
+            // 팀원이 없는 경우에도 프롬프트에는 null이 아닌 빈 JSON 배열([])을 전달
+            List<OpenAiRequestDto.TeamMember> safeTeamMembers =
+                    teamMembers == null ? List.of() : teamMembers;
+
+            // TeamMember DTO 목록을 AI가 정확히 읽을 수 있는 JSON 문자열로 변환
+            String teamMembersJson = objectMapper.writeValueAsString(safeTeamMembers);
+
+            // system 메시지에는 요약 기준과 담당자·마감일 판단 규칙을 정의
+            String systemPrompt = """
+                    너는 한국어 비즈니스 회의록 작성 전문가다.
+
+                    회의 전문을 근거로 다음 내용을 추출한다.
+                    - 회의 전체 요약
+                    - 확정된 결정사항
+                    - 논의된 문제 또는 추가 검토 이슈
+                    - 회의 중 특정 팀원이 회의 이후 수행하기로 약속했거나 요청받은 구체적인 업무(ActionItem)
+
+                    ActionItem 추출 규칙:
+                    - ActionItem은 회의 이후 누군가가 실제로 수행해야 하는 구체적인 업무다.
+                    - 참석자가 직접 수행하겠다고 약속한 업무와 다른 사람에게 명시적으로 요청하거나 배정한 업무만 추출한다.
+                    - 단순한 의견, 아이디어, 제안, 질문, 정보 공유, 논의 주제는 ActionItem으로 추출하지 않는다.
+                    - 회의 전에 이미 완료된 업무나 전문에서 완료되었다고 보고한 업무는 ActionItem으로 추출하지 않는다.
+                    - 동일한 업무가 여러 번 언급되면 하나의 ActionItem으로 통합한다.
+                    - content에는 회의 내용을 그대로 나열하지 말고, 수행할 행동과 결과물이 드러나는 구체적인 문장 하나를 작성한다.
+                    - 추출한 각 업무는 응답의 actionItems 배열에 담는다.
+                    - 수행할 업무가 명확하지 않다면 억지로 만들지 말고 actionItems를 빈 배열로 반환한다.
+
+                    담당자 연결 규칙:
+                    - 전문에서 담당자가 명시된 경우에만 담당자를 연결한다.
+                    - 제공된 팀원 목록의 userId와 name만 담당자 후보로 사용한다.
+                    - 이름과 사용자가 정확히 한 명의 팀원과 일치할 때만 assigneeUserId와 assigneeName을 반환한다.
+                    - 담당자가 불명확하거나 동명이인이거나 팀 외 사용자라면 assigneeUserId와 assigneeName은 null이다.
+                    - 담당자를 확정할 수 없으면 isUncertain은 true, 확정할 수 있으면 false다.
+                    - 화자 구분이 없는 전문에서 '제가 하겠습니다' 같은 표현만으로 담당자를 추측하지 않는다.
+
+                    마감일 규칙:
+                    - 제공된 현재 날짜를 기준으로 상대적인 날짜를 YYYY-MM-DD로 변환한다.
+                    - 전문에서 마감일을 확인할 수 없으면 dueDate는 null이다.
+                    - 전문에 없는 담당자, 날짜, 결정사항을 만들거나 추측하지 않는다.
+                    """;
+
+            // user 메시지에는 실제 분석에 필요한 기준 날짜, 팀원 목록, 회의 전문을 전달
+            String userPrompt = """
+                    현재 날짜:
+                    %s
+
+                    팀원 목록:
+                    %s
+
+                    회의 전문:
+                    %s
+                    """.formatted(
+                    currentDate,
+                    teamMembersJson,
+                    rawTranscript
             );
-            // ChatGPT에게 보낼 옵션들을 세팅
-            Map<String, Object> requestBody = Map.of(
-                    "model", "gpt-4o-mini", // 사용할 싸고 빠른 모델
-                    "messages", messages,
-                    "temperature", 0.3, // 창의성 수치 (낮을수록 보수적이고 정확한 요약을 함)
-                    "response_format", Map.of("type", "json_object")
+
+            // OpenAI의 system/user 메시지를 Map이 아닌 요청 DTO로 구성
+            List<OpenAiRequestDto.Message> messages = List.of(
+                    new OpenAiRequestDto.Message("system", systemPrompt),
+                    new OpenAiRequestDto.Message("user", userPrompt)
             );
-            // OpenAI 챗봇 서버로 요청 (응답 대기 최대 2분)
-            Map<String, Object> response = openAiRestClient.post()
+
+            // 앞에서 정의한 회의록 Schema에 이름을 붙이고 strict 모드를 활성화
+            OpenAiRequestDto.JsonSchema jsonSchema =
+                    new OpenAiRequestDto.JsonSchema(
+                            "meeting_summary",
+                            true,
+                            createMeetingSummarySchema()
+                    );
+
+            // 일반 JSON 모드가 아니라 JSON Schema 기반 Structured Outputs를 요청
+            OpenAiRequestDto.ResponseFormat responseFormat =
+                    new OpenAiRequestDto.ResponseFormat(
+                            "json_schema",
+                            jsonSchema
+                    );
+
+            // OpenAI Chat Completions API에 전달할 최상위 요청 DTO를 완성
+            OpenAiRequestDto.ChatCompletion request =
+                    new OpenAiRequestDto.ChatCompletion(
+                            "gpt-4o-mini",
+                            messages,
+                            0.2,
+                            responseFormat
+                    );
+
+            // 응답 JSON을 Map으로 받지 않고 ChatCompletion DTO로 바로 역직렬화한다.
+            OpenApiResponseDto.ChatCompletion response = openAiRestClient.post()
                     .uri("/chat/completions")
                     .contentType(MediaType.APPLICATION_JSON)
-                    .body(requestBody)
+                    .body(request)
                     .retrieve()
-                    .body(Map.class);
+                    .body(OpenApiResponseDto.ChatCompletion.class);
 
-            if (response != null && response.containsKey("choices")) {
-                List<Map<String, Object>> choices = (List<Map<String, Object>>) response.get("choices");
-                if (!choices.isEmpty()) {
-                    Map<String, Object> message = (Map<String, Object>) choices.get(0).get("message");
-                    return (String) message.get("content");
-                }
+            // 응답 또는 choices가 비어 있으면 정상적인 요약 결과가 아니므로 실패 처리한다.
+            if (response == null
+                    || response.choices() == null
+                    || response.choices().isEmpty()) {
+                throw new GeneralException(SummaryErrorCode.SUMMARY_PROCESSING_FAILED);
             }
-            throw new GeneralException(SummaryErrorCode.SUMMARY_PROCESSING_FAILED);
+
+            // 현재는 OpenAI가 반환한 첫 번째 응답 후보를 사용한다.
+            OpenApiResponseDto.Message message = response.choices().getFirst().message();
+
+            // message가 없거나 안전 정책에 따른 refusal이 있으면 저장 가능한 결과가 아니다.
+            if (message == null || StringUtils.hasText(message.refusal())) {
+                throw new GeneralException(SummaryErrorCode.SUMMARY_PROCESSING_FAILED);
+            }
+
+            // Structured Outputs 결과는 message.content 안에 JSON 문자열 형태로 들어 있다.
+            if (!StringUtils.hasText(message.content())) {
+                throw new GeneralException(SummaryErrorCode.SUMMARY_PROCESSING_FAILED);
+            }
+
+            // content JSON 문자열을 최종 MeetingSummary DTO로 변환해 호출자에게 반환한다.
+            return objectMapper.readValue(
+                    message.content(),
+                    OpenApiResponseDto.MeetingSummary.class
+            );
+        } catch (GeneralException e) {
+            // 이미 프로젝트 공통 예외로 판단한 오류는 다른 예외로 다시 감싸지 않고 그대로 전달한다.
+            throw e;
         } catch (Exception e) {
-            log.error("[OpenAI ChatGPT] 요약 실패", e);
+            // 네트워크, 요청 직렬화, 응답 JSON 변환 오류를 회의록 요약 실패로 통일한다.
+            log.error("[OpenAI ChatGPT] 구조화 요약 실패", e);
             throw new GeneralException(SummaryErrorCode.SUMMARY_PROCESSING_FAILED);
         }
     }
 
-    private Map<String, Object> createTaskSchema() {
+    private Map<String, Object> createActionItemSchema() {
         return Map.of(
-                // tasks 배열의 각 항목은 content, 담당자, 마감일을 가진 객체
+                // actionItems 배열의 각 항목은 content, 담당자, 마감일을 가진 객체
                 "type", "object",
 
                 "properties", Map.of(
                         "content", Map.of(
                                 "type", "string",
-                                "description", "회의 이후 수행해야 할 구체적인 할 일"
+                                "description", "회의 중 누군가가 수행하기로 약속했거나 명시적으로 요청·배정받은, 행동과 결과물이 드러나는 구체적인 업무"
                         ),
                         "assigneeUserId", Map.of(
                                 "type", List.of("integer", "null"),
@@ -264,7 +361,7 @@ public class OpenAiClient {
      */
     private Map<String, Object> createMeetingSummarySchema() {
         return Map.of(
-                // 전체 회의록 응답은 summary, decisions, issues, tasks를 가진 객체
+                // 전체 회의록 응답은 summary, decisions, issues, actionItems를 가진 객체
                 "type", "object",
 
                 // 회의록 응답에 들어갈 수 있는 네 가지 필드를 정의
@@ -283,10 +380,10 @@ public class OpenAiClient {
                                 "description", "회의에서 논의된 문제나 추가 검토 내용",
                                 "items", Map.of("type", "string")
                         ),
-                        "tasks", Map.of(
+                        "actionItems", Map.of(
                                 "type", "array",
-                                "description", "회의 이후 수행해야 할 ActionItem 목록",
-                                "items", createTaskSchema()
+                                "description", "회의 이후 누군가가 실제로 수행하기로 약속했거나 명시적으로 요청·배정받은 업무 목록. 단순 의견, 아이디어, 질문, 정보 공유 및 이미 완료된 업무는 제외한다.",
+                                "items", createActionItemSchema()
                         )
                 ),
 
@@ -294,7 +391,7 @@ public class OpenAiClient {
                         "summary",
                         "decisions",
                         "issues",
-                        "tasks"
+                        "actionItems"
                 ),
 
                 "additionalProperties", false

--- a/src/main/java/com/_penLearning/Noddi/global/infrastructure/openAi/OpenAiClient.java
+++ b/src/main/java/com/_penLearning/Noddi/global/infrastructure/openAi/OpenAiClient.java
@@ -217,4 +217,87 @@ public class OpenAiClient {
             throw new GeneralException(SummaryErrorCode.SUMMARY_PROCESSING_FAILED);
         }
     }
+
+    private Map<String, Object> createTaskSchema() {
+        return Map.of(
+                // tasks 배열의 각 항목은 content, 담당자, 마감일을 가진 객체
+                "type", "object",
+
+                "properties", Map.of(
+                        "content", Map.of(
+                                "type", "string",
+                                "description", "회의 이후 수행해야 할 구체적인 할 일"
+                        ),
+                        "assigneeUserId", Map.of(
+                                "type", List.of("integer", "null"),
+                                "description", "팀원 목록과 정확히 일치하는 담당자 ID"
+                        ),
+                        "assigneeName", Map.of(
+                                "type", List.of("string", "null"),
+                                "description", "전문에서 확인된 담당자 이름"
+                        ),
+                        "dueDate", Map.of(
+                                "type", List.of("string", "null"),
+                                "description", "YYYY-MM-DD 형식의 마감일"
+                        ),
+                        "isUncertain", Map.of(
+                                "type", "boolean",
+                                "description", "담당자 연결이 불확실하면 true"
+                        )
+                ),
+
+                "required", List.of(
+                        "content",
+                        "assigneeUserId",
+                        "assigneeName",
+                        "dueDate",
+                        "isUncertain"
+                ),
+
+                "additionalProperties", false
+        );
+    }
+
+    /**
+     * OpenAI가 반환할 전체 회의록의 JSON 구조를 정의한다.
+     * 최종 응답 DTO인 OpenApiResponseDto.MeetingSummary 구조와 동일하게 맞춘다.
+     */
+    private Map<String, Object> createMeetingSummarySchema() {
+        return Map.of(
+                // 전체 회의록 응답은 summary, decisions, issues, tasks를 가진 객체
+                "type", "object",
+
+                // 회의록 응답에 들어갈 수 있는 네 가지 필드를 정의
+                "properties", Map.of(
+                        "summary", Map.of(
+                                "type", "string",
+                                "description", "회의 전체 내용을 요약한 3~4문장"
+                        ),
+                        "decisions", Map.of(
+                                "type", "array",
+                                "description", "회의에서 확정된 결정사항 목록",
+                                "items", Map.of("type", "string")
+                        ),
+                        "issues", Map.of(
+                                "type", "array",
+                                "description", "회의에서 논의된 문제나 추가 검토 내용",
+                                "items", Map.of("type", "string")
+                        ),
+                        "tasks", Map.of(
+                                "type", "array",
+                                "description", "회의 이후 수행해야 할 ActionItem 목록",
+                                "items", createTaskSchema()
+                        )
+                ),
+
+                "required", List.of(
+                        "summary",
+                        "decisions",
+                        "issues",
+                        "tasks"
+                ),
+
+                "additionalProperties", false
+        );
+    }
 }

--- a/src/main/java/com/_penLearning/Noddi/global/infrastructure/openAi/OpenAiClient.java
+++ b/src/main/java/com/_penLearning/Noddi/global/infrastructure/openAi/OpenAiClient.java
@@ -3,7 +3,7 @@ package com._penLearning.Noddi.global.infrastructure.openAi;
 import com._penLearning.Noddi.domain.summary.code.SummaryErrorCode;
 import com._penLearning.Noddi.global.exception.GeneralException;
 import com._penLearning.Noddi.global.infrastructure.openAi.dto.OpenAiRequestDto;
-import com._penLearning.Noddi.global.infrastructure.openAi.dto.OpenApiResponseDto;
+import com._penLearning.Noddi.global.infrastructure.openAi.dto.OpenAiResponseDto;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -143,12 +143,12 @@ public class OpenAiClient {
         body.add("model", "whisper-1");
         body.add("language", "ko");
 
-        OpenApiResponseDto.Transcription response = openAiRestClient.post()
+        OpenAiResponseDto.Transcription response = openAiRestClient.post()
                 .uri("/audio/transcriptions")
                 .contentType(MediaType.MULTIPART_FORM_DATA)
                 .body(body)
                 .retrieve()
-                .body(OpenApiResponseDto.Transcription.class);
+                .body(OpenAiResponseDto.Transcription.class);
 
         if (response != null && StringUtils.hasText(response.text())) {
             return response.text();
@@ -172,7 +172,7 @@ public class OpenAiClient {
         }
     }
 
-    public OpenApiResponseDto.MeetingSummary summarizeText(
+    public OpenAiResponseDto.MeetingSummary summarizeText(
             String rawTranscript,
             LocalDate currentDate,
             List<OpenAiRequestDto.TeamMember> teamMembers
@@ -273,12 +273,12 @@ public class OpenAiClient {
                     );
 
             // 응답 JSON을 Map으로 받지 않고 ChatCompletion DTO로 바로 역직렬화한다.
-            OpenApiResponseDto.ChatCompletion response = openAiRestClient.post()
+            OpenAiResponseDto.ChatCompletion response = openAiRestClient.post()
                     .uri("/chat/completions")
                     .contentType(MediaType.APPLICATION_JSON)
                     .body(request)
                     .retrieve()
-                    .body(OpenApiResponseDto.ChatCompletion.class);
+                    .body(OpenAiResponseDto.ChatCompletion.class);
 
             // 응답 또는 choices가 비어 있으면 정상적인 요약 결과가 아니므로 실패 처리한다.
             if (response == null
@@ -288,7 +288,7 @@ public class OpenAiClient {
             }
 
             // 현재는 OpenAI가 반환한 첫 번째 응답 후보를 사용한다.
-            OpenApiResponseDto.Message message = response.choices().getFirst().message();
+            OpenAiResponseDto.Message message = response.choices().getFirst().message();
 
             // message가 없거나 안전 정책에 따른 refusal이 있으면 저장 가능한 결과가 아니다.
             if (message == null || StringUtils.hasText(message.refusal())) {
@@ -303,7 +303,7 @@ public class OpenAiClient {
             // content JSON 문자열을 최종 MeetingSummary DTO로 변환해 호출자에게 반환한다.
             return objectMapper.readValue(
                     message.content(),
-                    OpenApiResponseDto.MeetingSummary.class
+                    OpenAiResponseDto.MeetingSummary.class
             );
         } catch (GeneralException e) {
             // 이미 프로젝트 공통 예외로 판단한 오류는 다른 예외로 다시 감싸지 않고 그대로 전달한다.

--- a/src/main/java/com/_penLearning/Noddi/global/infrastructure/openAi/dto/OpenAiRequestDto.java
+++ b/src/main/java/com/_penLearning/Noddi/global/infrastructure/openAi/dto/OpenAiRequestDto.java
@@ -1,0 +1,46 @@
+package com._penLearning.Noddi.global.infrastructure.openAi.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+
+public class OpenAiRequestDto {
+
+    public record TeamMemter(
+            Long userId,
+            String name
+    ) {
+    }
+
+    public record ChatCompletion(
+            String model,
+            List<Message> messages,
+            double temperature,
+
+            @JsonProperty("response_format")
+            ResponseFormat responseFormat
+    ) {
+    }
+
+    public record Message(
+            String role,
+            String content
+    ) {
+    }
+
+    public record ResponseFormat(
+            String type,
+
+            @JsonProperty("json_schema")
+            JsonSchema jsonSchema
+    ) {
+    }
+
+    //reponse를 정해진 구조로 강제
+    public record JsonSchema(
+            String name,
+            boolean strict,
+            Map<String, Object> schema
+    ) {
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/global/infrastructure/openAi/dto/OpenAiRequestDto.java
+++ b/src/main/java/com/_penLearning/Noddi/global/infrastructure/openAi/dto/OpenAiRequestDto.java
@@ -2,11 +2,12 @@ package com._penLearning.Noddi.global.infrastructure.openAi.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.List;
 import java.util.Map;
 
 public class OpenAiRequestDto {
 
-    public record TeamMemter(
+    public record TeamMember(
             Long userId,
             String name
     ) {
@@ -36,7 +37,7 @@ public class OpenAiRequestDto {
     ) {
     }
 
-    //reponse를 정해진 구조로 강제
+    // OpenAI response가 정해진 JSON 구조를 따르도록 설정하는 스키마 껍데기
     public record JsonSchema(
             String name,
             boolean strict,

--- a/src/main/java/com/_penLearning/Noddi/global/infrastructure/openAi/dto/OpenAiResponseDto.java
+++ b/src/main/java/com/_penLearning/Noddi/global/infrastructure/openAi/dto/OpenAiResponseDto.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.time.LocalDate;
 import java.util.List;
 
-public class OpenApiResponseDto {
+public class OpenAiResponseDto {
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record Transcription(

--- a/src/main/java/com/_penLearning/Noddi/global/infrastructure/openAi/dto/OpenApiResponseDto.java
+++ b/src/main/java/com/_penLearning/Noddi/global/infrastructure/openAi/dto/OpenApiResponseDto.java
@@ -15,7 +15,7 @@ public class OpenApiResponseDto {
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record ChatCompletion(
-            List<String> choices
+            List<Choice> choices
     ) {
     }
 

--- a/src/main/java/com/_penLearning/Noddi/global/infrastructure/openAi/dto/OpenApiResponseDto.java
+++ b/src/main/java/com/_penLearning/Noddi/global/infrastructure/openAi/dto/OpenApiResponseDto.java
@@ -2,9 +2,51 @@ package com._penLearning.Noddi.global.infrastructure.openAi.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
+import java.time.LocalDate;
+import java.util.List;
+
 public class OpenApiResponseDto {
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public record Transcription(String text) {
+    public record Transcription(
+            String text
+    ) {
     }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record ChatCompletion(
+            List<String> choices
+    ) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Choice(
+            Message message
+    ) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Message(
+            String content, String refusal
+    ) {
+    }
+
+
+    public record MeetingSummary(
+            String summary,
+            List<String> decisions,
+            List<String> issues,
+            List<Task> tasks
+    ) {
+    }
+
+    public record Task(
+            String content,
+            Long assigneeUserId,
+            String assigneeName,
+            LocalDate dueDate,
+            boolean isUncertain
+    ) {
+    }
+
 }

--- a/src/main/java/com/_penLearning/Noddi/global/infrastructure/openAi/dto/OpenApiResponseDto.java
+++ b/src/main/java/com/_penLearning/Noddi/global/infrastructure/openAi/dto/OpenApiResponseDto.java
@@ -36,11 +36,11 @@ public class OpenApiResponseDto {
             String summary,
             List<String> decisions,
             List<String> issues,
-            List<Task> tasks
+            List<ActionItem> actionItems
     ) {
     }
 
-    public record Task(
+    public record ActionItem(
             String content,
             Long assigneeUserId,
             String assigneeName,

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -39,6 +39,12 @@ scheduler:
     cron: "0 0 * * * *"
     zone: Asia/Seoul
     valid-days: 7
+  meeting-ai:
+    # PROCESSING 상태가 고립되었는지 5분마다 검사한다.
+    recovery-cron: "${MEETING_AI_RECOVERY_CRON:0 */5 * * * *}"
+    zone: "${MEETING_AI_RECOVERY_ZONE:Asia/Seoul}"
+    # 정상 처리 시간을 충분히 고려해 30분을 초과한 작업만 FAILED로 복구한다.
+    processing-timeout-minutes: ${MEETING_AI_PROCESSING_TIMEOUT_MINUTES:30}
 
 jwt:
   secret: ${JWT_SECRET} #환경변수 설정 필요


### PR DESCRIPTION
## <i>PULL REQUEST</i>

## 🎋 작업 브랜치
- feature/28 -> develop
- #28  (관련이슈 번호)

## 💡 작업동기
- 작업 배경을 알려주세요.

## 🔑 주요 변경사항
- Daily 녹음 완료 웹훅을 기반으로 AI 회의록 생성 파이프라인이 자동 실행되도록 구현했습니다.
- Daily 녹음 파일을 OpenAI Whisper로 전사하고, 회의 전문을 기반으로 전체 요약·결정사항·논의 이슈·ActionItem을 생성하도록 연동했습니다.
- 회의 팀원 정보를 AI에 전달하고 결과를 서버에서 재검증해 ActionItem 담당자와 마감일을 매칭하도록 구현했습니다.
- 생성된 회의 요약과 ActionItem을 하나의 트랜잭션으로 저장하고, 처리 결과에 따라 AI 상태를 PROCESSING / COMPLETED / FAILED로 관리하도록 구성했습니다.
- 웹훅 전달 순서 변경과 중복 요청을 고려해 회의 종료·녹음 준비 조건 확인, 비관적 락 및 비동기 이벤트 처리를 적용했습니다.
- AI 회의록 생성 실패 시 다시 처리할 수 있는 재시도 API를 구현했습니다.
- 서비스 단위 테스트와 실제 녹음 기반 통합 테스트를 통해 전사·요약·DB 저장 흐름을 검증했습니다.

## 🏞 스크린샷 (선택)
> 스크린샷을 첨부해주세요.

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
