### PR TITLE
[feat] 프로젝트 팀원 초대 시 조직원 조회 기능 구현

### DIFF
--- a/src/main/java/com/_penLearning/Noddi/domain/project/code/ProjectMemberApi.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/code/ProjectMemberApi.java
@@ -7,9 +7,13 @@ import com._penLearning.Noddi.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 
@@ -38,6 +42,17 @@ public interface ProjectMemberApi {
     @Operation(summary = "프로젝트 멤버 조회", description = "해당 프로젝트에 가입된 멤버 목록을 조회합니다.")
     ApiResponse<List<ProjectMemberResponseDto.MemberInfo>> getMembers(
             @PathVariable Long projectId,
+            @Parameter(hidden = true) @AuthenticationPrincipal AuthMember authMember
+    );
+
+    @Operation(
+            summary = "프로젝트 초대 가능 조직원 조회",
+            description = "프로젝트 리더가 같은 조직에서 프로젝트에 가입하지 않았고 대기 중 초대도 없는 사용자를 이름 또는 이메일로 검색합니다."
+    )
+    ApiResponse<Page<ProjectMemberResponseDto.InviteCandidate>> getInvitableOrganizationMembers(
+            @PathVariable Long projectId,
+            @RequestParam(required = false) String keyword,
+            @ParameterObject Pageable pageable,
             @Parameter(hidden = true) @AuthenticationPrincipal AuthMember authMember
     );
 

--- a/src/main/java/com/_penLearning/Noddi/domain/project/controller/ProjectMemberController.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/controller/ProjectMemberController.java
@@ -8,6 +8,9 @@ import com._penLearning.Noddi.domain.project.service.ProjectMemberService;
 import com._penLearning.Noddi.global.apiPayload.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -65,6 +68,25 @@ public class ProjectMemberController implements ProjectMemberApi {
                 projectMemberService.getMembers(projectId, authMember.getUserId());
         // 2. 일관된 응답 포맷(ApiResponse)으로 감싸서 리턴
         return ApiResponse.onSuccess("프로젝트 멤버 목록 조회에 성공했습니다.", response);
+    }
+
+    @Override
+    @GetMapping("/{projectId}/invitable-organization-members")
+    public ApiResponse<Page<ProjectMemberResponseDto.InviteCandidate>> getInvitableOrganizationMembers(
+            @PathVariable Long projectId,
+            @RequestParam(required = false) String keyword,
+            @PageableDefault(size = 20) Pageable pageable,
+            @AuthenticationPrincipal AuthMember authMember
+    ) {
+        Page<ProjectMemberResponseDto.InviteCandidate> response =
+                projectMemberService.getInvitableOrganizationMembers(
+                        projectId,
+                        authMember.getUserId(),
+                        keyword,
+                        pageable
+                );
+
+        return ApiResponse.onSuccess("프로젝트 초대 가능 조직원 목록 조회에 성공했습니다.", response);
     }
 
     @Override

--- a/src/main/java/com/_penLearning/Noddi/domain/project/dto/ProjectMemberResponseDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/dto/ProjectMemberResponseDto.java
@@ -3,10 +3,28 @@ package com._penLearning.Noddi.domain.project.dto;
 import com._penLearning.Noddi.domain.project.entity.ProjectInvite;
 import com._penLearning.Noddi.domain.project.entity.ProjectMember;
 import com._penLearning.Noddi.domain.project.entity.ProjectRole;
+import com._penLearning.Noddi.domain.user.entity.User;
 import lombok.Builder;
 import lombok.Getter;
 
 public class ProjectMemberResponseDto {
+
+    // 프로젝트와 같은 조직에 속하면서 아직 초대 가능한 사용자 DTO
+    @Getter
+    @Builder
+    public static class InviteCandidate {
+        private Long userId;
+        private String name;
+        private String email;
+
+        public static InviteCandidate from(User user) {
+            return InviteCandidate.builder()
+                    .userId(user.getUserId())
+                    .name(user.getName())
+                    .email(user.getEmail())
+                    .build();
+        }
+    }
 
     // 프로젝트 멤버 조회용 Dto
     @Getter

--- a/src/main/java/com/_penLearning/Noddi/domain/project/repository/ProjectInviteRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/repository/ProjectInviteRepository.java
@@ -1,9 +1,12 @@
 package com._penLearning.Noddi.domain.project.repository;
 
+import com._penLearning.Noddi.domain.organization.entity.Organization;
 import com._penLearning.Noddi.domain.project.entity.InviteStatus;
 import com._penLearning.Noddi.domain.project.entity.Project;
 import com._penLearning.Noddi.domain.project.entity.ProjectInvite;
 import com._penLearning.Noddi.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -25,6 +28,64 @@ public interface ProjectInviteRepository extends JpaRepository<ProjectInvite, Lo
     // 3. 내 초대장 목록 조회 (N+1 방지)
     @Query("SELECT pi FROM ProjectInvite pi JOIN FETCH pi.project JOIN FETCH pi.inviter WHERE pi.invitee = :invitee AND pi.status = :status")
     List<ProjectInvite> findByInviteeAndStatusWithProject(@Param("invitee") User invitee, @Param("status") InviteStatus status);
+
+    // 같은 조직원 중 이미 가입했거나 대기 중인 초대가 있는 사용자를 DB에서 제외한다.
+    @Query(
+            value = """
+                    SELECT u
+                    FROM User u
+                    WHERE u.organization = :organization
+                      AND NOT EXISTS (
+                          SELECT pm.projectMemberId
+                          FROM ProjectMember pm
+                          WHERE pm.project = :project
+                            AND pm.user = u
+                      )
+                      AND NOT EXISTS (
+                          SELECT pi.inviteId
+                          FROM ProjectInvite pi
+                          WHERE pi.project = :project
+                            AND pi.invitee = u
+                            AND pi.status = :pendingStatus
+                      )
+                      AND (
+                          :keyword IS NULL
+                          OR LOWER(u.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                          OR LOWER(u.email) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                      )
+                    ORDER BY u.name ASC, u.userId ASC
+                    """,
+            countQuery = """
+                    SELECT COUNT(u)
+                    FROM User u
+                    WHERE u.organization = :organization
+                      AND NOT EXISTS (
+                          SELECT pm.projectMemberId
+                          FROM ProjectMember pm
+                          WHERE pm.project = :project
+                            AND pm.user = u
+                      )
+                      AND NOT EXISTS (
+                          SELECT pi.inviteId
+                          FROM ProjectInvite pi
+                          WHERE pi.project = :project
+                            AND pi.invitee = u
+                            AND pi.status = :pendingStatus
+                      )
+                      AND (
+                          :keyword IS NULL
+                          OR LOWER(u.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                          OR LOWER(u.email) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                      )
+                    """
+    )
+    Page<User> findInvitableUsers(
+            @Param("organization") Organization organization,
+            @Param("project") Project project,
+            @Param("pendingStatus") InviteStatus pendingStatus,
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
 
     // 4. 프로젝트 삭제 시 연관 초대장 일괄 삭제 (벌크 연산)
     @Modifying(clearAutomatically = true)

--- a/src/main/java/com/_penLearning/Noddi/domain/project/repository/ProjectMemberRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/repository/ProjectMemberRepository.java
@@ -21,16 +21,13 @@ public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Lo
     Optional<ProjectMember> findByProjectAndUser(Project project, User user);
 
     // 3. 프로젝트의 멤버 목록 조회 (N+1 방지)
-    // 팩트: 상태 검증이 필요 없으므로 기존 findJoinedMembersByProject를 삭제하고 이것으로 통합
     @Query("SELECT pm FROM ProjectMember pm JOIN FETCH pm.user WHERE pm.project = :project")
     List<ProjectMember> findAllByProjectWithUser(@Param("project") Project project);
 
     // 4. 특정 권한을 가진 멤버 수 카운트 (마지막 리더 검증용)
-    // 팩트: Status 조건이 포함되었던 countByProjectAndRoleAndStatus 쿼리 대체
     long countByProjectAndRole(Project project, ProjectRole role);
 
     // 5. 프로젝트 삭제 시 멤버 일괄 삭제 (벌크 연산)
-    // 팩트: N+1 문제를 유발하는 기존 deleteAllByProject 메서드는 완전 삭제
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM ProjectMember pm WHERE pm.project = :project")
     void bulkDeleteByProject(@Param("project") Project project);

--- a/src/main/java/com/_penLearning/Noddi/domain/project/service/ProjectMemberService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/service/ProjectMemberService.java
@@ -12,6 +12,9 @@ import com._penLearning.Noddi.domain.user.repository.UserRepository;
 import com._penLearning.Noddi.global.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -49,7 +52,7 @@ public class ProjectMemberService {
             throw new GeneralException(ProjectErrorCode.ALREADY_PROJECT_MEMBER);
         }
 
-        // 2. 중복 초대 방어
+        // 중복 초대 방어
         if (projectInviteRepository.existsByProjectAndInviteeAndStatus(project, targetUser, InviteStatus.PENDING)) {
             throw new GeneralException(ProjectErrorCode.ALREADY_INVITED_USER);
         }
@@ -124,6 +127,33 @@ public class ProjectMemberService {
         return projectMemberRepository.findAllByProjectWithUser(project).stream()
                 .map(ProjectMemberResponseDto.MemberInfo::from)
                 .toList();
+    }
+
+    // 리더가 초대할 수 있는 조직원을 이름 또는 이메일로 검색해 페이지 단위로 조회한다.
+    public Page<ProjectMemberResponseDto.InviteCandidate> getInvitableOrganizationMembers(
+            Long projectId,
+            Long requesterId,
+            String keyword,
+            Pageable pageable
+    ) {
+        Project project = getProjectOrThrow(projectId);
+        validateProjectLeader(project, requesterId);
+
+        // 과도한 단건 요청을 막고, 정렬은 Repository 쿼리에서 이름/ID 순으로 고정한다.
+        Pageable limitedPageable = PageRequest.of(
+                pageable.getPageNumber(),
+                Math.min(pageable.getPageSize(), 50)
+        );
+        String normalizedKeyword = keyword == null || keyword.isBlank() ? null : keyword.strip();
+
+        return projectInviteRepository.findInvitableUsers(
+                        project.getOrganization(),
+                        project,
+                        InviteStatus.PENDING,
+                        normalizedKeyword,
+                        limitedPageable
+                )
+                .map(ProjectMemberResponseDto.InviteCandidate::from);
     }
 
     // 멤버 권한 변경 (리더만 가능)


### PR DESCRIPTION
## <i>PULL REQUEST</i>

## 🎋 작업 브랜치

- `feat/#50-org-member-get` → `develop`
- #50

## 💡 작업동기

- 프로젝트 멤버 초대 시 같은 조직에 소속된 사용자 중 초대 가능한 사용자만 조회할 수 있도록 API를 구현했습니다.
- 이미 프로젝트에 가입했거나 초대 대기 중인 사용자가 중복 노출되지 않도록 개선했습니다.

## 🔑 주요 변경사항

- 프로젝트 초대 가능 조직원 조회 API 추가
- 프로젝트 리더만 조회할 수 있도록 권한 검증
- 기존 프로젝트 멤버 및 `PENDING` 초대 대상자 제외
- 이름 또는 이메일 기반 검색 지원
- 페이징 적용 및 페이지 크기 최대 50개로 제한
- 이름 및 사용자 ID 기준 정렬 적용

## 🏞 스크린샷 (선택)
> 스크린샷을 첨부해주세요.

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
