### PR TITLE
[Feat] 프로젝트·팀별 Q&A 피드 조회 API 구현

### DIFF
--- a/src/main/java/com/_penLearning/Noddi/domain/qa/code/QaApi.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/code/QaApi.java
@@ -32,6 +32,19 @@ public interface QaApi {
             @Parameter(hidden = true) AuthMember authMember,
             Pageable pageable
     );
+    @Operation(summary = "팀 Q&A 피드 조회",
+            description = """
+                특정 팀에 등록된 질문과 현재 답변을 피드 형태로 조회합니다.
+                cursor를 생략하면 최신 질문부터 조회하며,
+                응답의 nextCursor를 다음 요청의 cursor로 전달하면 이전 질문을 조회할 수 있습니다.
+                """
+    )
+    ApiResponse<QaResponseDto.Feed> getTeamFeed(
+            @Parameter(description = "대상 팀 ID") Long teamId,
+            @Parameter(description = "이전 질문 조회를 위한 커서(questionId)", example = "100") Long cursor,
+            @Parameter(description = "한 번에 조회할 질문 수, 1 이상 50 이하", example = "20") int size,
+            @Parameter(hidden = true) AuthMember authMember
+    );
 
     @Operation(summary = "질문 상세 조회", description = "단건 질문의 상세 내용과 (존재할 경우) 답변을 조회합니다.")
     ApiResponse<QaResponseDto.QuestionDetail> getQuestionDetail(

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/code/QaApi.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/code/QaApi.java
@@ -42,7 +42,7 @@ public interface QaApi {
     ApiResponse<QaResponseDto.Feed> getTeamFeed(
             @Parameter(description = "대상 팀 ID") Long teamId,
             @Parameter(description = "이전 질문 조회를 위한 커서(questionId)", example = "100") Long cursor,
-            @Parameter(description = "한 번에 조회할 질문 수, 1 이상 50 이하", example = "20") int size,
+            @Parameter(description = "한 번에 조회할 질문 수, 1 이상 50 이하 (기본값 20)", example = "20") int size,
             @Parameter(hidden = true) AuthMember authMember
     );
 

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/code/QaErrorCode.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/code/QaErrorCode.java
@@ -9,27 +9,22 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum QaErrorCode implements BaseErrorCode {
 
-    INVALID_AI_ANSWER_CITATION(
-            HttpStatus.INTERNAL_SERVER_ERROR,
-            "QA500_2",
-            "AI 답변에서 유효한 근거를 확인할 수 없습니다."
-    ),
+    INVALID_AI_ANSWER_CITATION(HttpStatus.INTERNAL_SERVER_ERROR, "QA500_2", "AI 답변에서 유효한 근거를 확인할 수 없습니다."),
+    AI_ANSWER_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "QA500_1", "AI 답변을 생성하지 못했습니다."),
 
-    AI_ANSWER_GENERATION_FAILED(
-            HttpStatus.INTERNAL_SERVER_ERROR,
-            "QA500_1",
-            "AI 답변을 생성하지 못했습니다."
-    ),
-
-    INVALID_QUESTION_STATUS(HttpStatus.CONFLICT, "QA409_2", "현재 질문 상태에서는 요청한 작업을 수행할 수 없습니다."),
-
-    QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "QA404_1", "질문을 찾을 수 없습니다."),
-    ANSWER_NOT_FOUND(HttpStatus.NOT_FOUND, "QA404_2", "답변을 찾을 수 없습니다."),
+    INVALID_FEED_SIZE(HttpStatus.BAD_REQUEST, "QA400_1", "피드 조회 크기는 1 이상 50 이하여야 합니다."),
+    INVALID_FEED_CURSOR(HttpStatus.BAD_REQUEST, "QA400_2", "피드 커서는 1 이상이어야 합니다."),
 
     NOT_PROJECT_MEMBER(HttpStatus.FORBIDDEN, "QA403_1", "해당 프로젝트의 멤버가 아닙니다."),
     NOT_TARGET_TEAM_MEMBER(HttpStatus.FORBIDDEN, "QA403_2", "질문 대상 팀의 멤버만 답변할 수 있습니다."),
 
-    ALREADY_ANSWERED(HttpStatus.CONFLICT, "QA409_1", "이미 답변이 완료된 질문입니다.");
+    QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "QA404_1", "질문을 찾을 수 없습니다."),
+    ANSWER_NOT_FOUND(HttpStatus.NOT_FOUND, "QA404_2", "답변을 찾을 수 없습니다."),
+
+    ALREADY_ANSWERED(HttpStatus.CONFLICT, "QA409_1", "이미 답변이 완료된 질문입니다."),
+    INVALID_QUESTION_STATUS(HttpStatus.CONFLICT, "QA409_2", "현재 질문 상태에서는 요청한 작업을 수행할 수 없습니다.");
+
+
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/controller/QaController.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/controller/QaController.java
@@ -57,6 +57,20 @@ public class QaController implements QaApi {
         return ApiResponse.onSuccess("팀 질문 목록 조회에 성공했습니다.", response);
     }
 
+    // 특정 팀의 질문과 답변 피드 조회
+    @Override
+    @GetMapping("/api/v1/teams/{teamId}/qa/feed")
+    public ApiResponse<QaResponseDto.Feed> getTeamFeed(
+            @PathVariable Long teamId,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "20") int size,
+            @AuthenticationPrincipal AuthMember authMember
+    ) {
+        QaResponseDto.Feed response = qaQuestionQueryService.getTeamFeed(authMember.getUserId(), teamId, cursor, size);
+
+        return ApiResponse.onSuccess("팀 Q&A 피드 조회에 성공했습니다.", response);
+    }
+
     // 질문 상세 단건 조회
     @Override
     @GetMapping("/api/v1/qa/questions/{questionId}")

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/dto/QaResponseDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/dto/QaResponseDto.java
@@ -6,6 +6,7 @@ import com._penLearning.Noddi.domain.qa.entity.QaAnswerSource;
 import com._penLearning.Noddi.domain.qa.entity.QaQuestion;
 import com._penLearning.Noddi.domain.qa.entity.QaStatus;
 import com._penLearning.Noddi.domain.qa.entity.SourceType;
+import com._penLearning.Noddi.domain.team.entity.Team;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -139,6 +140,110 @@ public class QaResponseDto {
                     .referenceId(source.getReferenceId())
                     .sourceTitle(source.getSourceTitle())
                     .excerpt(source.getExcerpt())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class Feed {
+        private Long projectId;
+        private String projectName;
+
+        private Long teamId;
+        private String teamName;
+
+        private List<FeedItem> items;
+
+        private Long nextCursor;
+        private boolean hasNext;
+
+        public static Feed of(Team team, List<FeedItem> items, Long nextCursor, boolean hasNext) {
+            return Feed.builder()
+                    .projectId(team.getProject().getProjectId())
+                    .projectName(team.getProject().getName())
+                    .teamId(team.getTeamId())
+                    .teamName(team.getName())
+                    .items(items)
+                    .nextCursor(nextCursor)
+                    .hasNext(hasNext)
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class FeedItem {
+        private FeedQuestion question;
+        private QaStatus status;
+        private FeedAnswer answer;
+
+        public static FeedItem of(QaQuestion question, QaAnswer answer, List<QaAnswerSource> sources) {
+            return FeedItem.builder()
+                    .question(FeedQuestion.from(question))
+                    .status(question.getStatus())
+                    .answer(
+                            answer != null ? FeedAnswer.from(answer, sources) : null
+                    )
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class FeedQuestion {
+        private Long questionId;
+
+        private Long questionerId;
+        private String questionerName;
+
+        private String content;
+        private LocalDateTime createdAt;
+        //현재 소속 부서 + 직함 엔티티가 없어서 일단 빼고 이름만 반환
+
+        public static FeedQuestion from(QaQuestion question){
+            return FeedQuestion.builder()
+                    .questionId(question.getQuestionId())
+                    .questionerId(question.getQuestioner().getUserId())
+                    .questionerName(question.getQuestioner().getName())
+                    .content(question.getContent())
+                    .createdAt(question.getCreatedAt())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class FeedAnswer {
+        private Long answerId;
+        private String content;
+        private AnswerType answerType;
+
+        private boolean revised;
+
+        private Long lastRevisedById;
+        private String lastRevisedByName;
+
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+
+        private List<AnswerSourceInfo> sources;
+
+        public static FeedAnswer from(QaAnswer answer, List<QaAnswerSource> sources) {
+            return FeedAnswer.builder()
+                    .answerId(answer.getAnswerId())
+                    .content(answer.getContent())
+                    .answerType(answer.getAnswerType())
+                    .revised(answer.isRevised())
+                    .lastRevisedById(
+                            answer.isRevised() ? answer.getRevisedBy().getUserId() : null
+                    )
+                    .lastRevisedByName(
+                            answer.isRevised() ? answer.getRevisedBy().getName() : null
+                    )
+                    .createdAt(answer.getCreatedAt())
+                    .updatedAt(answer.getUpdatedAt())
+                    .sources(sources.stream().map(AnswerSourceInfo::from).toList())
                     .build();
         }
     }

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/repository/QaAnswerRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/repository/QaAnswerRepository.java
@@ -9,6 +9,8 @@ import org.springframework.data.repository.query.Param;
 
 import jakarta.persistence.LockModeType;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface QaAnswerRepository extends JpaRepository<QaAnswer, Long> {
@@ -27,4 +29,15 @@ public interface QaAnswerRepository extends JpaRepository<QaAnswer, Long> {
             WHERE a.answerId = :answerId
             """)
     Optional<QaAnswer> findByIdWithQuestionAndTeamForUpdate(@Param("answerId") Long answerId);
+
+    @Query("""
+        SELECT a
+        FROM QaAnswer a
+        JOIN FETCH a.question q
+        LEFT JOIN FETCH a.revisedBy
+        WHERE q IN :questions
+        """)
+    List<QaAnswer> findAllByQuestionsWithReviser(
+            @Param("questions") Collection<QaQuestion> questions
+    );
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/repository/QaAnswerSourceRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/repository/QaAnswerSourceRepository.java
@@ -1,11 +1,13 @@
 package com._penLearning.Noddi.domain.qa.repository;
 
+import com._penLearning.Noddi.domain.qa.entity.QaAnswer;
 import com._penLearning.Noddi.domain.qa.entity.QaAnswerSource;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface QaAnswerSourceRepository extends JpaRepository<QaAnswerSource, Long> {
@@ -16,4 +18,15 @@ public interface QaAnswerSourceRepository extends JpaRepository<QaAnswerSource, 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE FROM QaAnswerSource source WHERE source.answer.answerId = :answerId")
     int deleteAllByAnswerId(@Param("answerId") Long answerId);
+
+    @Query("""
+        SELECT source
+        FROM QaAnswerSource source
+        JOIN FETCH source.answer answer
+        WHERE answer IN :answers
+        ORDER BY answer.answerId ASC, source.citationIndex ASC
+        """)
+    List<QaAnswerSource> findAllByAnswersOrderByCitationIndex(
+            @Param("answers") Collection<QaAnswer> answers
+    );
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/repository/QaQuestionRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/repository/QaQuestionRepository.java
@@ -69,4 +69,18 @@ public interface QaQuestionRepository extends JpaRepository<QaQuestion, Long> {
             Collection<QaStatus> statuses,
             LocalDateTime threshold
     );
+
+    @Query("""
+        SELECT q
+        FROM QaQuestion q
+        JOIN FETCH q.questioner
+        WHERE q.targetTeam = :targetTeam
+          AND (:cursor IS NULL OR q.questionId < :cursor)
+        ORDER BY q.questionId DESC
+        """)
+    List<QaQuestion> findFeedByTargetTeam(
+            @Param("targetTeam") Team targetTeam,
+            @Param("cursor") Long cursor,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaQuestionQueryService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaQuestionQueryService.java
@@ -18,11 +18,17 @@ import com._penLearning.Noddi.domain.user.repository.UserRepository;
 import com._penLearning.Noddi.global.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Q&A 피드와 질문 상세 조회를 담당한다.
@@ -51,13 +57,62 @@ public class QaQuestionQueryService {
 
     // 특정 팀에 등록된 질문 조회
     public Page<QaResponseDto.QuestionInfo> getTeamQuestions(Long requesterId, Long teamId, Pageable pageable) {
-        Team targetTeam = teamRepository.findById(teamId)
-                .orElseThrow(() -> new GeneralException(TeamErrorCode.TEAM_NOT_FOUND));
+        Team targetTeam = getTeamOrThrow(teamId);
 
         validateProjectMembership(requesterId, targetTeam);
 
         return qaQuestionRepository.findAllByTargetTeamWithUser(targetTeam, pageable)
                 .map(QaResponseDto.QuestionInfo::from);
+    }
+
+    public QaResponseDto.Feed  getTeamFeed(Long requesterId, Long teamId, Long cursor, int size) {
+        validateFeedRequest(cursor, size);
+
+        Team targetTeam = getTeamOrThrow(teamId);
+
+        validateProjectMembership(requesterId, targetTeam);
+
+        List<QaQuestion> fetchedQuestions = qaQuestionRepository.findFeedByTargetTeam(
+                targetTeam, cursor, PageRequest.of(0, size + 1));
+
+        boolean hasNext = fetchedQuestions.size() > size;
+
+        List<QaQuestion> questions = fetchedQuestions.stream()
+                .limit(size)
+                .toList();
+
+        Long nextCursor = calculateNextCursor(questions, hasNext);
+
+        List<QaAnswer> answers = findAnswers(questions);
+
+        Map<Long, QaAnswer> answerByQuestionId = answers.stream()
+                .collect(Collectors.toMap(
+                        answer -> answer.getQuestion().getQuestionId(),
+                        Function.identity()
+                ));
+
+        List<QaAnswerSource> sources = findSources(answers);
+
+        Map<Long, List<QaAnswerSource>> sourceByAnswerId = sources.stream()
+                .collect(Collectors.groupingBy(
+                        source -> source.getAnswer().getAnswerId()
+                ));
+
+        List<QaResponseDto.FeedItem> items = questions.stream()
+                .map(question -> {
+                    QaAnswer answer = answerByQuestionId.get(question.getQuestionId());
+
+                    List<QaAnswerSource> answerSources =
+                            answer == null ? List.of() : sourceByAnswerId.get(answer.getAnswerId());
+
+                    return QaResponseDto.FeedItem.of(question, answer, answerSources);
+                })
+                .collect(Collectors.toCollection(ArrayList::new));
+
+        Collections.reverse(items);
+
+        return QaResponseDto.Feed.of(targetTeam, items, nextCursor, hasNext);
+
     }
 
     // 질문 상세 조회
@@ -74,6 +129,11 @@ public class QaQuestionQueryService {
         return QaResponseDto.QuestionDetail.of(question, answer, sources);
     }
 
+    private Team getTeamOrThrow(Long teamId) {
+        return teamRepository.findById(teamId)
+                .orElseThrow(() -> new GeneralException(TeamErrorCode.TEAM_NOT_FOUND));
+    }
+
     // 공통 프로젝트 권한 검증 로직
     private void validateProjectMembership(Long requesterId, Team targetTeam) {
         User requester = userRepository.findById(requesterId)
@@ -82,5 +142,42 @@ public class QaQuestionQueryService {
         if (!projectMemberRepository.existsByProjectAndUser(targetTeam.getProject(), requester)) {
             throw new GeneralException(QaErrorCode.NOT_PROJECT_MEMBER);
         }
+    }
+
+    private void validateFeedRequest(Long cursor, int size) {
+        if (size < 1 || size > 50) {
+            throw new GeneralException(QaErrorCode.INVALID_FEED_SIZE);
+        }
+
+        if (cursor != null && cursor < 1) {
+            throw new GeneralException(QaErrorCode.INVALID_FEED_CURSOR);
+        }
+    }
+
+    private Long calculateNextCursor(List<QaQuestion> questions, boolean hasNext)
+    {
+        if (!hasNext || questions.isEmpty()) {
+            return null;
+        }
+
+        return questions.get(questions.size() - 1).getQuestionId();
+    }
+
+    private List<QaAnswer> findAnswers(List<QaQuestion> questions)
+    {
+        if (questions.isEmpty()) {
+            return List.of();
+        }
+
+        return qaAnswerRepository.findAllByQuestionsWithReviser(questions);
+    }
+
+    private List<QaAnswerSource> findSources(List<QaAnswer> answers)
+    {
+        if (answers.isEmpty()) {
+            return List.of();
+        }
+
+        return qaAnswerSourceRepository.findAllByAnswersOrderByCitationIndex(answers);
     }
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaQuestionQueryService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaQuestionQueryService.java
@@ -103,7 +103,7 @@ public class QaQuestionQueryService {
                     QaAnswer answer = answerByQuestionId.get(question.getQuestionId());
 
                     List<QaAnswerSource> answerSources =
-                            answer == null ? List.of() : sourceByAnswerId.get(answer.getAnswerId());
+                            answer == null ? List.of() : sourceByAnswerId.getOrDefault(answer.getAnswerId(), List.of());
 
                     return QaResponseDto.FeedItem.of(question, answer, answerSources);
                 })

--- a/src/test/java/com/_penLearning/Noddi/domain/qa/controller/QaControllerTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/qa/controller/QaControllerTest.java
@@ -1,0 +1,199 @@
+package com._penLearning.Noddi.domain.qa.controller;
+
+import com._penLearning.Noddi.domain.auth.entity.AuthMember;
+import com._penLearning.Noddi.domain.qa.dto.QaResponseDto;
+import com._penLearning.Noddi.domain.qa.entity.AnswerType;
+import com._penLearning.Noddi.domain.qa.entity.QaStatus;
+import com._penLearning.Noddi.domain.qa.entity.SourceType;
+import com._penLearning.Noddi.domain.qa.service.QaAnswerUpdateService;
+import com._penLearning.Noddi.domain.qa.service.QaQuestionCommandService;
+import com._penLearning.Noddi.domain.qa.service.QaQuestionQueryService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class QaControllerTest {
+
+    /*
+     * 이 테스트는 HTTP 요청이 QaController를 거쳐 서비스 호출과 JSON 응답으로 이어지는지 확인한다.
+     * 실제 비즈니스 규칙은 QaQuestionQueryServiceTest에서 검증했으므로 여기서는 다음 경계만 확인한다.
+     *
+     * 1. URL의 teamId와 query parameter가 올바르게 바인딩된다.
+     * 2. 로그인 사용자의 userId가 @AuthenticationPrincipal에서 추출된다.
+     * 3. 컨트롤러가 서비스 반환값을 공통 ApiResponse 형식으로 감싸서 응답한다.
+     */
+
+    @Mock
+    private QaQuestionCommandService qaQuestionCommandService;
+
+    @Mock
+    private QaQuestionQueryService qaQuestionQueryService;
+
+    @Mock
+    private QaAnswerUpdateService qaAnswerUpdateService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        QaController controller = new QaController(
+                qaQuestionCommandService,
+                qaQuestionQueryService,
+                qaAnswerUpdateService
+        );
+
+        // 실제 JWT 필터를 실행하는 대신 로그인 완료 후 SecurityContext에 들어갈 인증 객체를 준비한다.
+        // AuthenticationPrincipalArgumentResolver가 이 principal을 읽어 컨트롤러의 AuthMember 인자로 전달한다.
+        AuthMember authMember = AuthMember.builder()
+                .userId(1L)
+                .email("requester@noddi.com")
+                .build();
+
+        SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+        securityContext.setAuthentication(
+                new UsernamePasswordAuthenticationToken(authMember, null, List.of())
+        );
+        SecurityContextHolder.setContext(securityContext);
+
+        // Spring 전체 애플리케이션을 띄우지 않고 QaController만 MockMvc에 연결한다.
+        // 따라서 이 테스트는 빠르게 HTTP 매핑과 응답 직렬화에만 집중할 수 있다.
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setCustomArgumentResolvers(new AuthenticationPrincipalArgumentResolver())
+                .build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        // SecurityContextHolder는 ThreadLocal을 사용하므로 다음 테스트에 인증 정보가 남지 않게 정리한다.
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void returnsTeamQaFeedWithDefaultPagination() throws Exception {
+        // Given: 서비스가 질문, AI 답변, 답변 근거가 결합된 피드를 반환한다.
+        LocalDateTime createdAt = LocalDateTime.of(2026, 8, 15, 10, 0);
+        QaResponseDto.Feed response = createAnsweredFeed(createdAt);
+
+        // cursor를 생략하고 size도 보내지 않으면 컨트롤러의 기본값인 20이 서비스에 전달되어야 한다.
+        when(qaQuestionQueryService.getTeamFeed(1L, 10L, null, 20))
+                .thenReturn(response);
+
+        // When & Then: 팀 Q&A 피드 API를 호출하면 공통 응답 형식과 피드 내용이 JSON으로 반환된다.
+        mockMvc.perform(get("/api/v1/teams/{teamId}/qa/feed", 10L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.message").value("팀 Q&A 피드 조회에 성공했습니다."))
+                .andExpect(jsonPath("$.result.projectId").value(100L))
+                .andExpect(jsonPath("$.result.projectName").value("노디프로젝트"))
+                .andExpect(jsonPath("$.result.teamId").value(10L))
+                .andExpect(jsonPath("$.result.teamName").value("마케팅팀"))
+                .andExpect(jsonPath("$.result.hasNext").value(false))
+                .andExpect(jsonPath("$.result.nextCursor").isEmpty())
+                .andExpect(jsonPath("$.result.items[0].question.questionId").value(101L))
+                .andExpect(jsonPath("$.result.items[0].question.questionerName").value("김유진"))
+                .andExpect(jsonPath("$.result.items[0].status").value("ANSWERED"))
+                .andExpect(jsonPath("$.result.items[0].answer.answerId").value(201L))
+                .andExpect(jsonPath("$.result.items[0].answer.answerType").value("AI"))
+                .andExpect(jsonPath("$.result.items[0].answer.sources[0].citationIndex").value(1))
+                .andExpect(jsonPath("$.result.items[0].answer.sources[0].sourceTitle")
+                        .value("8월 기획 회의"));
+
+        // 로그인 사용자 ID, 경로의 팀 ID, 기본 페이지 조건이 서비스에 그대로 전달됐는지 확인한다.
+        verify(qaQuestionQueryService).getTeamFeed(1L, 10L, null, 20);
+    }
+
+    @Test
+    void passesCursorAndSizeQueryParametersToService() throws Exception {
+        // Given: 이전 응답의 nextCursor=81을 사용해 과거 질문 10개를 요청하는 상황이다.
+        QaResponseDto.Feed response = QaResponseDto.Feed.builder()
+                .projectId(100L)
+                .projectName("노디프로젝트")
+                .teamId(10L)
+                .teamName("마케팅팀")
+                .items(List.of())
+                .nextCursor(70L)
+                .hasNext(true)
+                .build();
+
+        when(qaQuestionQueryService.getTeamFeed(1L, 10L, 81L, 10))
+                .thenReturn(response);
+
+        // When: 클라이언트가 cursor와 size를 query parameter로 명시해 다음 페이지를 요청한다.
+        mockMvc.perform(get("/api/v1/teams/{teamId}/qa/feed", 10L)
+                        .param("cursor", "81")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.items").isArray())
+                .andExpect(jsonPath("$.result.items").isEmpty())
+                .andExpect(jsonPath("$.result.nextCursor").value(70L))
+                .andExpect(jsonPath("$.result.hasNext").value(true));
+
+        // Then: 문자열 query parameter가 Long과 int로 변환되어 서비스에 정확히 전달된다.
+        verify(qaQuestionQueryService).getTeamFeed(1L, 10L, 81L, 10);
+    }
+
+    private QaResponseDto.Feed createAnsweredFeed(LocalDateTime createdAt) {
+        // 응답 JSON 구조 검증에 사용할 대표 데이터다.
+        // Controller 테스트에서는 Entity 변환을 다시 시험하지 않고 완성된 DTO를 직접 만든다.
+        QaResponseDto.AnswerSourceInfo source = QaResponseDto.AnswerSourceInfo.builder()
+                .citationIndex(1)
+                .sourceType(SourceType.TRANSCRIPT)
+                .referenceId(301L)
+                .sourceTitle("8월 기획 회의")
+                .excerpt("출시일을 9월 5일로 변경합니다.")
+                .build();
+
+        QaResponseDto.FeedAnswer answer = QaResponseDto.FeedAnswer.builder()
+                .answerId(201L)
+                .content("출시일은 9월 5일입니다.")
+                .answerType(AnswerType.AI)
+                .revised(false)
+                .createdAt(createdAt.plusSeconds(5))
+                .updatedAt(createdAt.plusSeconds(5))
+                .sources(List.of(source))
+                .build();
+
+        QaResponseDto.FeedQuestion question = QaResponseDto.FeedQuestion.builder()
+                .questionId(101L)
+                .questionerId(1L)
+                .questionerName("김유진")
+                .content("출시일은 언제인가요?")
+                .createdAt(createdAt)
+                .build();
+
+        QaResponseDto.FeedItem item = QaResponseDto.FeedItem.builder()
+                .question(question)
+                .status(QaStatus.ANSWERED)
+                .answer(answer)
+                .build();
+
+        return QaResponseDto.Feed.builder()
+                .projectId(100L)
+                .projectName("노디프로젝트")
+                .teamId(10L)
+                .teamName("마케팅팀")
+                .items(List.of(item))
+                .nextCursor(null)
+                .hasNext(false)
+                .build();
+    }
+}

--- a/src/test/java/com/_penLearning/Noddi/domain/qa/service/QaQuestionQueryServiceTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/qa/service/QaQuestionQueryServiceTest.java
@@ -1,0 +1,340 @@
+package com._penLearning.Noddi.domain.qa.service;
+
+import com._penLearning.Noddi.domain.project.entity.Project;
+import com._penLearning.Noddi.domain.project.repository.ProjectMemberRepository;
+import com._penLearning.Noddi.domain.qa.dto.QaResponseDto;
+import com._penLearning.Noddi.domain.qa.entity.AnswerType;
+import com._penLearning.Noddi.domain.qa.entity.QaAnswer;
+import com._penLearning.Noddi.domain.qa.entity.QaAnswerSource;
+import com._penLearning.Noddi.domain.qa.entity.QaQuestion;
+import com._penLearning.Noddi.domain.qa.entity.QaStatus;
+import com._penLearning.Noddi.domain.qa.entity.SourceType;
+import com._penLearning.Noddi.domain.qa.repository.QaAnswerRepository;
+import com._penLearning.Noddi.domain.qa.repository.QaAnswerSourceRepository;
+import com._penLearning.Noddi.domain.qa.repository.QaQuestionRepository;
+import com._penLearning.Noddi.domain.team.entity.Team;
+import com._penLearning.Noddi.domain.team.repository.TeamRepository;
+import com._penLearning.Noddi.domain.user.entity.User;
+import com._penLearning.Noddi.domain.user.repository.UserRepository;
+import com._penLearning.Noddi.global.exception.GeneralException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class QaQuestionQueryServiceTest {
+
+    /*
+     * 이 테스트는 DB까지 연결하는 통합 테스트가 아니라 QaQuestionQueryService만 검증하는 단위 테스트다.
+     * Repository는 모두 Mock으로 대체해서 다음 흐름에 집중한다.
+     *
+     * 1. 조회 권한을 검사한다.
+     * 2. 질문을 size + 1개 조회해 다음 페이지 존재 여부를 판단한다.
+     * 3. 답변과 출처를 한 번씩 일괄 조회한다.
+     * 4. 질문-답변-출처를 묶어 화면에 필요한 Feed DTO로 변환한다.
+     */
+
+    @Mock
+    private QaQuestionRepository qaQuestionRepository;
+
+    @Mock
+    private QaAnswerRepository qaAnswerRepository;
+
+    @Mock
+    private QaAnswerSourceRepository qaAnswerSourceRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private TeamRepository teamRepository;
+
+    @Mock
+    private ProjectMemberRepository projectMemberRepository;
+
+    @Mock
+    private Team targetTeam;
+
+    @Mock
+    private Project project;
+
+    @Mock
+    private User requester;
+
+    private QaQuestionQueryService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new QaQuestionQueryService(
+                qaQuestionRepository,
+                qaAnswerRepository,
+                qaAnswerSourceRepository,
+                userRepository,
+                teamRepository,
+                projectMemberRepository
+        );
+    }
+
+    @Test
+    void returnsQuestionAndAnswerFeedInChronologicalOrder() {
+        // Given: 최신순으로 조회된 질문 3개 중 실제 응답에는 요청한 size(2개)만 포함되는 상황이다.
+        // 세 번째 질문은 데이터가 더 남았는지 확인하기 위한 size + 1번째 데이터다.
+        QaQuestion newestQuestion = mock(QaQuestion.class);
+        QaQuestion olderQuestion = mock(QaQuestion.class);
+        QaQuestion nextPageQuestion = mock(QaQuestion.class);
+        User newestQuestioner = mock(User.class);
+        User olderQuestioner = mock(User.class);
+        QaAnswer olderAnswer = mock(QaAnswer.class);
+        QaAnswerSource answerSource = mock(QaAnswerSource.class);
+
+        LocalDateTime olderQuestionTime = LocalDateTime.of(2026, 8, 15, 10, 0);
+        LocalDateTime newestQuestionTime = LocalDateTime.of(2026, 8, 15, 10, 10);
+        LocalDateTime answerTime = LocalDateTime.of(2026, 8, 15, 10, 0, 5);
+
+        allowProjectAccess();
+
+        when(newestQuestion.getQuestionId()).thenReturn(103L);
+        when(newestQuestion.getQuestioner()).thenReturn(newestQuestioner);
+        when(newestQuestion.getContent()).thenReturn("출시 담당자는 누구인가요?");
+        when(newestQuestion.getStatus()).thenReturn(QaStatus.PROCESSING);
+        when(newestQuestion.getCreatedAt()).thenReturn(newestQuestionTime);
+        when(newestQuestioner.getUserId()).thenReturn(7L);
+        when(newestQuestioner.getName()).thenReturn("홍길동");
+
+        when(olderQuestion.getQuestionId()).thenReturn(102L);
+        when(olderQuestion.getQuestioner()).thenReturn(olderQuestioner);
+        when(olderQuestion.getContent()).thenReturn("출시일은 언제인가요?");
+        when(olderQuestion.getStatus()).thenReturn(QaStatus.ANSWERED);
+        when(olderQuestion.getCreatedAt()).thenReturn(olderQuestionTime);
+        when(olderQuestioner.getUserId()).thenReturn(5L);
+        when(olderQuestioner.getName()).thenReturn("김유진");
+
+        when(olderAnswer.getAnswerId()).thenReturn(201L);
+        when(olderAnswer.getQuestion()).thenReturn(olderQuestion);
+        when(olderAnswer.getContent()).thenReturn("출시일은 9월 5일입니다.");
+        when(olderAnswer.getAnswerType()).thenReturn(AnswerType.AI);
+        when(olderAnswer.isRevised()).thenReturn(false);
+        when(olderAnswer.getCreatedAt()).thenReturn(answerTime);
+        when(olderAnswer.getUpdatedAt()).thenReturn(answerTime);
+
+        when(answerSource.getAnswer()).thenReturn(olderAnswer);
+        when(answerSource.getCitationIndex()).thenReturn(1);
+        when(answerSource.getSourceType()).thenReturn(SourceType.TRANSCRIPT);
+        when(answerSource.getReferenceId()).thenReturn(30L);
+        when(answerSource.getSourceTitle()).thenReturn("8월 기획 회의");
+        when(answerSource.getExcerpt()).thenReturn("출시일을 9월 5일로 변경합니다.");
+
+        when(qaQuestionRepository.findFeedByTargetTeam(
+                eq(targetTeam),
+                isNull(),
+                any(Pageable.class)
+        )).thenReturn(List.of(newestQuestion, olderQuestion, nextPageQuestion));
+        when(qaAnswerRepository.findAllByQuestionsWithReviser(anyCollection()))
+                .thenReturn(List.of(olderAnswer));
+        when(qaAnswerSourceRepository.findAllByAnswersOrderByCitationIndex(anyCollection()))
+                .thenReturn(List.of(answerSource));
+
+        // When: 첫 페이지를 2개 크기로 조회한다.
+        QaResponseDto.Feed response = service.getTeamFeed(1L, 10L, null, 2);
+
+        // Then: 프로젝트/팀 정보와 다음 페이지 정보가 응답에 정확히 들어간다.
+        assertThat(response.getProjectId()).isEqualTo(1L);
+        assertThat(response.getProjectName()).isEqualTo("노디프로젝트");
+        assertThat(response.getTeamId()).isEqualTo(10L);
+        assertThat(response.getTeamName()).isEqualTo("마케팅팀");
+        assertThat(response.isHasNext()).isTrue();
+        assertThat(response.getNextCursor()).isEqualTo(102L);
+        assertThat(response.getItems()).hasSize(2);
+
+        QaResponseDto.FeedItem firstItem = response.getItems().get(0);
+        QaResponseDto.FeedItem secondItem = response.getItems().get(1);
+
+        // Repository는 최신순(103 -> 102)으로 반환하지만, 채팅 화면에는 과거 질문부터 보이도록
+        // 서비스가 응답 순서를 102 -> 103으로 뒤집었는지 확인한다.
+        assertThat(firstItem.getQuestion().getQuestionId()).isEqualTo(102L);
+        assertThat(firstItem.getStatus()).isEqualTo(QaStatus.ANSWERED);
+        assertThat(firstItem.getAnswer()).isNotNull();
+        assertThat(firstItem.getAnswer().getAnswerId()).isEqualTo(201L);
+        assertThat(firstItem.getAnswer().getContent()).isEqualTo("출시일은 9월 5일입니다.");
+        assertThat(firstItem.getAnswer().getSources()).hasSize(1);
+        assertThat(firstItem.getAnswer().getSources().get(0).getSourceTitle())
+                .isEqualTo("8월 기획 회의");
+
+        assertThat(secondItem.getQuestion().getQuestionId()).isEqualTo(103L);
+        assertThat(secondItem.getStatus()).isEqualTo(QaStatus.PROCESSING);
+        assertThat(secondItem.getAnswer()).isNull();
+
+        // hasNext를 별도 count 쿼리 없이 판단하기 위해 요청 크기보다 1개 더 조회했는지 확인한다.
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(qaQuestionRepository).findFeedByTargetTeam(
+                eq(targetTeam),
+                isNull(),
+                pageableCaptor.capture()
+        );
+        assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(3);
+
+        // size + 1번째 질문은 다음 페이지 확인용이므로 제외하고,
+        // 실제 응답에 포함될 질문 2개에 대해서만 답변과 출처를 일괄 조회했는지 확인한다.
+        verify(qaAnswerRepository).findAllByQuestionsWithReviser(
+                List.of(newestQuestion, olderQuestion)
+        );
+        verify(qaAnswerSourceRepository).findAllByAnswersOrderByCitationIndex(
+                List.of(olderAnswer)
+        );
+    }
+
+    @Test
+    void returnsEmptySourcesWhenAnswerHasNoCitation() {
+        // Given: 답변은 있지만 근거로 인용한 회의록 조각이 없는 질문이다.
+        QaQuestion question = mock(QaQuestion.class);
+        User questioner = mock(User.class);
+        QaAnswer answer = mock(QaAnswer.class);
+        LocalDateTime createdAt = LocalDateTime.of(2026, 8, 15, 11, 0);
+
+        allowProjectAccess();
+
+        when(question.getQuestionId()).thenReturn(101L);
+        when(question.getQuestioner()).thenReturn(questioner);
+        when(question.getContent()).thenReturn("자료에 없는 질문");
+        when(question.getStatus()).thenReturn(QaStatus.ANSWERED);
+        when(question.getCreatedAt()).thenReturn(createdAt);
+        when(questioner.getUserId()).thenReturn(5L);
+        when(questioner.getName()).thenReturn("김유진");
+
+        when(answer.getAnswerId()).thenReturn(201L);
+        when(answer.getQuestion()).thenReturn(question);
+        when(answer.getContent()).thenReturn("제공된 팀 자료에서 확인할 수 없습니다.");
+        when(answer.getAnswerType()).thenReturn(AnswerType.AI);
+        when(answer.isRevised()).thenReturn(false);
+        when(answer.getCreatedAt()).thenReturn(createdAt);
+        when(answer.getUpdatedAt()).thenReturn(createdAt);
+
+        when(qaQuestionRepository.findFeedByTargetTeam(
+                eq(targetTeam),
+                isNull(),
+                any(Pageable.class)
+        )).thenReturn(List.of(question));
+        when(qaAnswerRepository.findAllByQuestionsWithReviser(anyCollection()))
+                .thenReturn(List.of(answer));
+        when(qaAnswerSourceRepository.findAllByAnswersOrderByCitationIndex(anyCollection()))
+                .thenReturn(List.of());
+
+        // When: Q&A 피드를 조회한다.
+        QaResponseDto.Feed response = service.getTeamFeed(1L, 10L, null, 20);
+
+        // Then: 답변은 정상적으로 반환하고 sources는 null이 아닌 빈 배열로 내려준다.
+        // 프론트에서는 null 여부를 따로 검사하지 않고 배열로 일관되게 처리할 수 있다.
+        assertThat(response.getItems()).hasSize(1);
+        assertThat(response.getItems().get(0).getAnswer()).isNotNull();
+        assertThat(response.getItems().get(0).getAnswer().getSources()).isEmpty();
+    }
+
+    @Test
+    void returnsEmptyFeedWhenTeamHasNoQuestions() {
+        // Given: 조회 권한은 있지만 해당 팀에 등록된 질문이 없다.
+        allowProjectAccess();
+        when(qaQuestionRepository.findFeedByTargetTeam(
+                eq(targetTeam),
+                isNull(),
+                any(Pageable.class)
+        )).thenReturn(List.of());
+
+        // When: Q&A 피드를 조회한다.
+        QaResponseDto.Feed response = service.getTeamFeed(1L, 10L, null, 20);
+
+        // Then: 빈 목록과 함께 다음 페이지가 없다는 정보를 반환한다.
+        assertThat(response.getItems()).isEmpty();
+        assertThat(response.isHasNext()).isFalse();
+        assertThat(response.getNextCursor()).isNull();
+
+        // 질문이 없으면 답변/출처를 조회할 필요가 없으므로 불필요한 Repository 호출도 없어야 한다.
+        verifyNoInteractions(qaAnswerRepository, qaAnswerSourceRepository);
+    }
+
+    @Test
+    void rejectsRequesterWhoIsNotProjectMember() {
+        // Given: 팀과 사용자는 존재하지만 사용자가 해당 팀이 속한 프로젝트의 멤버가 아니다.
+        when(teamRepository.findById(10L)).thenReturn(Optional.of(targetTeam));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(requester));
+        when(targetTeam.getProject()).thenReturn(project);
+        when(projectMemberRepository.existsByProjectAndUser(project, requester)).thenReturn(false);
+
+        // When & Then: 프로젝트 외부 사용자의 피드 조회 요청은 예외로 거절한다.
+        assertThatThrownBy(() -> service.getTeamFeed(1L, 10L, null, 20))
+                .isInstanceOf(GeneralException.class);
+
+        // 권한 검증에 실패한 뒤에는 실제 Q&A 데이터를 조회하지 않아야 한다.
+        verifyNoInteractions(
+                qaQuestionRepository,
+                qaAnswerRepository,
+                qaAnswerSourceRepository
+        );
+    }
+
+    @Test
+    void rejectsInvalidFeedSize() {
+        // When & Then: 허용 범위(1~50)를 벗어난 페이지 크기는 즉시 거절한다.
+        assertThatThrownBy(() -> service.getTeamFeed(1L, 10L, null, 0))
+                .isInstanceOf(GeneralException.class);
+        assertThatThrownBy(() -> service.getTeamFeed(1L, 10L, null, 51))
+                .isInstanceOf(GeneralException.class);
+
+        // 입력값 자체가 잘못됐으므로 팀/사용자/피드 조회까지 진행하지 않아야 한다.
+        verifyNoInteractions(
+                teamRepository,
+                userRepository,
+                projectMemberRepository,
+                qaQuestionRepository,
+                qaAnswerRepository,
+                qaAnswerSourceRepository
+        );
+    }
+
+    @Test
+    void rejectsInvalidFeedCursor() {
+        // When & Then: 실제 질문 ID가 될 수 없는 0 이하 cursor는 즉시 거절한다.
+        assertThatThrownBy(() -> service.getTeamFeed(1L, 10L, 0L, 20))
+                .isInstanceOf(GeneralException.class);
+
+        // cursor 검증에서 실패했으므로 Repository에는 접근하지 않아야 한다.
+        verifyNoInteractions(
+                teamRepository,
+                userRepository,
+                projectMemberRepository,
+                qaQuestionRepository,
+                qaAnswerRepository,
+                qaAnswerSourceRepository
+        );
+    }
+
+    private void allowProjectAccess() {
+        // 여러 성공 테스트에서 반복되는 "요청자가 프로젝트 멤버인 상황"을 공통으로 준비한다.
+        when(teamRepository.findById(10L)).thenReturn(Optional.of(targetTeam));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(requester));
+        when(targetTeam.getProject()).thenReturn(project);
+        when(targetTeam.getTeamId()).thenReturn(10L);
+        when(targetTeam.getName()).thenReturn("마케팅팀");
+        when(project.getProjectId()).thenReturn(1L);
+        when(project.getName()).thenReturn("노디프로젝트");
+        when(projectMemberRepository.existsByProjectAndUser(project, requester)).thenReturn(true);
+    }
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

## 🎋 작업 브랜치
- feature/43 -> develop
- #43  (관련이슈 번호)

## 💡 작업동기
- 피드 조회 api를 구현합니다

## 🔑 주요 변경사항
- 팀별 Q&A 피드 조회 API 구현
- 질문·답변·답변 출처를 하나의 피드 응답으로 제공
- 커서 기반 페이지네이션 적용cursor 생략 시 첫 페이지 조회
  - size 기본값 20, 최대 50

- 프로젝트 멤버만 피드를 조회할 수 있도록 권한 검증
- 답변과 출처를 일괄 조회해 N+1 문제 방지
- 채팅 화면에 맞게 오래된 질문부터 정렬해 반환
- 서비스 및 컨트롤러 단위 테스트 추가
## 🏞 스크린샷 (선택)
> 스크린샷을 첨부해주세요.

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
