### PR TITLE
[feat] 공지사항 crud 구현

### DIFF
--- a/src/main/java/com/_penLearning/Noddi/domain/announcement/code/AnnouncementApi.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/announcement/code/AnnouncementApi.java
@@ -31,7 +31,7 @@ public interface AnnouncementApi {
 
     @Operation(
             summary = "공지 수정",
-            description = "공지 작성자가 공지의 제목과 본문을 수정합니다."
+            description = "공지 작성자가 공지의 제목과 본문 전체를 수정합니다."
     )
     ApiResponse<AnnouncementResponseDto.Result> updateAnnouncement(
             @Parameter(description = "프로젝트 ID") @PathVariable Long projectId,
@@ -52,7 +52,7 @@ public interface AnnouncementApi {
 
     @Operation(
             summary = "프로젝트 전체 공지 목록 조회",
-            description = "프로젝트 멤버가 프로젝트 내 모든 팀의 공지를 페이징하여 조회합니다."
+            description = "프로젝트 멤버가 프로젝트 내 모든 팀의 공지를 최근 수정 순으로 페이징하여 조회합니다."
     )
     ApiResponse<Page<AnnouncementResponseDto.Summary>> getAnnouncements(
             @Parameter(description = "프로젝트 ID") @PathVariable Long projectId,

--- a/src/main/java/com/_penLearning/Noddi/domain/announcement/code/AnnouncementApi.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/announcement/code/AnnouncementApi.java
@@ -1,0 +1,72 @@
+package com._penLearning.Noddi.domain.announcement.code;
+
+import com._penLearning.Noddi.domain.announcement.dto.AnnouncementRequestDto;
+import com._penLearning.Noddi.domain.announcement.dto.AnnouncementResponseDto;
+import com._penLearning.Noddi.domain.auth.entity.AuthMember;
+import com._penLearning.Noddi.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Announcement API", description = "프로젝트 전체 공지 등록·조회·수정·삭제 API")
+public interface AnnouncementApi {
+
+    @Operation(
+            summary = "공지 등록",
+            description = "프로젝트에 속한 팀 멤버가 해당 팀 명의의 공지를 등록합니다."
+    )
+    ApiResponse<AnnouncementResponseDto.Result> createAnnouncement(
+            @Parameter(description = "프로젝트 ID") @PathVariable Long projectId,
+            @Parameter(description = "공지 작성 팀 ID") @PathVariable Long teamId,
+            @Parameter(hidden = true) @AuthenticationPrincipal AuthMember authMember,
+            @Valid @RequestBody AnnouncementRequestDto.Create request
+    );
+
+    @Operation(
+            summary = "공지 수정",
+            description = "공지 작성자가 공지의 제목과 본문을 수정합니다."
+    )
+    ApiResponse<AnnouncementResponseDto.Result> updateAnnouncement(
+            @Parameter(description = "프로젝트 ID") @PathVariable Long projectId,
+            @Parameter(description = "공지 ID") @PathVariable Long announcementId,
+            @Parameter(hidden = true) @AuthenticationPrincipal AuthMember authMember,
+            @Valid @RequestBody AnnouncementRequestDto.Update request
+    );
+
+    @Operation(
+            summary = "공지 상세 조회",
+            description = "프로젝트 멤버가 공지의 상세 내용을 조회합니다."
+    )
+    ApiResponse<AnnouncementResponseDto.Detail> getAnnouncement(
+            @Parameter(description = "프로젝트 ID") @PathVariable Long projectId,
+            @Parameter(description = "공지 ID") @PathVariable Long announcementId,
+            @Parameter(hidden = true) @AuthenticationPrincipal AuthMember authMember
+    );
+
+    @Operation(
+            summary = "프로젝트 전체 공지 목록 조회",
+            description = "프로젝트 멤버가 프로젝트 내 모든 팀의 공지를 페이징하여 조회합니다."
+    )
+    ApiResponse<Page<AnnouncementResponseDto.Summary>> getAnnouncements(
+            @Parameter(description = "프로젝트 ID") @PathVariable Long projectId,
+            @Parameter(hidden = true) @AuthenticationPrincipal AuthMember authMember,
+            @ParameterObject Pageable pageable
+    );
+
+    @Operation(
+            summary = "공지 삭제",
+            description = "공지 작성자가 공지를 삭제합니다."
+    )
+    ApiResponse<Void> deleteAnnouncement(
+            @Parameter(description = "프로젝트 ID") @PathVariable Long projectId,
+            @Parameter(description = "공지 ID") @PathVariable Long announcementId,
+            @Parameter(hidden = true) @AuthenticationPrincipal AuthMember authMember
+    );
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/announcement/code/AnnouncementErrorCode.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/announcement/code/AnnouncementErrorCode.java
@@ -1,0 +1,19 @@
+package com._penLearning.Noddi.domain.announcement.code;
+
+import com._penLearning.Noddi.global.apiPayload.code.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+
+@Getter
+@RequiredArgsConstructor
+public enum AnnouncementErrorCode implements BaseErrorCode {
+
+    ANNOUNCEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "ANNOUNCEMENT404_1", "해당 공지를 찾을 수 없습니다."),
+    YOU_ARE_NOT_AUTHOR(HttpStatus.FORBIDDEN, "ANNOUNCEMENT403_1", "작성자만 수정, 삭제할 수 있습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/announcement/controller/AnnouncementController.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/announcement/controller/AnnouncementController.java
@@ -1,0 +1,88 @@
+package com._penLearning.Noddi.domain.announcement.controller;
+
+import com._penLearning.Noddi.domain.announcement.code.AnnouncementApi;
+import com._penLearning.Noddi.domain.announcement.dto.AnnouncementRequestDto;
+import com._penLearning.Noddi.domain.announcement.dto.AnnouncementResponseDto;
+import com._penLearning.Noddi.domain.announcement.service.AnnouncementService;
+import com._penLearning.Noddi.domain.auth.entity.AuthMember;
+import com._penLearning.Noddi.global.apiPayload.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequestMapping("/api/v1/projects/{projectId}")
+@RequiredArgsConstructor
+public class AnnouncementController implements AnnouncementApi {
+
+    private final AnnouncementService announcementService;
+
+    @Override
+    @PostMapping("/teams/{teamId}/announcements")
+    public ApiResponse<AnnouncementResponseDto.Result> createAnnouncement(
+            @PathVariable Long projectId,
+            @PathVariable Long teamId,
+            @AuthenticationPrincipal AuthMember authMember,
+            @RequestBody @Valid AnnouncementRequestDto.Create request
+    ){
+        AnnouncementResponseDto.Result response = announcementService.createAnnouncement(projectId, teamId, authMember.getUserId(), request);
+        return ApiResponse.onSuccess("공지사항 등록에 성공하였습니다.", response);
+    }
+
+    @Override
+    @PatchMapping("/announcements/{announcementId}")
+    public ApiResponse<AnnouncementResponseDto.Result> updateAnnouncement(
+            @PathVariable Long projectId,
+            @PathVariable Long announcementId,
+            @AuthenticationPrincipal AuthMember authMember,
+            @RequestBody @Valid AnnouncementRequestDto.Update request
+    ){
+        AnnouncementResponseDto.Result response = announcementService.updateAnnouncement(projectId, announcementId, authMember.getUserId(), request);
+        return ApiResponse.onSuccess("공지사항 수정에 성공하였습니다.", response);
+    }
+
+    @Override
+    @GetMapping("/announcements/{announcementId}")
+    public ApiResponse<AnnouncementResponseDto.Detail> getAnnouncement(
+            @PathVariable Long projectId,
+            @PathVariable Long announcementId,
+            @AuthenticationPrincipal AuthMember authMember
+    ){
+        AnnouncementResponseDto.Detail response = announcementService.getAnnouncement(projectId, announcementId, authMember.getUserId());
+        return ApiResponse.onSuccess("공지사항 상세 조회에 성공하였습니다.", response);
+    }
+
+    @Override
+    @GetMapping("/announcements")
+    public ApiResponse<Page<AnnouncementResponseDto.Summary>> getAnnouncements(
+            @PathVariable Long projectId,
+            @AuthenticationPrincipal AuthMember authMember,
+            @PageableDefault(
+                    size = 10,
+                    sort = {"updatedAt", "announcementId"},
+                    direction = Sort.Direction.DESC
+            )
+            Pageable pageable
+    ){
+        Page<AnnouncementResponseDto.Summary> response = announcementService.getAnnouncements(projectId, authMember.getUserId(), pageable);
+        return ApiResponse.onSuccess("공지사항 목록 조회에 성공하였습니다.", response);
+    }
+
+    @Override
+    @DeleteMapping("/announcements/{announcementId}")
+    public ApiResponse<Void> deleteAnnouncement(
+            @PathVariable Long projectId,
+            @PathVariable Long announcementId,
+            @AuthenticationPrincipal AuthMember authMember
+    ){
+        announcementService.deleteAnnouncement(projectId, announcementId, authMember.getUserId());
+
+        return ApiResponse.onSuccess("공지사항 삭제에 성공하였습니다.", null);
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/announcement/controller/AnnouncementController.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/announcement/controller/AnnouncementController.java
@@ -10,7 +10,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -36,7 +35,7 @@ public class AnnouncementController implements AnnouncementApi {
     }
 
     @Override
-    @PatchMapping("/announcements/{announcementId}")
+    @PutMapping("/announcements/{announcementId}")
     public ApiResponse<AnnouncementResponseDto.Result> updateAnnouncement(
             @PathVariable Long projectId,
             @PathVariable Long announcementId,
@@ -63,12 +62,7 @@ public class AnnouncementController implements AnnouncementApi {
     public ApiResponse<Page<AnnouncementResponseDto.Summary>> getAnnouncements(
             @PathVariable Long projectId,
             @AuthenticationPrincipal AuthMember authMember,
-            @PageableDefault(
-                    size = 10,
-                    sort = {"updatedAt", "announcementId"},
-                    direction = Sort.Direction.DESC
-            )
-            Pageable pageable
+            @PageableDefault(size = 10) Pageable pageable
     ){
         Page<AnnouncementResponseDto.Summary> response = announcementService.getAnnouncements(projectId, authMember.getUserId(), pageable);
         return ApiResponse.onSuccess("공지사항 목록 조회에 성공하였습니다.", response);

--- a/src/main/java/com/_penLearning/Noddi/domain/announcement/dto/AnnouncementRequestDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/announcement/dto/AnnouncementRequestDto.java
@@ -1,0 +1,35 @@
+package com._penLearning.Noddi.domain.announcement.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class AnnouncementRequestDto {
+
+    @Getter
+    @NoArgsConstructor
+    public static class Create{
+
+        @NotBlank
+        @Size(max = 50)
+        private String title;
+
+        @NotBlank
+        @Size(max = 1000)
+        private String content;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class Update{
+
+        @NotBlank
+        @Size(max = 50)
+        private String title;
+
+        @NotBlank
+        @Size(max = 1000)
+        private String content;
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/announcement/dto/AnnouncementResponseDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/announcement/dto/AnnouncementResponseDto.java
@@ -1,0 +1,72 @@
+package com._penLearning.Noddi.domain.announcement.dto;
+
+import com._penLearning.Noddi.domain.announcement.entity.Announcement;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+public class AnnouncementResponseDto {
+
+    @Getter
+    @Builder
+    public static class Result {
+        private Long announcementId;
+
+        public static Result from(Announcement announcement) {
+            return Result.builder()
+                    .announcementId(announcement.getAnnouncementId())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class Summary {
+        private Long announcementId;
+        private Long teamId;
+        private String teamName;
+        private String title;
+        private String content;
+        private LocalDateTime updatedAt;
+
+        public static Summary from(Announcement announcement) {
+            return Summary.builder()
+                    .announcementId(announcement.getAnnouncementId())
+                    .teamId(announcement.getTeam().getTeamId())
+                    .teamName(announcement.getTeam().getName())
+                    .title(announcement.getTitle())
+                    .content(announcement.getContent())
+                    .updatedAt(announcement.getUpdatedAt())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class Detail {
+        private Long announcementId;
+        private Long teamId;
+        private String teamName;
+        private Long authorId;
+        private String authorName;
+        private String title;
+        private String content;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+
+        public static Detail from(Announcement announcement) {
+            return Detail.builder()
+                    .announcementId(announcement.getAnnouncementId())
+                    .teamId(announcement.getTeam().getTeamId())
+                    .teamName(announcement.getTeam().getName())
+                    .authorId(announcement.getAuthor().getUserId())
+                    .authorName(announcement.getAuthor().getName())
+                    .title(announcement.getTitle())
+                    .content(announcement.getContent())
+                    .createdAt(announcement.getCreatedAt())
+                    .updatedAt(announcement.getUpdatedAt())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/announcement/entity/Announcement.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/announcement/entity/Announcement.java
@@ -1,0 +1,48 @@
+package com._penLearning.Noddi.domain.announcement.entity;
+
+
+import com._penLearning.Noddi.domain.team.entity.Team;
+import com._penLearning.Noddi.domain.user.entity.User;
+import com._penLearning.Noddi.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Announcement extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long announcementId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "teamId", nullable = false)
+    private Team team;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "authorId", nullable = false)
+    private User author;
+
+    @Column(nullable = false, length = 50)
+    private String title;
+
+    @Column(nullable = false, length = 1000)
+    private String content;
+
+    public void update(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+
+    @Builder
+    public Announcement(Team team, User author, String title, String content){
+        this.team = team;
+        this.author = author;
+        this.title = title;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/announcement/repository/AnnouncementRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/announcement/repository/AnnouncementRepository.java
@@ -1,0 +1,55 @@
+package com._penLearning.Noddi.domain.announcement.repository;
+
+import com._penLearning.Noddi.domain.announcement.entity.Announcement;
+import com._penLearning.Noddi.domain.project.entity.Project;
+import com._penLearning.Noddi.domain.team.entity.Team;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface AnnouncementRepository extends JpaRepository<Announcement, Long> {
+
+    @Query(
+            value = """
+                SELECT announcement
+                FROM Announcement announcement
+                JOIN FETCH announcement.team team
+                WHERE team.project = :project
+                """,
+            countQuery = """
+                SELECT COUNT(announcement)
+                FROM Announcement announcement
+                WHERE announcement.team.project = :project
+                """
+    )
+    Page<Announcement> findAllByProjectWithTeam(
+            @Param("project") Project project,
+            Pageable pageable
+    );
+
+    @Query("""
+        SELECT announcement
+        FROM Announcement announcement
+        JOIN FETCH announcement.team team
+        JOIN FETCH announcement.author
+        WHERE announcement.announcementId = :announcementId
+          AND team.project = :project
+        """)
+    Optional<Announcement> findByIdAndProjectWithTeamAndAuthor(
+            @Param("announcementId") Long announcementId,
+            @Param("project") Project project
+    );
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM Announcement announcement WHERE announcement.team = :team")
+    void bulkDeleteByTeam(@Param("team") Team team);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM Announcement announcement WHERE announcement.team.project = :project")
+    void bulkDeleteByProject(@Param("project") Project project);
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/announcement/service/AnnouncementService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/announcement/service/AnnouncementService.java
@@ -20,7 +20,9 @@ import com._penLearning.Noddi.domain.user.repository.UserRepository;
 import com._penLearning.Noddi.global.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,6 +30,12 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class AnnouncementService {
+
+    private static final int MAX_PAGE_SIZE = 50;
+    private static final Sort LATEST_ANNOUNCEMENT_SORT = Sort.by(
+            Sort.Order.desc("updatedAt"),
+            Sort.Order.desc("announcementId")
+    );
 
     private final UserRepository userRepository;
     private final TeamRepository teamRepository;
@@ -107,7 +115,13 @@ public class AnnouncementService {
 
         validateProjectMember(project, requester);
 
-        return announcementRepository.findAllByProjectWithTeam(project, pageable)
+        Pageable fixedPageable = PageRequest.of(
+                pageable.getPageNumber(),
+                Math.min(pageable.getPageSize(), MAX_PAGE_SIZE),
+                LATEST_ANNOUNCEMENT_SORT
+        );
+
+        return announcementRepository.findAllByProjectWithTeam(project, fixedPageable)
                 .map(AnnouncementResponseDto.Summary::from);
     }
 

--- a/src/main/java/com/_penLearning/Noddi/domain/announcement/service/AnnouncementService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/announcement/service/AnnouncementService.java
@@ -1,0 +1,172 @@
+package com._penLearning.Noddi.domain.announcement.service;
+
+
+import com._penLearning.Noddi.domain.announcement.code.AnnouncementErrorCode;
+import com._penLearning.Noddi.domain.announcement.dto.AnnouncementRequestDto;
+import com._penLearning.Noddi.domain.announcement.dto.AnnouncementResponseDto;
+import com._penLearning.Noddi.domain.announcement.entity.Announcement;
+import com._penLearning.Noddi.domain.announcement.repository.AnnouncementRepository;
+import com._penLearning.Noddi.domain.project.code.ProjectErrorCode;
+import com._penLearning.Noddi.domain.project.entity.Project;
+import com._penLearning.Noddi.domain.project.repository.ProjectMemberRepository;
+import com._penLearning.Noddi.domain.project.repository.ProjectRepository;
+import com._penLearning.Noddi.domain.team.code.TeamErrorCode;
+import com._penLearning.Noddi.domain.team.entity.Team;
+import com._penLearning.Noddi.domain.team.repository.TeamMemberRepository;
+import com._penLearning.Noddi.domain.team.repository.TeamRepository;
+import com._penLearning.Noddi.domain.user.code.UserErrorCode;
+import com._penLearning.Noddi.domain.user.entity.User;
+import com._penLearning.Noddi.domain.user.repository.UserRepository;
+import com._penLearning.Noddi.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AnnouncementService {
+
+    private final UserRepository userRepository;
+    private final TeamRepository teamRepository;
+    private final TeamMemberRepository teamMemberRepository;
+    private final ProjectRepository projectRepository;
+    private final ProjectMemberRepository projectMemberRepository;
+    private final AnnouncementRepository announcementRepository;
+
+    @Transactional
+    public AnnouncementResponseDto.Result createAnnouncement(
+            Long projectId,
+            Long teamId,
+            Long authorId,
+            AnnouncementRequestDto.Create request
+    ) {
+        Project project = getProjectOrThrow(projectId);
+        Team team = getTeamOrThrow(teamId);
+        User author = getUserOrThrow(authorId);
+
+        validateProjectMember(project, author);
+        validateTeamBelongsToProject(project, team);
+        validateTeamMember(team, author);
+
+        Announcement announcement = Announcement.builder()
+                .team(team)
+                .author(author)
+                .title(request.getTitle())
+                .content(request.getContent())
+                .build();
+        Announcement savedAnnouncement = announcementRepository.save(announcement);
+
+        return AnnouncementResponseDto.Result.from(savedAnnouncement);
+    }
+
+    @Transactional
+    public AnnouncementResponseDto.Result updateAnnouncement(
+            Long projectId,
+            Long announcementId,
+            Long requesterId,
+            AnnouncementRequestDto.Update request
+    ) {
+        Project project = getProjectOrThrow(projectId);
+        User requester = getUserOrThrow(requesterId);
+
+        validateProjectMember(project, requester);
+
+        Announcement announcement = getAnnouncementOrThrow(announcementId, project);
+        validateTeamMember(announcement.getTeam(), requester);
+        validateAuthor(announcement, requesterId);
+
+        announcement.update(request.getTitle(), request.getContent());
+
+        return AnnouncementResponseDto.Result.from(announcement);
+    }
+
+    public AnnouncementResponseDto.Detail getAnnouncement(
+            Long projectId,
+            Long announcementId,
+            Long requesterId
+    ) {
+        Project project = getProjectOrThrow(projectId);
+        User requester = getUserOrThrow(requesterId);
+
+        validateProjectMember(project, requester);
+
+        Announcement announcement = getAnnouncementOrThrow(announcementId, project);
+        return AnnouncementResponseDto.Detail.from(announcement);
+    }
+
+    public Page<AnnouncementResponseDto.Summary> getAnnouncements(
+            Long projectId,
+            Long requesterId,
+            Pageable pageable
+    ) {
+        Project project = getProjectOrThrow(projectId);
+        User requester = getUserOrThrow(requesterId);
+
+        validateProjectMember(project, requester);
+
+        return announcementRepository.findAllByProjectWithTeam(project, pageable)
+                .map(AnnouncementResponseDto.Summary::from);
+    }
+
+    @Transactional
+    public void deleteAnnouncement(Long projectId, Long announcementId, Long requesterId) {
+        Project project = getProjectOrThrow(projectId);
+        User requester = getUserOrThrow(requesterId);
+
+        validateProjectMember(project, requester);
+
+        Announcement announcement = getAnnouncementOrThrow(announcementId, project);
+        validateTeamMember(announcement.getTeam(), requester);
+        validateAuthor(announcement, requesterId);
+
+        announcementRepository.delete(announcement);
+    }
+
+    //--검증 헬퍼 메서드--
+    private Project getProjectOrThrow(Long projectId) {
+        return projectRepository.findById(projectId)
+                .orElseThrow(() -> new GeneralException(ProjectErrorCode.PROJECT_NOT_FOUND));
+    }
+
+    private Team getTeamOrThrow(Long teamId) {
+        return teamRepository.findById(teamId)
+                .orElseThrow(() -> new GeneralException(TeamErrorCode.TEAM_NOT_FOUND));
+    }
+
+    private User getUserOrThrow(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    private void validateProjectMember(Project project, User user) {
+        if (!projectMemberRepository.existsByProjectAndUser(project, user)) {
+            throw new GeneralException(ProjectErrorCode.PROJECT_MEMBER_NOT_FOUND);
+        }
+    }
+
+    private void validateTeamBelongsToProject(Project project, Team team) {
+        if (!team.getProject().getProjectId().equals(project.getProjectId())) {
+            throw new GeneralException(TeamErrorCode.TEAM_NOT_FOUND);
+        }
+    }
+
+    private void validateTeamMember(Team team, User user) {
+        if (!teamMemberRepository.existsByTeamAndUser(team, user)) {
+            throw new GeneralException(TeamErrorCode.TEAM_MEMBER_NOT_FOUND);
+        }
+    }
+
+    private Announcement getAnnouncementOrThrow(Long announcementId, Project project) {
+        return announcementRepository.findByIdAndProjectWithTeamAndAuthor(announcementId, project)
+                .orElseThrow(() -> new GeneralException(AnnouncementErrorCode.ANNOUNCEMENT_NOT_FOUND));
+    }
+
+    private void validateAuthor(Announcement announcement, Long requesterId) {
+        if (!announcement.getAuthor().getUserId().equals(requesterId)) {
+            throw new GeneralException(AnnouncementErrorCode.YOU_ARE_NOT_AUTHOR);
+        }
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/project/service/ProjectService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/service/ProjectService.java
@@ -1,5 +1,6 @@
 package com._penLearning.Noddi.domain.project.service;
 
+import com._penLearning.Noddi.domain.announcement.repository.AnnouncementRepository;
 import com._penLearning.Noddi.domain.project.code.ProjectErrorCode;
 import com._penLearning.Noddi.domain.project.dto.ProjectRequestDto;
 import com._penLearning.Noddi.domain.project.dto.ProjectResponseDto;
@@ -39,6 +40,7 @@ public class ProjectService {
     private final TeamMemberRepository teamMemberRepository;
     private final TeamPageRepository teamPageRepository;
     private final KnowledgeDeletionService knowledgeDeletionService;
+    private final AnnouncementRepository announcementRepository;
 
     // 프로젝트 생성
     @Transactional
@@ -103,6 +105,7 @@ public class ProjectService {
         knowledgeDeletionService.deleteProjectKnowledge(projectId);
 
         // FK 제약조건을 고려해 팀의 하위 데이터부터 삭제한다.
+        announcementRepository.bulkDeleteByProject(project);
         teamPageRepository.bulkDeleteByProject(project);
         teamInviteRepository.bulkDeleteByProject(project);
         teamMemberRepository.bulkDeleteByProject(project);

--- a/src/main/java/com/_penLearning/Noddi/domain/team/service/TeamCommandService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/team/service/TeamCommandService.java
@@ -1,5 +1,6 @@
 package com._penLearning.Noddi.domain.team.service;
 
+import com._penLearning.Noddi.domain.announcement.repository.AnnouncementRepository;
 import com._penLearning.Noddi.domain.project.code.ProjectErrorCode;
 import com._penLearning.Noddi.domain.project.entity.Project;
 import com._penLearning.Noddi.domain.project.entity.ProjectMember;
@@ -35,6 +36,7 @@ public class TeamCommandService {
     private final TeamInviteExpirationService teamInviteExpirationService;
     private final TeamPageRepository teamPageRepository;
     private final KnowledgeDeletionService knowledgeDeletionService;
+    private final AnnouncementRepository announcementRepository;
 
     // 팀 생성 (생성자는 자동으로 LEADER 역할 부여)
     @Transactional
@@ -158,6 +160,7 @@ public class TeamCommandService {
         knowledgeDeletionService.deleteTeamKnowledge(teamId);
 
         // 하위 데이터 일괄 삭제 (FK 제약조건 방어)
+        announcementRepository.bulkDeleteByTeam(team);
         teamPageRepository.bulkDeleteByTeam(team);
         teamInviteRepository.deleteAllByTeam(team);
         teamMemberRepository.deleteAllByTeam(team);

--- a/src/main/java/com/_penLearning/Noddi/global/config/SwaggerConfig.java
+++ b/src/main/java/com/_penLearning/Noddi/global/config/SwaggerConfig.java
@@ -41,6 +41,7 @@ public class SwaggerConfig {
                 new Tag().name("Auth API").description("인증 API"),
                 new Tag().name("User API").description("사용자 API"),
                 new Tag().name("Organization API").description("조직 API"),
+                new Tag().name("Announcement API").description("프로젝트 전체 공지 API"),
                 new Tag().name("Project API").description("프로젝트 API"),
                 new Tag().name("Project Member API").description("프로젝트 멤버 API"),
                 new Tag().name("Team API").description("팀 API"),


### PR DESCRIPTION
## <i>PULL REQUEST</i>

## 🎋 작업 브랜치
- `feat/#37-announcement` → `develop`
- #37

## 💡 작업동기
- 프로젝트에 속한 여러 팀이 공지사항을 등록하고, 프로젝트 구성원 전체가 이를 확인할 수 있도록 공지 기능을 구현했습니다.
- 팀별 주요 일정과 전달 사항을 프로젝트 단위로 한곳에서 확인할 수 있도록 조회 범위를 구성했습니다.

## 🔑 주요 변경사항
- 프로젝트 전체 공지 CRUD API 구현
- 공지 작성 팀과 작성자 연관관계 구성
- 프로젝트 멤버만 공지 목록과 상세 내용을 조회할 수 있도록 권한 검증
- 프로젝트 및 해당 팀의 멤버만 공지를 등록할 수 있도록 권한 검증
- 현재 작성 팀에 소속된 작성자만 공지를 수정·삭제할 수 있도록 권한 검증
- 다른 프로젝트의 공지에 접근할 수 없도록 프로젝트 단위 조회 범위 제한
- 공지 목록 페이징 및 최근 수정 순 정렬 적용
- Team·Author fetch join을 통한 조회 쿼리 최적화
- 팀 및 프로젝트 삭제 시 연관 공지를 먼저 벌크 삭제하도록 FK 정합성 보완
- 공지 제목 50자, 본문 1,000자 입력값 검증 적용
- Swagger API 명세 및 공지 도메인 태그 추가

## 🏞 스크린샷 (선택)
> 스크린샷을 첨부해주세요.

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
