### PR TITLE
[feat] 팀 공유페이지 RAG 인덱싱 기능 구현

### DIFF
--- a/src/main/java/com/_penLearning/Noddi/domain/qa/rag/indexing/KnowledgeDeletionService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/rag/indexing/KnowledgeDeletionService.java
@@ -29,6 +29,12 @@ public class KnowledgeDeletionService {
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void deleteTeamPageKnowledge(Long pageId) {
+        knowledgeIndexRepository.findBySourceIdAndSourceType(pageId, SourceType.TEAM_TEXT)
+                .ifPresent(index -> deleteIndexes(List.of(index)));
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void deleteTeamKnowledge(Long teamId) {
         deleteIndexes(knowledgeIndexRepository.findAllByTeam_TeamId(teamId));
     }

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/rag/indexing/KnowledgeIndexResult.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/rag/indexing/KnowledgeIndexResult.java
@@ -1,0 +1,16 @@
+package com._penLearning.Noddi.domain.qa.rag.indexing;
+
+/** 하나의 지식 원본을 Pinecone과 동기화한 결과다. */
+public record KnowledgeIndexResult(
+        int indexedChunkCount,
+        boolean skipped
+) {
+
+    public static KnowledgeIndexResult indexed(int chunkCount) {
+        return new KnowledgeIndexResult(chunkCount, false);
+    }
+
+    public static KnowledgeIndexResult skippedResult() {
+        return new KnowledgeIndexResult(0, true);
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/rag/indexing/KnowledgeIndexService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/rag/indexing/KnowledgeIndexService.java
@@ -1,0 +1,114 @@
+package com._penLearning.Noddi.domain.qa.rag.indexing;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 회의 전사와 팀 공유페이지처럼 종류가 다른 텍스트 원본을 동일한 규칙으로 Pinecone과 동기화한다.
+ * 원본이 바뀌지 않았다면 임베딩 API 호출을 생략하고, 청크 수가 줄면 남은 이전 벡터도 삭제한다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KnowledgeIndexService {
+
+    private final QaKnowledgeIndexStateService indexStateService;
+    private final KnowledgeDocumentFactory documentFactory;
+    private final VectorStore vectorStore;
+
+    public KnowledgeIndexResult synchronize(KnowledgeSourceContent source) {
+        Optional<KnowledgeIndexState> previousState = indexStateService.get(
+                source.sourceId(),
+                source.sourceType()
+        );
+
+        if (source.content() == null || source.content().isBlank()) {
+            removePreviousSource(source, previousState);
+            return KnowledgeIndexResult.skippedResult();
+        }
+
+        String contentHash = sha256(source.content());
+        if (previousState.map(KnowledgeIndexState::contentHash).filter(contentHash::equals).isPresent()) {
+            return KnowledgeIndexResult.skippedResult();
+        }
+
+        List<Document> documents = documentFactory.create(source);
+        vectorStore.add(documents);
+
+        previousState.ifPresent(state -> deleteStaleDocuments(
+                source,
+                documents.size(),
+                state.chunkCount()
+        ));
+
+        indexStateService.recordSuccess(
+                source.sourceId(),
+                source.teamId(),
+                source.sourceType(),
+                contentHash,
+                documents.size()
+        );
+
+        log.info(
+                "[KnowledgeIndex] 인덱싱 완료: sourceId={}, sourceType={}, chunkCount={}",
+                source.sourceId(),
+                source.sourceType(),
+                documents.size()
+        );
+        return KnowledgeIndexResult.indexed(documents.size());
+    }
+
+    private void removePreviousSource(
+            KnowledgeSourceContent source,
+            Optional<KnowledgeIndexState> previousState
+    ) {
+        previousState.ifPresent(state -> {
+            List<String> ids = documentFactory.documentIds(
+                    source.sourceId(),
+                    source.sourceType(),
+                    0,
+                    state.chunkCount()
+            );
+            if (!ids.isEmpty()) {
+                vectorStore.delete(ids);
+            }
+            indexStateService.remove(source.sourceId(), source.sourceType());
+        });
+    }
+
+    private void deleteStaleDocuments(
+            KnowledgeSourceContent source,
+            int newChunkCount,
+            int previousChunkCount
+    ) {
+        if (previousChunkCount <= newChunkCount) {
+            return;
+        }
+
+        vectorStore.delete(documentFactory.documentIds(
+                source.sourceId(),
+                source.sourceType(),
+                newChunkCount,
+                previousChunkCount
+        ));
+    }
+
+    private String sha256(String content) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(content.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("SHA-256 algorithm is not available", exception);
+        }
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/rag/indexing/MeetingKnowledgeIndexService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/rag/indexing/MeetingKnowledgeIndexService.java
@@ -1,142 +1,24 @@
 package com._penLearning.Noddi.domain.qa.rag.indexing;
 
-import com._penLearning.Noddi.domain.qa.entity.SourceType;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.ai.document.Document;
-import org.springframework.ai.vectorstore.VectorStore;
 import org.springframework.stereotype.Service;
 
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.HexFormat;
-import java.util.List;
-import java.util.Optional;
-
-// 회의 전사를 실제로 Pinecone에 넣는 전체 과정을 제어함
-@Slf4j
+/** 회의 전사를 공통 지식 인덱싱 흐름에 전달한다. */
 @Service
 @RequiredArgsConstructor
 public class MeetingKnowledgeIndexService {
 
     private final MeetingKnowledgeSourceReader sourceReader;
-    private final QaKnowledgeIndexStateService indexStateService;
-    private final KnowledgeDocumentFactory documentFactory;
-    private final VectorStore vectorStore;
+    private final KnowledgeIndexService knowledgeIndexService;
 
     public MeetingKnowledgeIndexResult index(Long meetingId) {
         KnowledgeSourceContent source = sourceReader.read(meetingId);
-
-        // 회의 전사를 공통 소스 형식으로 전달하여 팀 작성 텍스트와 같은 색인 규칙을 사용한다.
-        SourceSyncResult transcriptResult = synchronize(source);
+        KnowledgeIndexResult result = knowledgeIndexService.synchronize(source);
 
         return new MeetingKnowledgeIndexResult(
                 meetingId,
-                transcriptResult.indexedChunkCount(),
-                transcriptResult.skippedSourceCount()
+                result.indexedChunkCount(),
+                result.skipped() ? 1 : 0
         );
-    }
-
-    private SourceSyncResult synchronize(KnowledgeSourceContent source) {
-        Optional<KnowledgeIndexState> previousState = indexStateService.get(
-                source.sourceId(),
-                source.sourceType()
-        );
-
-        if (source.content() == null || source.content().isBlank()) {
-            removePreviousSource(source.sourceId(), source.sourceType(), previousState);
-            return SourceSyncResult.skipped();
-        }
-
-        String contentHash = sha256(source.content());
-        if (previousState.map(KnowledgeIndexState::contentHash).filter(contentHash::equals).isPresent()) {
-            return SourceSyncResult.skipped();
-        }
-
-        List<Document> documents = documentFactory.create(source);
-
-        // Pinecone 저장이 성공한 뒤에만 MySQL 색인 상태를 갱신한다.
-        vectorStore.add(documents);
-
-        previousState.ifPresent(state -> deleteStaleDocuments(
-                source.sourceId(),
-                source.sourceType(),
-                documents.size(),
-                state.chunkCount()
-        ));
-
-        indexStateService.recordSuccess(
-                source.sourceId(),
-                source.teamId(),
-                source.sourceType(),
-                contentHash,
-                documents.size()
-        );
-
-        log.info(
-                "[MeetingKnowledgeIndex] 색인 완료: sourceId={}, sourceType={}, chunkCount={}",
-                source.sourceId(),
-                source.sourceType(),
-                documents.size()
-        );
-        return SourceSyncResult.indexed(documents.size());
-    }
-
-    private void removePreviousSource(
-            Long sourceId,
-            SourceType sourceType,
-            Optional<KnowledgeIndexState> previousState
-    ) {
-        previousState.ifPresent(state -> {
-            List<String> ids = documentFactory.documentIds(
-                    sourceId,
-                    sourceType,
-                    0,
-                    state.chunkCount()
-            );
-            if (!ids.isEmpty()) {
-                vectorStore.delete(ids);
-            }
-            indexStateService.remove(sourceId, sourceType);
-        });
-    }
-
-    private void deleteStaleDocuments(
-            Long sourceId,
-            SourceType sourceType,
-            int newChunkCount,
-            int previousChunkCount
-    ) {
-        if (previousChunkCount <= newChunkCount) {
-            return;
-        }
-
-        vectorStore.delete(documentFactory.documentIds(
-                sourceId,
-                sourceType,
-                newChunkCount,
-                previousChunkCount
-        ));
-    }
-
-    private String sha256(String content) {
-        try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            return HexFormat.of().formatHex(digest.digest(content.getBytes(StandardCharsets.UTF_8)));
-        } catch (NoSuchAlgorithmException exception) {
-            throw new IllegalStateException("SHA-256 algorithm is not available", exception);
-        }
-    }
-
-    private record SourceSyncResult(int indexedChunkCount, int skippedSourceCount) {
-
-        private static SourceSyncResult indexed(int chunkCount) {
-            return new SourceSyncResult(chunkCount, 0);
-        }
-
-        private static SourceSyncResult skipped() {
-            return new SourceSyncResult(0, 1);
-        }
     }
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/rag/indexing/TeamPageKnowledgeCoordinator.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/rag/indexing/TeamPageKnowledgeCoordinator.java
@@ -1,0 +1,56 @@
+package com._penLearning.Noddi.domain.qa.rag.indexing;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * 같은 공유페이지에서 발생한 색인과 삭제 작업이 동시에 실행되지 않도록 조정한다.
+ *
+ * 현재 서버는 단일 애플리케이션 인스턴스로 운영하므로 JVM 내부 striped lock을 사용한다.
+ * pageId마다 lock을 계속 생성하는 대신 고정된 lock 배열을 사용해 메모리 누수를 방지한다.
+ */
+@Component
+@RequiredArgsConstructor
+public class TeamPageKnowledgeCoordinator {
+
+    private static final int LOCK_STRIPE_COUNT = 256;
+
+    private final TeamPageKnowledgeIndexService indexService;
+    private final KnowledgeDeletionService deletionService;
+    private final ReentrantLock[] locks = createLocks();
+
+    public KnowledgeIndexResult synchronize(Long pageId) {
+        ReentrantLock lock = lockFor(pageId);
+        lock.lock();
+        try {
+            return indexService.index(pageId);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void delete(Long pageId) {
+        ReentrantLock lock = lockFor(pageId);
+        lock.lock();
+        try {
+            deletionService.deleteTeamPageKnowledge(pageId);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private ReentrantLock lockFor(Long pageId) {
+        int stripeIndex = Math.floorMod(Long.hashCode(pageId), LOCK_STRIPE_COUNT);
+        return locks[stripeIndex];
+    }
+
+    private ReentrantLock[] createLocks() {
+        ReentrantLock[] createdLocks = new ReentrantLock[LOCK_STRIPE_COUNT];
+        for (int index = 0; index < LOCK_STRIPE_COUNT; index++) {
+            createdLocks[index] = new ReentrantLock();
+        }
+        return createdLocks;
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/rag/indexing/TeamPageKnowledgeEventHandler.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/rag/indexing/TeamPageKnowledgeEventHandler.java
@@ -1,0 +1,47 @@
+package com._penLearning.Noddi.domain.qa.rag.indexing;
+
+import com._penLearning.Noddi.domain.teamPage.event.TeamPageChangedEvent;
+import com._penLearning.Noddi.domain.teamPage.event.TeamPageDeletedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/** 공유페이지 트랜잭션이 확정된 뒤 Pinecone 벡터와 MySQL 인덱싱 상태를 비동기로 동기화한다. */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TeamPageKnowledgeEventHandler {
+
+    private final TeamPageKnowledgeIndexService indexService;
+    private final KnowledgeDeletionService deletionService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleChanged(TeamPageChangedEvent event) {
+        try {
+            KnowledgeIndexResult result = indexService.index(event.pageId());
+            log.info(
+                    "[TeamPageKnowledgeIndex] 동기화 완료: pageId={}, indexedChunkCount={}, skipped={}",
+                    event.pageId(),
+                    result.indexedChunkCount(),
+                    result.skipped()
+            );
+        } catch (Exception exception) {
+            // 공유페이지 저장은 이미 완료되었으므로 인덱싱 실패를 분리해서 기록한다.
+            log.error("[TeamPageKnowledgeIndex] 동기화 실패: pageId={}", event.pageId(), exception);
+        }
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleDeleted(TeamPageDeletedEvent event) {
+        try {
+            deletionService.deleteTeamPageKnowledge(event.pageId());
+        } catch (Exception exception) {
+            log.error("[TeamPageKnowledgeIndex] 삭제 실패: pageId={}", event.pageId(), exception);
+        }
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/rag/indexing/TeamPageKnowledgeEventHandler.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/rag/indexing/TeamPageKnowledgeEventHandler.java
@@ -15,14 +15,13 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @RequiredArgsConstructor
 public class TeamPageKnowledgeEventHandler {
 
-    private final TeamPageKnowledgeIndexService indexService;
-    private final KnowledgeDeletionService deletionService;
+    private final TeamPageKnowledgeCoordinator coordinator;
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleChanged(TeamPageChangedEvent event) {
         try {
-            KnowledgeIndexResult result = indexService.index(event.pageId());
+            KnowledgeIndexResult result = coordinator.synchronize(event.pageId());
             log.info(
                     "[TeamPageKnowledgeIndex] 동기화 완료: pageId={}, indexedChunkCount={}, skipped={}",
                     event.pageId(),
@@ -30,7 +29,7 @@ public class TeamPageKnowledgeEventHandler {
                     result.skipped()
             );
         } catch (Exception exception) {
-            // 공유페이지 저장은 이미 완료되었으므로 인덱싱 실패를 분리해서 기록한다.
+            // 공유페이지 저장은 이미 완료됐다. 실패 건은 복구 스케줄러가 DB 상태를 기준으로 다시 처리한다.
             log.error("[TeamPageKnowledgeIndex] 동기화 실패: pageId={}", event.pageId(), exception);
         }
     }
@@ -39,8 +38,9 @@ public class TeamPageKnowledgeEventHandler {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleDeleted(TeamPageDeletedEvent event) {
         try {
-            deletionService.deleteTeamPageKnowledge(event.pageId());
+            coordinator.delete(event.pageId());
         } catch (Exception exception) {
+            // 원본 없이 남은 TEAM_TEXT 색인은 복구 스케줄러가 찾아 다시 삭제한다.
             log.error("[TeamPageKnowledgeIndex] 삭제 실패: pageId={}", event.pageId(), exception);
         }
     }

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/rag/indexing/TeamPageKnowledgeIndexService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/rag/indexing/TeamPageKnowledgeIndexService.java
@@ -1,0 +1,17 @@
+package com._penLearning.Noddi.domain.qa.rag.indexing;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/** 공유페이지 원문을 읽어 공통 Pinecone 인덱싱 흐름에 전달한다. */
+@Service
+@RequiredArgsConstructor
+public class TeamPageKnowledgeIndexService {
+
+    private final TeamPageKnowledgeSourceReader sourceReader;
+    private final KnowledgeIndexService knowledgeIndexService;
+
+    public KnowledgeIndexResult index(Long pageId) {
+        return knowledgeIndexService.synchronize(sourceReader.read(pageId));
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/rag/indexing/TeamPageKnowledgeRecoveryScheduler.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/rag/indexing/TeamPageKnowledgeRecoveryScheduler.java
@@ -1,0 +1,78 @@
+package com._penLearning.Noddi.domain.qa.rag.indexing;
+
+import com._penLearning.Noddi.domain.qa.entity.SourceType;
+import com._penLearning.Noddi.domain.qa.repository.QaKnowledgeIndexRepository;
+import com._penLearning.Noddi.domain.teamPage.repository.TeamPageRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * 공유페이지 이벤트 유실과 일시적인 외부 API 장애를 주기적으로 복구한다.
+ * 누락·변경된 페이지는 다시 색인하고, 원본 없이 남은 색인은 삭제한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TeamPageKnowledgeRecoveryScheduler {
+
+    private static final int RECOVERY_BATCH_SIZE = 100;
+
+    private final TeamPageRepository teamPageRepository;
+    private final QaKnowledgeIndexRepository knowledgeIndexRepository;
+    private final TeamPageKnowledgeCoordinator coordinator;
+
+    @Scheduled(
+            cron = "${scheduler.qa-knowledge.recovery-cron:0 */5 * * * *}",
+            zone = "${scheduler.qa-knowledge.zone:Asia/Seoul}"
+    )
+    public void reconcileTeamPageKnowledge() {
+        List<Long> synchronizationTargets = teamPageRepository
+                .findIdsRequiringKnowledgeSynchronization(
+                        SourceType.TEAM_TEXT,
+                        PageRequest.of(0, RECOVERY_BATCH_SIZE)
+                );
+
+        for (Long pageId : synchronizationTargets) {
+            try {
+                coordinator.synchronize(pageId);
+            } catch (Exception exception) {
+                // 한 페이지의 장애가 같은 배치의 나머지 복구를 막지 않도록 건별로 격리한다.
+                log.error(
+                        "[TeamPageKnowledgeRecovery] 공유페이지 재색인 실패: pageId={}",
+                        pageId,
+                        exception
+                );
+            }
+        }
+
+        List<Long> deletionTargets = knowledgeIndexRepository.findOrphanedSourceIds(
+                SourceType.TEAM_TEXT,
+                PageRequest.of(0, RECOVERY_BATCH_SIZE)
+        );
+
+        for (Long pageId : deletionTargets) {
+            try {
+                coordinator.delete(pageId);
+            } catch (Exception exception) {
+                log.error(
+                        "[TeamPageKnowledgeRecovery] 고아 색인 삭제 실패: pageId={}",
+                        pageId,
+                        exception
+                );
+            }
+        }
+
+        if (!synchronizationTargets.isEmpty() || !deletionTargets.isEmpty()) {
+            log.info(
+                    "[TeamPageKnowledgeRecovery] 정합성 복구 시도 완료: synchronizeCount={}, deleteCount={}",
+                    synchronizationTargets.size(),
+                    deletionTargets.size()
+            );
+        }
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/rag/indexing/TeamPageKnowledgeSourceReader.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/rag/indexing/TeamPageKnowledgeSourceReader.java
@@ -1,0 +1,37 @@
+package com._penLearning.Noddi.domain.qa.rag.indexing;
+
+import com._penLearning.Noddi.domain.qa.entity.SourceType;
+import com._penLearning.Noddi.domain.teamPage.code.TeamPageErrorCode;
+import com._penLearning.Noddi.domain.teamPage.entity.TeamPage;
+import com._penLearning.Noddi.domain.teamPage.repository.TeamPageRepository;
+import com._penLearning.Noddi.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** 공유페이지를 Pinecone 인덱싱에 사용하는 공통 지식 원본 형식으로 변환한다. */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TeamPageKnowledgeSourceReader {
+
+    private final TeamPageRepository teamPageRepository;
+
+    public KnowledgeSourceContent read(Long pageId) {
+        TeamPage page = teamPageRepository.findByPageIdWithTeam(pageId)
+                .orElseThrow(() -> new GeneralException(TeamPageErrorCode.TEAM_PAGE_NOT_FOUND));
+
+        return new KnowledgeSourceContent(
+                page.getPageId(),
+                page.getTeam().getTeamId(),
+                SourceType.TEAM_TEXT,
+                page.getTitle(),
+                markdownContent(page)
+        );
+    }
+
+    private String markdownContent(TeamPage page) {
+        // 제목도 임베딩 대상에 포함해야 제목 검색과 제목만 변경된 경우의 재인덱싱이 가능하다.
+        return "# %s\n\n%s".formatted(page.getTitle(), page.getContent());
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/repository/QaKnowledgeIndexRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/repository/QaKnowledgeIndexRepository.java
@@ -2,7 +2,10 @@ package com._penLearning.Noddi.domain.qa.repository;
 
 import com._penLearning.Noddi.domain.qa.entity.QaKnowledgeIndex;
 import com._penLearning.Noddi.domain.qa.entity.SourceType;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -17,4 +20,21 @@ public interface QaKnowledgeIndexRepository extends JpaRepository<QaKnowledgeInd
     List<QaKnowledgeIndex> findAllByTeam_TeamId(Long teamId);
 
     List<QaKnowledgeIndex> findAllByTeam_Project_ProjectId(Long projectId);
+
+    /** 원본 공유페이지는 삭제됐지만 TEAM_TEXT 색인 상태가 남은 sourceId를 조회한다. */
+    @Query("""
+            SELECT knowledgeIndex.sourceId
+            FROM QaKnowledgeIndex knowledgeIndex
+            WHERE knowledgeIndex.sourceType = :sourceType
+              AND NOT EXISTS (
+                  SELECT page.pageId
+                  FROM TeamPage page
+                  WHERE page.pageId = knowledgeIndex.sourceId
+              )
+            ORDER BY knowledgeIndex.sourceId ASC
+            """)
+    List<Long> findOrphanedSourceIds(
+            @Param("sourceType") SourceType sourceType,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/teamPage/event/TeamPageChangedEvent.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/teamPage/event/TeamPageChangedEvent.java
@@ -1,0 +1,5 @@
+package com._penLearning.Noddi.domain.teamPage.event;
+
+/** 공유페이지 생성 또는 수정 커밋 이후 Pinecone 동기화를 요청한다. */
+public record TeamPageChangedEvent(Long pageId) {
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/teamPage/event/TeamPageDeletedEvent.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/teamPage/event/TeamPageDeletedEvent.java
@@ -1,0 +1,5 @@
+package com._penLearning.Noddi.domain.teamPage.event;
+
+/** 공유페이지 삭제 커밋 이후 Pinecone에 남은 청크 삭제를 요청한다. */
+public record TeamPageDeletedEvent(Long pageId) {
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/teamPage/repository/TeamPageRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/teamPage/repository/TeamPageRepository.java
@@ -1,6 +1,7 @@
 package com._penLearning.Noddi.domain.teamPage.repository;
 
 import com._penLearning.Noddi.domain.project.entity.Project;
+import com._penLearning.Noddi.domain.qa.entity.SourceType;
 import com._penLearning.Noddi.domain.team.entity.Team;
 import com._penLearning.Noddi.domain.teamPage.entity.TeamPage;
 import org.springframework.data.domain.Page;
@@ -10,6 +11,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface TeamPageRepository extends JpaRepository<TeamPage, Long> {
@@ -33,6 +35,27 @@ public interface TeamPageRepository extends JpaRepository<TeamPage, Long> {
     );
 
     Optional<TeamPage> findByPageIdAndTeam(Long pageId, Team team);
+
+    /**
+     * TEAM_TEXT 색인이 없거나 페이지 수정 시각보다 색인 상태가 오래된 페이지를 조회한다.
+     * 이벤트 유실 및 일시적인 Pinecone 장애가 발생했을 때 복구 스케줄러가 사용한다.
+     */
+    @Query("""
+            SELECT page.pageId
+            FROM TeamPage page
+            WHERE NOT EXISTS (
+                SELECT knowledgeIndex.indexId
+                FROM QaKnowledgeIndex knowledgeIndex
+                WHERE knowledgeIndex.sourceId = page.pageId
+                  AND knowledgeIndex.sourceType = :sourceType
+                  AND knowledgeIndex.updatedAt >= page.updatedAt
+            )
+            ORDER BY page.updatedAt ASC, page.pageId ASC
+            """)
+    List<Long> findIdsRequiringKnowledgeSynchronization(
+            @Param("sourceType") SourceType sourceType,
+            Pageable pageable
+    );
 
     @Query("""
             SELECT page

--- a/src/main/java/com/_penLearning/Noddi/domain/teamPage/repository/TeamPageRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/teamPage/repository/TeamPageRepository.java
@@ -34,6 +34,14 @@ public interface TeamPageRepository extends JpaRepository<TeamPage, Long> {
 
     Optional<TeamPage> findByPageIdAndTeam(Long pageId, Team team);
 
+    @Query("""
+            SELECT page
+            FROM TeamPage page
+            JOIN FETCH page.team
+            WHERE page.pageId = :pageId
+            """)
+    Optional<TeamPage> findByPageIdWithTeam(@Param("pageId") Long pageId);
+
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE FROM TeamPage page WHERE page.team = :team")
     void bulkDeleteByTeam(@Param("team") Team team);

--- a/src/main/java/com/_penLearning/Noddi/domain/teamPage/service/TeamPageService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/teamPage/service/TeamPageService.java
@@ -8,12 +8,15 @@ import com._penLearning.Noddi.domain.teamPage.code.TeamPageErrorCode;
 import com._penLearning.Noddi.domain.teamPage.dto.TeamPageRequestDto;
 import com._penLearning.Noddi.domain.teamPage.dto.TeamPageResponseDto;
 import com._penLearning.Noddi.domain.teamPage.entity.TeamPage;
+import com._penLearning.Noddi.domain.teamPage.event.TeamPageChangedEvent;
+import com._penLearning.Noddi.domain.teamPage.event.TeamPageDeletedEvent;
 import com._penLearning.Noddi.domain.teamPage.repository.TeamPageRepository;
 import com._penLearning.Noddi.domain.user.code.UserErrorCode;
 import com._penLearning.Noddi.domain.user.entity.User;
 import com._penLearning.Noddi.domain.user.repository.UserRepository;
 import com._penLearning.Noddi.global.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -30,6 +33,7 @@ public class TeamPageService {
     private final TeamMemberRepository teamMemberRepository;
     private final TeamRepository teamRepository;
     private final UserRepository userRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public TeamPageResponseDto.Result createPage(Long teamId, Long authorId, TeamPageRequestDto.Create request){
@@ -50,6 +54,7 @@ public class TeamPageService {
                 .build();
 
         TeamPage savedPage = teamPageRepository.save(teamPage);
+        eventPublisher.publishEvent(new TeamPageChangedEvent(savedPage.getPageId()));
         return TeamPageResponseDto.Result.from(savedPage);
     }
 
@@ -73,6 +78,7 @@ public class TeamPageService {
         }
 
         teamPage.update(request.getTitle(), request.getContent());
+        eventPublisher.publishEvent(new TeamPageChangedEvent(teamPage.getPageId()));
 
         return TeamPageResponseDto.Result.from(teamPage);
     }
@@ -121,5 +127,6 @@ public class TeamPageService {
            throw new GeneralException(TeamPageErrorCode.YOU_ARE_NOT_AUTHOR);
         }
         teamPageRepository.delete(teamPage);
+        eventPublisher.publishEvent(new TeamPageDeletedEvent(teamPage.getPageId()));
     }
 }

--- a/src/test/java/com/_penLearning/Noddi/domain/qa/integration/TeamPageKnowledgeIndexIntegrationTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/qa/integration/TeamPageKnowledgeIndexIntegrationTest.java
@@ -1,0 +1,356 @@
+package com._penLearning.Noddi.domain.qa.integration;
+
+import com._penLearning.Noddi.domain.organization.entity.Organization;
+import com._penLearning.Noddi.domain.organization.repository.OrganizationRepository;
+import com._penLearning.Noddi.domain.project.entity.Project;
+import com._penLearning.Noddi.domain.project.repository.ProjectRepository;
+import com._penLearning.Noddi.domain.qa.entity.QaKnowledgeIndex;
+import com._penLearning.Noddi.domain.qa.entity.SourceType;
+import com._penLearning.Noddi.domain.qa.rag.indexing.KnowledgeDeletionService;
+import com._penLearning.Noddi.domain.qa.repository.QaKnowledgeIndexRepository;
+import com._penLearning.Noddi.domain.team.entity.Team;
+import com._penLearning.Noddi.domain.team.repository.TeamRepository;
+import com._penLearning.Noddi.domain.teamPage.entity.TeamPage;
+import com._penLearning.Noddi.domain.teamPage.event.TeamPageChangedEvent;
+import com._penLearning.Noddi.domain.teamPage.event.TeamPageDeletedEvent;
+import com._penLearning.Noddi.domain.teamPage.repository.TeamPageRepository;
+import com._penLearning.Noddi.domain.user.entity.User;
+import com._penLearning.Noddi.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 공유페이지 변경 이벤트부터 OpenAI 임베딩과 Pinecone 저장·검색·삭제까지 확인하는 수동 종단 테스트다.
+ * IntelliJ 실행 구성에 OPENAI_API_KEY, PINECONE_API_KEY, PINECONE_INDEX_NAME이 필요하다.
+ */
+@SpringBootTest(properties = {
+        "spring.datasource.url=jdbc:h2:mem:team-page-knowledge-integration;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.ai.model.chat=openai",
+        "spring.ai.model.embedding=openai",
+        "spring.ai.vectorstore.type=pinecone",
+        "spring.ai.openai.api-key=${OPENAI_API_KEY}",
+        "spring.ai.openai.chat.model=${OPENAI_CHAT_MODEL:gpt-4o-mini}",
+        "spring.ai.openai.embedding.model=${OPENAI_EMBEDDING_MODEL:text-embedding-3-small}",
+        "spring.ai.openai.embedding.dimensions=${OPENAI_EMBEDDING_DIMENSIONS:1536}",
+        "spring.ai.vectorstore.pinecone.api-key=${PINECONE_API_KEY}",
+        "spring.ai.vectorstore.pinecone.index-name=${PINECONE_INDEX_NAME}"
+})
+@ActiveProfiles("test")
+@Tag("external")
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "PINECONE_API_KEY", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "PINECONE_INDEX_NAME", matches = ".+")
+class TeamPageKnowledgeIndexIntegrationTest {
+
+    private static final long TEST_PAGE_ID_START = randomIdInRange(1_500_000_000L);
+    private static final long TEST_TEAM_ID_START = randomIdInRange(1_700_000_000L);
+    private static final String OTHER_TEAM_ID = Long.toString(randomIdInRange(1_900_000_000L));
+    private static final String INITIAL_TITLE = "피닉스 배포 운영 규칙";
+    private static final String INITIAL_CONTENT = """
+            ## 정기 배포 일정
+            피닉스 백엔드는 매주 금요일 오후 4시에 배포합니다.
+            배포 담당자는 체크리스트를 확인한 뒤 승인을 요청합니다.
+            """;
+    private static final String UPDATED_TITLE = "피닉스 긴급 배포 운영 규칙";
+    private static final String UPDATED_CONTENT = """
+            ## 변경된 배포 일정
+            피닉스 백엔드 긴급 배포는 매주 목요일 오후 3시에 진행합니다.
+            운영 책임자의 승인을 받은 뒤 배포합니다.
+            """;
+
+    @DynamicPropertySource
+    static void useIsolatedH2Database(DynamicPropertyRegistry registry) {
+        String jdbcUrl = "jdbc:h2:mem:team-page-knowledge-integration;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE";
+        registry.add("spring.datasource.url", () -> jdbcUrl);
+        registry.add("spring.datasource.hikari.jdbc-url", () -> jdbcUrl);
+        registry.add("spring.datasource.driver-class-name", () -> "org.h2.Driver");
+        registry.add("spring.datasource.username", () -> "sa");
+        registry.add("spring.datasource.password", () -> "");
+        registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.H2Dialect");
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+    }
+
+    @Autowired
+    private VectorStore vectorStore;
+    @Autowired
+    private OrganizationRepository organizationRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private ProjectRepository projectRepository;
+    @Autowired
+    private TeamRepository teamRepository;
+    @Autowired
+    private TeamPageRepository teamPageRepository;
+    @Autowired
+    private QaKnowledgeIndexRepository knowledgeIndexRepository;
+    @Autowired
+    private KnowledgeDeletionService deletionService;
+    @Autowired
+    private ApplicationEventPublisher eventPublisher;
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    void synchronizesTeamPageWithPineconeAfterCreateUpdateAndDeleteEvents() throws InterruptedException {
+        PageFixture fixture = createPageAndPublishChangedEvent();
+        String documentId = documentId(fixture.pageId());
+
+        try {
+            System.out.println("1. 공유페이지 생성 이벤트 발행 완료: pageId=" + fixture.pageId());
+            QaKnowledgeIndex initialIndex = waitUntilIndexStateExists(fixture.pageId());
+            Document initialDocument = waitUntilDocumentIsSearchable(
+                    fixture.teamId(),
+                    documentId,
+                    "피닉스 백엔드 정기 배포 시간"
+            );
+
+            System.out.println("2. 생성된 공유페이지 Pinecone 검색 성공");
+            printDocument(initialDocument);
+            assertTeamTextMetadata(initialDocument, fixture, INITIAL_TITLE);
+            assertThat(initialDocument.getText())
+                    .contains("# " + INITIAL_TITLE)
+                    .contains("금요일 오후 4시");
+            assertDocumentIsNotExposedToOtherTeam(documentId);
+
+            updatePageAndPublishChangedEvent(fixture.pageId());
+            waitUntilIndexHashChanges(fixture.pageId(), initialIndex.getContentHash());
+            Document updatedDocument = waitUntilDocumentContains(
+                    fixture.teamId(),
+                    documentId,
+                    "피닉스 백엔드 긴급 배포 시간",
+                    "목요일 오후 3시"
+            );
+
+            System.out.println("3. 수정된 공유페이지 Pinecone 갱신 성공");
+            printDocument(updatedDocument);
+            assertTeamTextMetadata(updatedDocument, fixture, UPDATED_TITLE);
+            assertThat(updatedDocument.getText())
+                    .contains("# " + UPDATED_TITLE)
+                    .contains("목요일 오후 3시")
+                    .doesNotContain("금요일 오후 4시");
+
+            deletePageAndPublishDeletedEvent(fixture.pageId());
+            waitUntilIndexStateIsDeleted(fixture.pageId());
+            waitUntilDocumentIsDeleted(fixture.teamId(), documentId);
+            System.out.println("4. 삭제된 공유페이지 Pinecone 청크 정리 성공");
+        } finally {
+            // 중간 검증이 실패해도 공용 Pinecone 인덱스에 테스트 벡터가 남지 않게 정리한다.
+            deletionService.deleteTeamPageKnowledge(fixture.pageId());
+            vectorStore.delete(List.of(documentId));
+        }
+    }
+
+    private PageFixture createPageAndPublishChangedEvent() {
+        jdbcTemplate.execute("ALTER TABLE team_page ALTER COLUMN page_id RESTART WITH " + TEST_PAGE_ID_START);
+        jdbcTemplate.execute("ALTER TABLE Team ALTER COLUMN team_id RESTART WITH " + TEST_TEAM_ID_START);
+        String runId = UUID.randomUUID().toString();
+
+        return transactionTemplate.execute(status -> {
+            Organization organization = organizationRepository.save(Organization.builder()
+                    .name("공유페이지 RAG 테스트 조직")
+                    .emailDomain("team-page-" + runId + ".local")
+                    .build());
+            User author = userRepository.save(User.builder()
+                    .organization(organization)
+                    .email("author@team-page-" + runId + ".local")
+                    .name("공유페이지 작성자")
+                    .password("encoded-test-password")
+                    .build());
+            Project project = projectRepository.save(Project.create(
+                    "공유페이지 RAG 테스트 프로젝트",
+                    "공유페이지 Pinecone 종단 테스트",
+                    organization,
+                    author
+            ));
+            Team team = teamRepository.save(Team.builder()
+                    .project(project)
+                    .name("공유페이지 RAG 테스트 팀")
+                    .description("공유페이지 Pinecone 종단 테스트")
+                    .createdBy(author)
+                    .build());
+            TeamPage page = teamPageRepository.save(TeamPage.builder()
+                    .team(team)
+                    .author(author)
+                    .title(INITIAL_TITLE)
+                    .content(INITIAL_CONTENT)
+                    .build());
+
+            eventPublisher.publishEvent(new TeamPageChangedEvent(page.getPageId()));
+            return new PageFixture(page.getPageId(), team.getTeamId());
+        });
+    }
+
+    private void updatePageAndPublishChangedEvent(Long pageId) {
+        transactionTemplate.executeWithoutResult(status -> {
+            TeamPage page = teamPageRepository.findById(pageId).orElseThrow();
+            page.update(UPDATED_TITLE, UPDATED_CONTENT);
+            eventPublisher.publishEvent(new TeamPageChangedEvent(pageId));
+        });
+    }
+
+    private void deletePageAndPublishDeletedEvent(Long pageId) {
+        transactionTemplate.executeWithoutResult(status -> {
+            teamPageRepository.deleteById(pageId);
+            eventPublisher.publishEvent(new TeamPageDeletedEvent(pageId));
+        });
+    }
+
+    private QaKnowledgeIndex waitUntilIndexStateExists(Long pageId) throws InterruptedException {
+        for (int attempt = 1; attempt <= 20; attempt++) {
+            QaKnowledgeIndex index = knowledgeIndexRepository
+                    .findBySourceIdAndSourceType(pageId, SourceType.TEAM_TEXT)
+                    .orElse(null);
+            System.out.println("인덱싱 상태 확인: " + attempt + "/20, indexed=" + (index != null));
+            if (index != null) {
+                return index;
+            }
+            Thread.sleep(1_000);
+        }
+        throw new IllegalStateException("공유페이지 인덱싱 상태가 제한 시간 안에 저장되지 않았습니다.");
+    }
+
+    private void waitUntilIndexHashChanges(Long pageId, String previousHash) throws InterruptedException {
+        for (int attempt = 1; attempt <= 20; attempt++) {
+            String currentHash = knowledgeIndexRepository
+                    .findBySourceIdAndSourceType(pageId, SourceType.TEAM_TEXT)
+                    .map(QaKnowledgeIndex::getContentHash)
+                    .orElse(null);
+            System.out.println("수정 인덱싱 상태 확인: " + attempt + "/20");
+            if (currentHash != null && !currentHash.equals(previousHash)) {
+                return;
+            }
+            Thread.sleep(1_000);
+        }
+        throw new IllegalStateException("수정된 공유페이지 인덱싱 상태가 제한 시간 안에 반영되지 않았습니다.");
+    }
+
+    private Document waitUntilDocumentIsSearchable(
+            Long teamId,
+            String expectedDocumentId,
+            String query
+    ) throws InterruptedException {
+        for (int attempt = 1; attempt <= 10; attempt++) {
+            Thread.sleep(2_000);
+            List<Document> results = search(teamId.toString(), query);
+            System.out.println("Pinecone 생성 반영 확인: " + attempt + "/10, 결과=" + results.size());
+            Document document = findDocument(results, expectedDocumentId);
+            if (document != null) {
+                return document;
+            }
+        }
+        throw new IllegalStateException("공유페이지 청크가 제한 시간 안에 Pinecone 검색에 반영되지 않았습니다.");
+    }
+
+    private Document waitUntilDocumentContains(
+            Long teamId,
+            String expectedDocumentId,
+            String query,
+            String expectedText
+    ) throws InterruptedException {
+        for (int attempt = 1; attempt <= 10; attempt++) {
+            Thread.sleep(2_000);
+            Document document = findDocument(search(teamId.toString(), query), expectedDocumentId);
+            System.out.println("Pinecone 수정 반영 확인: " + attempt + "/10");
+            if (document != null && document.getText().contains(expectedText)) {
+                return document;
+            }
+        }
+        throw new IllegalStateException("수정된 공유페이지 청크가 제한 시간 안에 Pinecone 검색에 반영되지 않았습니다.");
+    }
+
+    private void waitUntilIndexStateIsDeleted(Long pageId) throws InterruptedException {
+        for (int attempt = 1; attempt <= 20; attempt++) {
+            boolean exists = knowledgeIndexRepository
+                    .findBySourceIdAndSourceType(pageId, SourceType.TEAM_TEXT)
+                    .isPresent();
+            if (!exists) {
+                return;
+            }
+            Thread.sleep(1_000);
+        }
+        throw new IllegalStateException("삭제된 공유페이지 인덱싱 상태가 제한 시간 안에 제거되지 않았습니다.");
+    }
+
+    private void waitUntilDocumentIsDeleted(Long teamId, String expectedDocumentId) throws InterruptedException {
+        for (int attempt = 1; attempt <= 10; attempt++) {
+            Thread.sleep(2_000);
+            List<Document> results = search(teamId.toString(), "피닉스 백엔드 배포 규칙");
+            System.out.println("Pinecone 삭제 반영 확인: " + attempt + "/10, 결과=" + results.size());
+            if (findDocument(results, expectedDocumentId) == null) {
+                return;
+            }
+        }
+        throw new IllegalStateException("삭제된 공유페이지 청크가 제한 시간 안에 Pinecone에서 제거되지 않았습니다.");
+    }
+
+    private void assertDocumentIsNotExposedToOtherTeam(String expectedDocumentId) {
+        assertThat(search(OTHER_TEAM_ID, "피닉스 백엔드 정기 배포 시간"))
+                .noneMatch(document -> expectedDocumentId.equals(document.getId()));
+    }
+
+    private List<Document> search(String teamId, String query) {
+        return vectorStore.similaritySearch(SearchRequest.builder()
+                .query(query)
+                .topK(10)
+                .similarityThreshold(0.0)
+                .filterExpression("team_id == '" + teamId + "'")
+                .build());
+    }
+
+    private Document findDocument(List<Document> documents, String expectedDocumentId) {
+        return documents.stream()
+                .filter(document -> expectedDocumentId.equals(document.getId()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private void assertTeamTextMetadata(Document document, PageFixture fixture, String expectedTitle) {
+        assertThat(document.getMetadata())
+                .containsEntry("team_id", fixture.teamId().toString())
+                .containsEntry("source_id", fixture.pageId().toString())
+                .containsEntry("source_type", SourceType.TEAM_TEXT.name())
+                .containsEntry("source_title", expectedTitle);
+        assertThat(((Number) document.getMetadata().get("chunk_index")).intValue()).isZero();
+    }
+
+    private void printDocument(Document document) {
+        System.out.println("문서 ID: " + document.getId());
+        System.out.println("검색 결과: " + document.getText());
+        System.out.println("메타데이터: " + document.getMetadata());
+    }
+
+    private String documentId(Long pageId) {
+        return "knowledge-team_text-" + pageId + "-0";
+    }
+
+    private static long randomIdInRange(long rangeStart) {
+        return rangeStart + Math.floorMod(UUID.randomUUID().getMostSignificantBits(), 90_000_000L);
+    }
+
+    private record PageFixture(Long pageId, Long teamId) {
+    }
+}

--- a/src/test/java/com/_penLearning/Noddi/domain/qa/rag/indexing/KnowledgeIndexServiceTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/qa/rag/indexing/KnowledgeIndexServiceTest.java
@@ -1,0 +1,96 @@
+package com._penLearning.Noddi.domain.qa.rag.indexing;
+
+import com._penLearning.Noddi.domain.qa.entity.SourceType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.vectorstore.VectorStore;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class KnowledgeIndexServiceTest {
+
+    @Mock
+    private QaKnowledgeIndexStateService indexStateService;
+    @Mock
+    private KnowledgeDocumentFactory documentFactory;
+    @Mock
+    private VectorStore vectorStore;
+
+    @InjectMocks
+    private KnowledgeIndexService indexService;
+
+    @Test
+    void skipsEmbeddingWhenSourceContentHasNotChanged() throws Exception {
+        KnowledgeSourceContent source = source("same content");
+        when(indexStateService.get(20L, SourceType.TEAM_TEXT))
+                .thenReturn(Optional.of(new KnowledgeIndexState(sha256("same content"), 1)));
+
+        KnowledgeIndexResult result = indexService.synchronize(source);
+
+        assertThat(result.skipped()).isTrue();
+        verify(vectorStore, never()).add(org.mockito.ArgumentMatchers.anyList());
+    }
+
+    @Test
+    void indexesChangedContentAndRecordsStateAfterVectorStoreWrite() {
+        KnowledgeSourceContent source = source("new content");
+        List<Document> documents = List.of(
+                Document.builder().id("doc-1").text("chunk 1").build(),
+                Document.builder().id("doc-2").text("chunk 2").build()
+        );
+        when(indexStateService.get(20L, SourceType.TEAM_TEXT)).thenReturn(Optional.empty());
+        when(documentFactory.create(source)).thenReturn(documents);
+
+        KnowledgeIndexResult result = indexService.synchronize(source);
+
+        assertThat(result.indexedChunkCount()).isEqualTo(2);
+        verify(vectorStore).add(documents);
+        verify(indexStateService).recordSuccess(
+                eq(20L),
+                eq(10L),
+                eq(SourceType.TEAM_TEXT),
+                anyString(),
+                eq(2)
+        );
+    }
+
+    @Test
+    void deletesChunksThatRemainAfterContentGetsShorter() {
+        KnowledgeSourceContent source = source("shortened content");
+        List<Document> documents = List.of(Document.builder().id("doc-1").text("chunk 1").build());
+        List<String> staleIds = List.of("knowledge-team_text-20-1", "knowledge-team_text-20-2");
+        when(indexStateService.get(20L, SourceType.TEAM_TEXT))
+                .thenReturn(Optional.of(new KnowledgeIndexState("old-hash", 3)));
+        when(documentFactory.create(source)).thenReturn(documents);
+        when(documentFactory.documentIds(20L, SourceType.TEAM_TEXT, 1, 3)).thenReturn(staleIds);
+
+        indexService.synchronize(source);
+
+        verify(vectorStore).delete(staleIds);
+    }
+
+    private KnowledgeSourceContent source(String content) {
+        return new KnowledgeSourceContent(20L, 10L, SourceType.TEAM_TEXT, "team page", content);
+    }
+
+    private String sha256(String content) throws Exception {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        return HexFormat.of().formatHex(digest.digest(content.getBytes(StandardCharsets.UTF_8)));
+    }
+}

--- a/src/test/java/com/_penLearning/Noddi/domain/qa/rag/indexing/MeetingKnowledgeIndexServiceTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/qa/rag/indexing/MeetingKnowledgeIndexServiceTest.java
@@ -6,20 +6,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.ai.document.Document;
-import org.springframework.ai.vectorstore.VectorStore;
-
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.util.HexFormat;
-import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -28,66 +16,37 @@ class MeetingKnowledgeIndexServiceTest {
     @Mock
     private MeetingKnowledgeSourceReader sourceReader;
     @Mock
-    private QaKnowledgeIndexStateService indexStateService;
-    @Mock
-    private KnowledgeDocumentFactory documentFactory;
-    @Mock
-    private VectorStore vectorStore;
+    private KnowledgeIndexService knowledgeIndexService;
 
     @InjectMocks
     private MeetingKnowledgeIndexService indexService;
 
     @Test
-    void skipsEmbeddingWhenSourceContentHasNotChanged() throws Exception {
-        KnowledgeSourceContent source = source("same transcript");
+    void delegatesTranscriptToCommonKnowledgeIndexer() {
+        KnowledgeSourceContent source = new KnowledgeSourceContent(
+                20L, 10L, SourceType.TRANSCRIPT, "weekly meeting", "new transcript"
+        );
         when(sourceReader.read(20L)).thenReturn(source);
-        when(indexStateService.get(20L, SourceType.TRANSCRIPT))
-                .thenReturn(Optional.of(new KnowledgeIndexState(sha256("same transcript"), 1)));
+        when(knowledgeIndexService.synchronize(source)).thenReturn(KnowledgeIndexResult.indexed(2));
+
+        MeetingKnowledgeIndexResult result = indexService.index(20L);
+
+        assertThat(result.meetingId()).isEqualTo(20L);
+        assertThat(result.indexedChunkCount()).isEqualTo(2);
+        assertThat(result.skippedSourceCount()).isZero();
+    }
+
+    @Test
+    void mapsSkippedSynchronizationToMeetingResult() {
+        KnowledgeSourceContent source = new KnowledgeSourceContent(
+                20L, 10L, SourceType.TRANSCRIPT, "weekly meeting", "same transcript"
+        );
+        when(sourceReader.read(20L)).thenReturn(source);
+        when(knowledgeIndexService.synchronize(source)).thenReturn(KnowledgeIndexResult.skippedResult());
 
         MeetingKnowledgeIndexResult result = indexService.index(20L);
 
         assertThat(result.indexedChunkCount()).isZero();
         assertThat(result.skippedSourceCount()).isEqualTo(1);
-        verify(vectorStore, never()).add(org.mockito.ArgumentMatchers.anyList());
-    }
-
-    @Test
-    void indexesChangedContentAndRecordsStateAfterVectorStoreWrite() {
-        KnowledgeSourceContent source = source("new transcript");
-        List<Document> documents = List.of(
-                Document.builder().id("doc-1").text("chunk 1").build(),
-                Document.builder().id("doc-2").text("chunk 2").build()
-        );
-        when(sourceReader.read(20L)).thenReturn(source);
-        when(indexStateService.get(20L, SourceType.TRANSCRIPT)).thenReturn(Optional.empty());
-        when(documentFactory.create(source)).thenReturn(documents);
-
-        MeetingKnowledgeIndexResult result = indexService.index(20L);
-
-        assertThat(result.indexedChunkCount()).isEqualTo(2);
-        assertThat(result.skippedSourceCount()).isZero();
-        verify(vectorStore).add(documents);
-        verify(indexStateService).recordSuccess(
-                eq(20L),
-                eq(10L),
-                eq(SourceType.TRANSCRIPT),
-                anyString(),
-                eq(2)
-        );
-    }
-
-    private KnowledgeSourceContent source(String transcript) {
-        return new KnowledgeSourceContent(
-                20L,
-                10L,
-                SourceType.TRANSCRIPT,
-                "weekly meeting",
-                transcript
-        );
-    }
-
-    private String sha256(String content) throws Exception {
-        MessageDigest digest = MessageDigest.getInstance("SHA-256");
-        return HexFormat.of().formatHex(digest.digest(content.getBytes(StandardCharsets.UTF_8)));
     }
 }

--- a/src/test/java/com/_penLearning/Noddi/domain/qa/rag/indexing/TeamPageKnowledgeSourceReaderTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/qa/rag/indexing/TeamPageKnowledgeSourceReaderTest.java
@@ -1,0 +1,48 @@
+package com._penLearning.Noddi.domain.qa.rag.indexing;
+
+import com._penLearning.Noddi.domain.qa.entity.SourceType;
+import com._penLearning.Noddi.domain.team.entity.Team;
+import com._penLearning.Noddi.domain.teamPage.entity.TeamPage;
+import com._penLearning.Noddi.domain.teamPage.repository.TeamPageRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TeamPageKnowledgeSourceReaderTest {
+
+    @Mock
+    private TeamPageRepository teamPageRepository;
+    @Mock
+    private TeamPage page;
+    @Mock
+    private Team team;
+
+    @InjectMocks
+    private TeamPageKnowledgeSourceReader sourceReader;
+
+    @Test
+    void convertsMarkdownPageToTeamTextKnowledgeSource() {
+        when(teamPageRepository.findByPageIdWithTeam(30L)).thenReturn(Optional.of(page));
+        when(page.getPageId()).thenReturn(30L);
+        when(page.getTeam()).thenReturn(team);
+        when(team.getTeamId()).thenReturn(10L);
+        when(page.getTitle()).thenReturn("배포 규칙");
+        when(page.getContent()).thenReturn("## 일정\n- 금요일 배포");
+
+        KnowledgeSourceContent source = sourceReader.read(30L);
+
+        assertThat(source.sourceId()).isEqualTo(30L);
+        assertThat(source.teamId()).isEqualTo(10L);
+        assertThat(source.sourceType()).isEqualTo(SourceType.TEAM_TEXT);
+        assertThat(source.sourceTitle()).isEqualTo("배포 규칙");
+        assertThat(source.content()).isEqualTo("# 배포 규칙\n\n## 일정\n- 금요일 배포");
+    }
+}


### PR DESCRIPTION
## 🎋 작업 브랜치
- `feat/#48-team-page-rag` → `develop`
- #48

## 💡 작업동기
- 팀 공유페이지의 Markdown 데이터를 Q&A의 RAG 근거로 활용하기 위해 Pinecone 인덱싱 기능을 구현했습니다.
- 공유페이지 생성·수정·삭제 시 벡터 데이터가 자동으로 동기화되도록 구성했습니다.

## 🔑 주요 변경사항
- 공유페이지를 `TEAM_TEXT` 지식 원본으로 변환
- 제목과 Markdown 본문을 토큰 단위로 청킹
- Pinecone에 `team_id`, `source_id`, `source_type`, 제목, 청크 번호 메타데이터 저장
- 공유페이지 생성·수정 커밋 이후 비동기 인덱싱 이벤트 처리
- SHA-256 해시 비교를 통한 중복 임베딩 방지
- 수정 후 남은 이전 청크 자동 삭제
- 공유페이지 삭제 시 Pinecone 벡터와 MySQL 인덱싱 상태 제거
- 회의 전사와 공유페이지가 공통 인덱싱 로직을 사용하도록 리팩터링
- 팀별 데이터 격리 및 생성·수정·삭제 흐름을 검증하는 Pinecone 종단 테스트 추가

## ✅ 테스트
- 외부 API 제외 전체 테스트 통과
- 실제 OpenAI Embedding API 및 Pinecone 연동 테스트 통과
- 공유페이지 생성·수정·삭제 시 Pinecone 동기화 확인
- 다른 팀의 공유페이지가 검색되지 않는 `team_id` 격리 확인

## 🏞 스크린샷 (선택)
> 스크린샷을 첨부해주세요.

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
