### PR TITLE
[Feat] SSE stream 구현

### DIFF
--- a/src/main/java/com/_penLearning/Noddi/domain/qa/code/QaApi.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/code/QaApi.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Tag(name = "Q&A API", description = "팀 간 Q&A(질문/답변) 관리 API")
 public interface QaApi {
@@ -57,5 +58,22 @@ public interface QaApi {
             QaRequestDto.ReviseAnswer request,
             @Parameter(hidden = true) AuthMember authMember
     );
+
+    @Operation(
+            summary = "AI 답변 스트림 구독",
+            description = """
+                특정 질문의 AI 답변 생성 과정을 SSE로 구독합니다.
+                같은 프로젝트의 멤버만 구독할 수 있습니다.
+                
+                이벤트 종류:
+                - connected: SSE 연결 성공
+                - snapshot: 현재까지 생성된 전체 답변
+                - chunk: 새롭게 생성된 답변 조각
+                - completed: 최종 답변 저장 완료
+                - failed: 답변 생성 실패
+                """
+    )
+    SseEmitter subscribeAnswerStream(@Parameter(description = "질문 ID") @PathVariable Long questionId,
+                                     @Parameter(hidden = true) AuthMember authMember);
 
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/controller/QaController.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/controller/QaController.java
@@ -4,6 +4,7 @@ import com._penLearning.Noddi.domain.auth.entity.AuthMember;
 import com._penLearning.Noddi.domain.qa.code.QaApi;
 import com._penLearning.Noddi.domain.qa.dto.QaRequestDto;
 import com._penLearning.Noddi.domain.qa.dto.QaResponseDto;
+import com._penLearning.Noddi.domain.qa.service.QaAnswerStreamSubscriptionService;
 import com._penLearning.Noddi.domain.qa.service.QaQuestionCommandService;
 import com._penLearning.Noddi.domain.qa.service.QaAnswerUpdateService;
 import com._penLearning.Noddi.domain.qa.service.QaQuestionQueryService;
@@ -12,20 +13,24 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestController
+@RequestMapping("/api/v1")
 @RequiredArgsConstructor
 public class QaController implements QaApi {
 
     private final QaQuestionCommandService qaQuestionCommandService;
     private final QaQuestionQueryService qaQuestionQueryService;
     private final QaAnswerUpdateService qaAnswerUpdateService;
+    private final QaAnswerStreamSubscriptionService qaAnswerStreamSubscriptionService;
 
     // 질문 등록
     @Override
-    @PostMapping("/api/v1/qa/questions")
+    @PostMapping("/qa/questions")
     public ApiResponse<QaResponseDto.CreateQuestion> createQuestion(
             @RequestBody @Valid QaRequestDto.CreateQuestion request,
             @AuthenticationPrincipal AuthMember authMember) {
@@ -36,7 +41,7 @@ public class QaController implements QaApi {
 
     // 내가 작성한 질문 목록 조회
     @Override
-    @GetMapping("/api/v1/qa/questions/me")
+    @GetMapping("/qa/questions/me")
     public ApiResponse<Page<QaResponseDto.QuestionInfo>> getMyQuestions(
             @AuthenticationPrincipal AuthMember authMember,
             Pageable pageable) {
@@ -47,7 +52,7 @@ public class QaController implements QaApi {
 
     // 특정 팀의 질문 목록 조회 (경로 다름)
     @Override
-    @GetMapping("/api/v1/teams/{teamId}/qa/questions")
+    @GetMapping("/teams/{teamId}/qa/questions")
     public ApiResponse<Page<QaResponseDto.QuestionInfo>> getTeamQuestions(
             @PathVariable Long teamId,
             @AuthenticationPrincipal AuthMember authMember,
@@ -59,7 +64,7 @@ public class QaController implements QaApi {
 
     // 특정 팀의 질문과 답변 피드 조회
     @Override
-    @GetMapping("/api/v1/teams/{teamId}/qa/feed")
+    @GetMapping("/teams/{teamId}/qa/feed")
     public ApiResponse<QaResponseDto.Feed> getTeamFeed(
             @PathVariable Long teamId,
             @RequestParam(required = false) Long cursor,
@@ -73,7 +78,7 @@ public class QaController implements QaApi {
 
     // 질문 상세 단건 조회
     @Override
-    @GetMapping("/api/v1/qa/questions/{questionId}")
+    @GetMapping("/qa/questions/{questionId}")
     public ApiResponse<QaResponseDto.QuestionDetail> getQuestionDetail(
             @PathVariable Long questionId,
             @AuthenticationPrincipal AuthMember authMember) {
@@ -84,7 +89,7 @@ public class QaController implements QaApi {
 
     // AI 답변 수정
     @Override
-    @PatchMapping("/api/v1/qa/answers/{answerId}")
+    @PatchMapping("/qa/answers/{answerId}")
     public ApiResponse<QaResponseDto.ReviseAnswer> reviseAnswer(
             @PathVariable Long answerId,
             @RequestBody @Valid QaRequestDto.ReviseAnswer request,
@@ -97,4 +102,20 @@ public class QaController implements QaApi {
         return ApiResponse.onSuccess("AI 답변이 성공적으로 수정되었습니다.", response);
     }
 
+    /**
+     * 특정 질문의 AI 답변 생성 과정을 SSE로 구독한다.
+     *
+     * 일반 API처럼 한 번 응답하고 종료하는 것이 아니라,
+     * AI 답변이 완료되거나 실패할 때까지 HTTP 연결을 유지한다.
+     */
+    @Override
+    @GetMapping(value = "/qa/questions/{questionId}/answer-stream",
+            produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribeAnswerStream(
+            @PathVariable Long questionId,
+            @AuthenticationPrincipal AuthMember authMember
+    )
+    {
+        return qaAnswerStreamSubscriptionService.subscribe(authMember.getUserId(), questionId);
+    }
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/dto/QaAnswerStreamEventDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/dto/QaAnswerStreamEventDto.java
@@ -1,0 +1,157 @@
+package com._penLearning.Noddi.domain.qa.dto;
+
+import com._penLearning.Noddi.domain.qa.entity.QaStatus;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Q&A AI 답변 생성 과정에서 SSE로 전달하는 응답 DTO다.
+ */
+public record QaAnswerStreamEventDto(
+        EventType type,
+        Long questionId,
+        Long answerId,
+        QaStatus status,
+        String content,
+        String delta
+) {
+
+    /**
+     * SSE 연결이 정상적으로 생성됐음을 알리는 이벤트
+     *
+     * 사용자가 답변 생성 도중 또는 완료 이후에 접속할 수 있으므로
+     * 현재 질문 상태를 외부에서 전달받는다.
+     */
+    public static QaAnswerStreamEventDto connected(
+            Long questionId,
+            QaStatus status
+    ) {
+        return new QaAnswerStreamEventDto(
+                EventType.CONNECTED,
+                questionId,
+                null,
+                status,
+                null,
+                null
+        );
+    }
+
+    /**
+     * 현재까지 생성된 답변 전체를 전달한다.
+     *
+     * 사용자가 AI 답변 생성 도중 늦게 접속하거나 SSE 연결이 끊어진 뒤
+     * 다시 접속했을 때 이전 답변 조각을 복구하는 용도로 사용한다.
+     *
+     * 프론트에서는 기존 문자열에 추가하지 않고 content로 교체해야 한다.
+     */
+    public static QaAnswerStreamEventDto snapshot(
+            Long questionId,
+            String content
+    ) {
+        return new QaAnswerStreamEventDto(
+                EventType.SNAPSHOT,
+                questionId,
+                null,
+                QaStatus.PROCESSING,
+                content,
+                null
+        );
+    }
+
+    /**
+     * AI가 새롭게 생성한 답변 조각 하나를 전달한다.
+     *
+     * 프론트에서는 delta 값을 현재까지 표시한 답변 뒤에 이어 붙인다.
+     */
+    public static QaAnswerStreamEventDto chunk(
+            Long questionId,
+            String delta
+    ) {
+        return new QaAnswerStreamEventDto(
+                EventType.CHUNK,
+                questionId,
+                null,
+                QaStatus.PROCESSING,
+                null,
+                delta
+        );
+    }
+
+    /**
+     * AI 답변 전체가 DB에 저장된 후 전달한다.
+     *
+     * content에는 최종 답변 전체를 넣는다.
+     * 스트리밍 과정에서 일부 chunk를 놓쳤더라도 프론트가 마지막에
+     * content로 화면을 교체하면 DB의 최종 답변과 동일해진다.
+     */
+    public static QaAnswerStreamEventDto completed(
+            Long questionId,
+            Long answerId,
+            String content
+    ) {
+        return new QaAnswerStreamEventDto(
+                EventType.COMPLETED,
+                questionId,
+                answerId,
+                QaStatus.ANSWERED,
+                content,
+                null
+        );
+    }
+
+    /**
+     * AI 답변 생성 또는 저장에 실패했음을 알린다.
+     *
+     * 프론트는 답변 생성 로딩을 종료하고 실패 또는 재시도 UI를 표시한다.
+     */
+    public static QaAnswerStreamEventDto failed(Long questionId) {
+        return new QaAnswerStreamEventDto(
+                EventType.FAILED,
+                questionId,
+                null,
+                QaStatus.FAILED,
+                null,
+                null
+        );
+    }
+
+    /**
+     * SSE로 전달하는 이벤트 종류다.
+     *
+     * 질문 자체의 DB 상태인 QaStatus와 달리,
+     * 클라이언트가 어떤 동작을 해야 하는지 구분하기 위한 통신 규격이다.
+     */
+    public enum EventType {
+
+        // SSE 연결 성공
+        CONNECTED("connected"),
+
+        // 현재까지 생성된 전체 답변 전달
+        SNAPSHOT("snapshot"),
+
+        // 새롭게 생성된 답변 조각 전달
+        CHUNK("chunk"),
+
+        // 최종 답변 저장 완료
+        COMPLETED("completed"),
+
+        // 답변 생성 실패
+        FAILED("failed");
+
+        private final String eventName;
+
+        EventType(String eventName) {
+            this.eventName = eventName;
+        }
+
+        /**
+         * SSE의 event 이름과 JSON의 type 값에 사용한다.
+         *
+         * @JsonValue를 사용했기 때문에 JSON에는 "CHUNK"가 아니라
+         * 프론트에서 사용하기 편한 "chunk"로 직렬화된다.
+         */
+        @JsonValue
+        public String getEventName() {
+            return eventName;
+        }
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/event/QaQuestionCreatedEventHandler.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/event/QaQuestionCreatedEventHandler.java
@@ -6,6 +6,7 @@ import com._penLearning.Noddi.domain.qa.rag.generation.QaRagAnswerGenerator;
 import com._penLearning.Noddi.domain.qa.rag.generation.QaRagGeneration;
 import com._penLearning.Noddi.domain.qa.repository.QaQuestionRepository;
 import com._penLearning.Noddi.domain.qa.service.QaAiAnswerLifecycleService;
+import com._penLearning.Noddi.domain.qa.service.QaAnswerStreamService;
 import com._penLearning.Noddi.global.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,8 +17,10 @@ import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 /**
- * 질문 저장이 완료된 뒤 RAG 답변 생성을 시작하고 최종 답변을 DB에 저장한다.
- * SSE 전송은 담당하지 않으며, 생성기가 내보낸 문자열 조각을 저장 목적으로만 합친다.
+ * 질문 저장이 완료된 뒤 RAG 답변 생성을 시작한다.
+ *
+ * 생성되는 답변 조각은 SSE 구독자에게 실시간으로 전달하고,
+ * 생성이 끝나면 최종 답변과 근거를 DB에 저장한다.
  */
 @Slf4j
 @Component
@@ -32,6 +35,7 @@ public class QaQuestionCreatedEventHandler {
     private final QaQuestionRepository qaQuestionRepository;
     private final QaAiAnswerLifecycleService answerLifecycleService;
     private final QaRagAnswerGenerator answerGenerator;
+    private final QaAnswerStreamService answerStreamService;
 
     @Async // 질문 등록 API가 OpenAI 응답을 기다리지 않음
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT) // 질문 DB 저장이 확정된 후에만 AI 생성을 시작함
@@ -42,6 +46,14 @@ public class QaQuestionCreatedEventHandler {
         if (!answerLifecycleService.tryStart(questionId)) { // 중복 이벤트가 들어와도 OpenAI를 여러 번 호출하지 않도록 방지
             return;
         }
+
+        /*
+         * 이전 실패나 재시도 과정에서 남은 누적 답변을 초기화한다.
+         *
+         * SSE 초기화가 실패하더라도 AI 답변 생성과 DB 저장은 계속되어야 하므로
+         * 안전하게 감싼 메서드를 사용한다.
+         */
+        startStreamSafely(questionId);
 
         try {
             QaQuestion question = qaQuestionRepository.findByIdWithTeam(questionId)
@@ -58,6 +70,7 @@ public class QaQuestionCreatedEventHandler {
             }
 
             String answer = generation.answerChunks()
+                    .doOnNext(chunk -> publishChunkSafely(questionId, chunk))
                     .collectList()
                     .map(chunks -> String.join("", chunks))
                     .filter(content -> !content.isBlank())
@@ -66,10 +79,112 @@ public class QaQuestionCreatedEventHandler {
                     ))
                     .block();
 
-            answerLifecycleService.complete(questionId, answer, generation.sources()); // 답변과 근거 저장
+            Long answerId = answerLifecycleService.complete(questionId, answer, generation.sources()); // 답변과 근거 저장
+
+            publishCompletedSafely(questionId, answerId, answer);
         } catch (Exception exception) {
-            answerLifecycleService.fail(questionId); // API 호출 실패 또는 빈 답변이면 FAILED로 전환
+            failQuestionSafely(questionId);
+            publishFailedSafely(questionId);
             log.error("Q&A AI answer generation failed. questionId={}", questionId, exception);
+        }
+    }
+
+    /**
+     * SSE 처리 장애가 AI 답변 생성 자체를 중단시키지 않도록
+     * 스트림 시작 과정의 예외를 이 메서드 안에서 처리한다.
+     */
+    private void startStreamSafely(Long questionId) {
+        try {
+            answerStreamService.start(questionId);
+        } catch (RuntimeException exception) {
+            log.warn(
+                    "Q&A SSE stream initialization failed. questionId={}",
+                    questionId,
+                    exception
+            );
+        }
+    }
+
+    /**
+     * AI가 생성한 조각을 SSE로 전달한다.
+     *
+     * 사용자가 브라우저를 닫거나 네트워크가 끊어져 SSE 전송이 실패하더라도
+     * AI 최종 답변은 정상적으로 DB에 저장되어야 한다.
+     */
+    private void publishChunkSafely(
+            Long questionId,
+            String chunk
+    ) {
+        try {
+            answerStreamService.publishChunk(questionId, chunk);
+        } catch (RuntimeException exception) {
+            log.warn(
+                    "Q&A SSE chunk publishing failed. questionId={}",
+                    questionId,
+                    exception
+            );
+        }
+    }
+
+    /**
+     * 최종 답변의 DB 저장이 끝났음을 SSE 구독자에게 알린다.
+     * DB에는 이미 답변이 저장됐는데 실패 처리까지 시도하는 이상한 흐름이 생길 수 있어 책임을 분리합니다.
+     */
+    private void publishCompletedSafely(
+            Long questionId,
+            Long answerId,
+            String content
+    ) {
+        try {
+            answerStreamService.publishCompleted(
+                    questionId,
+                    answerId,
+                    content
+            );
+        } catch (RuntimeException exception) {
+            /*
+             * COMPLETED 전송이 실패해도 DB에는 이미 답변이 저장되어 있다.
+             * 따라서 질문을 FAILED로 변경하면 안 된다.
+             */
+            log.warn(
+                    "Q&A SSE completion publishing failed. questionId={}, answerId={}",
+                    questionId,
+                    answerId,
+                    exception
+            );
+        }
+    }
+
+    /**
+     * AI 답변 생성 실패를 SSE 구독자에게 알린다.
+     */
+    private void publishFailedSafely(Long questionId) {
+        try {
+            answerStreamService.publishFailed(questionId);
+        } catch (RuntimeException exception) {
+            log.warn(
+                    "Q&A SSE failure publishing failed. questionId={}",
+                    questionId,
+                    exception
+            );
+        }
+    }
+
+    /**
+     * 질문 상태를 FAILED로 변경한다.
+     *
+     * 실패 상태 저장 자체에서 추가 예외가 발생하더라도 원래 발생한
+     * AI 생성 예외가 사라지지 않게 별도로 처리한다.
+     */
+    private void failQuestionSafely(Long questionId) {
+        try {
+            answerLifecycleService.fail(questionId);
+        } catch (RuntimeException exception) {
+            log.error(
+                    "Q&A question failure state update failed. questionId={}",
+                    questionId,
+                    exception
+            );
         }
     }
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaAnswerStreamService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaAnswerStreamService.java
@@ -1,0 +1,416 @@
+package com._penLearning.Noddi.domain.qa.service;
+
+import com._penLearning.Noddi.domain.qa.dto.QaAnswerStreamEventDto;
+import com._penLearning.Noddi.domain.qa.entity.QaStatus;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+@Slf4j
+@Service
+public class QaAnswerStreamService {
+
+
+     //네트워크 지연이나 OpenAI 응답 지연을 고려해 한 SSE 연결을 최대 30분 동안 유지한다.
+    private static final long SSE_TIMEOUT_MILLIS = 30 * 60 * 1000L;
+
+    /*
+     * 완료 또는 실패 이벤트를 5분 동안 메모리에 남긴다.
+     *
+     * AI 답변이 끝나는 순간과 사용자가 SSE에 접속하는 순간이 겹치더라도
+     * 마지막 완료/실패 이벤트를 놓치지 않게 하기 위한 보관 시간이다.
+     */
+    private static final long TERMINATED_SESSION_RETENTION_MILLIS =
+            5 * 60 * 1000L;
+
+    /*
+     * questionId별 스트리밍 상태를 저장한다.
+     *
+     * 하나의 질문을 여러 프로젝트 멤버가 동시에 볼 수 있으므로
+     * 질문 하나에 여러 SseEmitter가 연결될 수 있다.
+     *
+     * ConcurrentHashMap을 사용하는 이유는 다음 작업들이 서로 다른
+     * 스레드에서 동시에 실행될 수 있기 때문이다.
+     *
+     * - HTTP 요청 스레드: SSE 구독
+     * - @Async 스레드: AI 답변 생성 및 chunk 전달
+     * - 스케줄러 스레드: 종료된 세션 정리
+     */
+    private final ConcurrentMap<Long, StreamSession> sessions =
+            new ConcurrentHashMap<>();
+
+    /**
+     * AI 답변 생성 작업을 시작할 때 호출한다.
+     *
+     * 이전 실패 또는 복구 작업에서 남아 있을 수 있는 답변 조각과
+     * 종료 이벤트를 초기화한다.
+     *
+     * 기존 SSE 연결 목록은 유지한다. 따라서 자동 재시도가 시작되더라도
+     * 사용자는 같은 연결에서 새 답변을 받을 수 있다.
+     */
+    public void start(Long questionId) {
+        StreamSession session = sessions.computeIfAbsent(
+                questionId,
+                ignored -> new StreamSession()
+        );
+
+        //여러 스레드가 동시에 실행하지 못하게 세션별로 잠금
+        synchronized (session) {
+            session.content.setLength(0);
+            session.terminalEvent = null;
+            session.terminatedAt = null;
+        }
+    }
+
+    /**
+     * 클라이언트의 SSE 연결을 생성한다.
+     *
+     * currentStatus, answerId, answerContent는 나중에 구독 서비스가
+     * DB에서 조회한 현재 질문/답변 정보를 전달한다.
+     *
+     * 서버가 재시작되어 메모리 세션이 사라졌더라도 DB 상태가 ANSWERED라면
+     * 저장된 최종 답변을 즉시 내려줄 수 있어야 하기 때문이다.
+     */
+    public SseEmitter subscribe(
+            Long questionId,
+            QaStatus currentStatus,
+            Long answerId,
+            String answerContent
+    ) {
+        SseEmitter emitter = new SseEmitter(SSE_TIMEOUT_MILLIS);
+
+        /*
+         * DB에서 이미 완료 또는 실패한 상태를 확인했다면
+         * 장시간 연결을 유지할 필요 없이 현재 상태를 보내고 종료한다.
+         */
+        if (currentStatus == QaStatus.ANSWERED) {
+            sendEvent(
+                    emitter,
+                    QaAnswerStreamEventDto.connected(questionId, currentStatus)
+            );
+            sendEvent(
+                    emitter,
+                    QaAnswerStreamEventDto.completed(
+                            questionId,
+                            answerId,
+                            answerContent
+                    )
+            );
+            emitter.complete();
+            return emitter;
+        }
+
+        if (currentStatus == QaStatus.FAILED) {
+            sendEvent(
+                    emitter,
+                    QaAnswerStreamEventDto.connected(questionId, currentStatus)
+            );
+            sendEvent(
+                    emitter,
+                    QaAnswerStreamEventDto.failed(questionId)
+            );
+            emitter.complete();
+            return emitter;
+        }
+
+        StreamSession session = sessions.computeIfAbsent(
+                questionId,
+                ignored -> new StreamSession()
+        );
+
+        registerCallbacks(questionId, session, emitter);
+
+        /*
+         * subscribe와 publishChunk가 동시에 실행되더라도 이벤트 순서가
+         * 뒤집히지 않도록 동일한 session 객체를 기준으로 동기화한다.
+         *
+         * 반드시 emitter를 먼저 등록하고 snapshot을 보내야 이후에 생성되는
+         * chunk가 현재 연결에도 전달된다.
+         */
+        synchronized (session) {
+            session.emitters.add(emitter);
+
+            boolean connected = sendEvent(
+                    emitter,
+                    QaAnswerStreamEventDto.connected(questionId, currentStatus)
+            );
+
+            if (!connected) {
+                session.emitters.remove(emitter);
+                return emitter;
+            }
+
+            /*
+             * DB 상태를 읽은 직후 AI 작업이 완료되는 경쟁 상황이 있을 수 있다.
+             *
+             * DB에서는 아직 PROCESSING을 읽었더라도 메모리 세션에 종료 이벤트가
+             * 등록됐다면 해당 이벤트를 즉시 보내고 연결을 종료한다.
+             */
+            if (session.terminalEvent != null) {
+                sendEvent(emitter, session.terminalEvent);
+                session.emitters.remove(emitter);
+                emitter.complete();
+                return emitter;
+            }
+
+            /*
+             * AI 답변 생성 도중 늦게 접속했다면 지금까지 누적된 전체 답변을
+             * snapshot으로 먼저 전달한다.
+             *
+             * 이후 생성되는 텍스트부터 chunk 이벤트로 이어서 받게 된다.
+             */
+            if (!session.content.isEmpty()) {
+                sendEvent(
+                        emitter,
+                        QaAnswerStreamEventDto.snapshot(
+                                questionId,
+                                session.content.toString()
+                        )
+                );
+            }
+        }
+
+        return emitter;
+    }
+
+    /**
+     * AI가 생성한 답변 조각 하나를 누적하고 모든 구독자에게 전달한다.
+     */
+    public void publishChunk(Long questionId, String delta) {
+        /*
+         * 공백 문자열도 AI 답변 구성에 필요할 수 있다.
+         *
+         * 따라서 isBlank()를 사용하면 안 된다.
+         * 예를 들어 " 출시일" 앞의 공백을 제거하면 문장이 붙어버릴 수 있다.
+         */
+        if (delta == null || delta.isEmpty()) {
+            return;
+        }
+
+        StreamSession session = sessions.computeIfAbsent(
+                questionId,
+                ignored -> new StreamSession()
+        );
+
+        synchronized (session) {
+            /*
+             * AI 답변이 종료된 이후 뒤늦게 도착한 chunk는 무시한다.
+             */
+            if (session.terminalEvent != null) {
+                return;
+            }
+
+            session.content.append(delta);
+
+            broadcast(
+                    session,
+                    QaAnswerStreamEventDto.chunk(questionId, delta)
+            );
+        }
+    }
+
+    /**
+     * 최종 답변이 DB에 저장된 이후 호출한다.
+     *
+     * 반드시 DB 저장이 성공한 뒤 호출해야 한다. DB 저장 전에 COMPLETED를
+     * 보내면 프론트가 피드를 다시 조회했을 때 답변을 찾지 못할 수 있다.
+     */
+    public void publishCompleted(
+            Long questionId,
+            Long answerId,
+            String content
+    ) {
+        StreamSession session = sessions.computeIfAbsent(
+                questionId,
+                ignored -> new StreamSession()
+        );
+
+        QaAnswerStreamEventDto completedEvent =
+                QaAnswerStreamEventDto.completed(
+                        questionId,
+                        answerId,
+                        content
+                );
+
+        terminate(session, completedEvent);
+    }
+
+    /**
+     * AI 생성 또는 답변 저장이 실패했을 때 호출한다.
+     */
+    public void publishFailed(Long questionId) {
+        StreamSession session = sessions.computeIfAbsent(
+                questionId,
+                ignored -> new StreamSession()
+        );
+
+        terminate(
+                session,
+                QaAnswerStreamEventDto.failed(questionId)
+        );
+    }
+
+    /**
+     * 종료 이벤트를 모든 구독자에게 전달하고 SSE 연결을 닫는다.
+     *
+     * 종료 이벤트 자체는 잠시 메모리에 보관한다. 완료 시점과 구독 시점이
+     * 겹치는 사용자가 마지막 이벤트를 놓치지 않도록 하기 위해서다.
+     */
+    private void terminate(
+            StreamSession session,
+            QaAnswerStreamEventDto terminalEvent
+    ) {
+        synchronized (session) {
+            /*
+             * complete와 fail이 경쟁하더라도 최초 종료 이벤트만 인정한다.
+             */
+            if (session.terminalEvent != null) {
+                return;
+            }
+
+            session.terminalEvent = terminalEvent;
+            session.terminatedAt = Instant.now();
+
+            for (SseEmitter emitter : session.emitters) {
+                sendEvent(emitter, terminalEvent);
+                emitter.complete();
+            }
+
+            session.emitters.clear();
+        }
+    }
+
+    /**
+     * 현재 질문을 구독 중인 모든 SSE 연결에 이벤트를 전달한다.
+     *
+     * 전송에 실패한 emitter는 이미 연결이 끊긴 것으로 보고 목록에서 제거한다.
+     */
+    private void broadcast(
+            StreamSession session,
+            QaAnswerStreamEventDto event
+    ) {
+        session.emitters.removeIf(emitter -> !sendEvent(emitter, event));
+    }
+
+    /**
+     * DTO를 실제 SSE 형식으로 변환해 전송한다.
+     *
+     * 예:
+     *
+     * event: chunk
+     * data: {"type":"chunk","questionId":1,...}
+     */
+    private boolean sendEvent(
+            SseEmitter emitter,
+            QaAnswerStreamEventDto event
+    ) {
+        try {
+            emitter.send(
+                    SseEmitter.event()
+                            .name(event.type().getEventName())
+                            .data(event)
+            );
+            return true;
+        } catch (IOException | IllegalStateException exception) {
+            /*
+             * 브라우저 종료나 네트워크 단절은 정상적으로 발생할 수 있으므로
+             * 전체 AI 생성 작업을 실패 처리하지 않는다.
+             */
+            log.debug(
+                    "Q&A SSE event send failed. questionId={}, type={}",
+                    event.questionId(),
+                    event.type(),
+                    exception
+            );
+            emitter.complete();
+            return false;
+        }
+    }
+
+    /**
+     * 타임아웃, 네트워크 오류, 정상 종료가 발생하면 emitter를 제거한다.
+     *
+     * 콜백을 등록하지 않으면 끊어진 연결이 Map에 계속 남아 메모리 누수가
+     * 발생할 수 있다.
+     */
+    private void registerCallbacks(
+            Long questionId,
+            StreamSession session,
+            SseEmitter emitter
+    ) {
+        emitter.onCompletion(() -> removeEmitter(questionId, session, emitter));
+
+        emitter.onTimeout(() -> {
+            removeEmitter(questionId, session, emitter);
+            emitter.complete();
+        });
+
+        emitter.onError(exception ->
+                removeEmitter(questionId, session, emitter)
+        );
+    }
+
+    private void removeEmitter(
+            Long questionId,
+            StreamSession session,
+            SseEmitter emitter
+    ) {
+        session.emitters.remove(emitter);
+
+        log.debug(
+                "Q&A SSE emitter removed. questionId={}, remainingConnections={}",
+                questionId,
+                session.emitters.size()
+        );
+    }
+
+    /**
+     * 완료 또는 실패 후 보관 시간이 지난 스트림 상태를 메모리에서 제거한다.
+     *
+     * 1분마다 검사하며, 실제 제거 기준은 TERMINATED_SESSION_RETENTION_MILLIS다.
+     */
+    @Scheduled(fixedDelay = 60_000)
+    public void cleanupTerminatedSessions() {
+        Instant threshold = Instant.now().minusMillis(
+                TERMINATED_SESSION_RETENTION_MILLIS
+        );
+
+        sessions.entrySet().removeIf(entry -> {
+            StreamSession session = entry.getValue();
+
+            synchronized (session) {
+                return session.terminatedAt != null
+                        && session.terminatedAt.isBefore(threshold);
+            }
+        });
+    }
+
+    /**
+     * 질문 하나의 SSE 실행 상태다.
+     *
+     * DB에 저장되는 Entity가 아니라 현재 서버 프로세스 안에서만 유지되는
+     * 일시적인 상태이므로 QaAnswerStreamService 내부 클래스로 둔다.
+     */
+    private static class StreamSession {
+
+        // 현재까지 생성된 답변 전체
+        private final StringBuilder content = new StringBuilder();
+
+        // 현재 질문을 구독하고 있는 SSE 연결
+        private final Set<SseEmitter> emitters =
+                ConcurrentHashMap.newKeySet();
+
+        // COMPLETED 또는 FAILED 이벤트
+        private QaAnswerStreamEventDto terminalEvent;
+
+        // 종료된 세션 정리 시간을 판단하기 위한 시각
+        private Instant terminatedAt;
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaAnswerStreamSubscriptionService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaAnswerStreamSubscriptionService.java
@@ -1,0 +1,122 @@
+package com._penLearning.Noddi.domain.qa.service;
+
+import com._penLearning.Noddi.domain.qa.code.QaErrorCode;
+import com._penLearning.Noddi.domain.qa.entity.QaAnswer;
+import com._penLearning.Noddi.domain.qa.entity.QaQuestion;
+import com._penLearning.Noddi.domain.qa.entity.QaStatus;
+import com._penLearning.Noddi.domain.qa.repository.QaAnswerRepository;
+import com._penLearning.Noddi.domain.qa.repository.QaQuestionRepository;
+import com._penLearning.Noddi.domain.project.repository.ProjectMemberRepository;
+import com._penLearning.Noddi.domain.user.code.UserErrorCode;
+import com._penLearning.Noddi.domain.user.entity.User;
+import com._penLearning.Noddi.domain.user.repository.UserRepository;
+import com._penLearning.Noddi.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class QaAnswerStreamSubscriptionService {
+
+    private final QaQuestionRepository qaQuestionRepository;
+    private final QaAnswerRepository qaAnswerRepository;
+    private final UserRepository userRepository;
+    private final ProjectMemberRepository projectMemberRepository;
+    private final QaAnswerStreamService qaAnswerStreamService;
+
+    /**
+     * 사용자가 특정 질문의 AI 답변 스트림을 구독한다.
+     *
+     * SSE 연결을 생성하기 전에 다음 사항을 확인
+     *
+     * 1. 요청한 사용자가 실제로 존재하는가?
+     * 2. 구독하려는 질문이 존재하는가?
+     * 3. 사용자가 질문이 속한 프로젝트의 멤버인가?
+     * 4. 이미 답변이 완료됐다면 저장된 답변은 무엇인가?
+     */
+    public SseEmitter subscribe(
+            Long requesterId,
+            Long questionId
+    ) {
+        User requester = getUserOrThrow(requesterId);
+        QaQuestion question = getQuestionOrThrow(questionId);
+
+        validateProjectMember(requester, question);
+
+        /*
+         * PENDING 또는 PROCESSING 상태에서는 아직 저장된 답변이 없으므로
+         * answerId와 answerContent를 null로 전달한다.
+         */
+        Long answerId = null;
+        String answerContent = null;
+
+        /*
+         * ANSWERED 상태라면 메모리 스트림이 이미 사라졌거나 서버가 재시작됐어도
+         * DB에 저장된 최종 답변을 즉시 전달할 수 있어야 한다.
+         */
+        if (question.getStatus() == QaStatus.ANSWERED) {
+            QaAnswer answer = qaAnswerRepository.findByQuestion(question)
+                    .orElseThrow(() ->
+                            new GeneralException(QaErrorCode.ANSWER_NOT_FOUND)
+                    );
+
+            answerId = answer.getAnswerId();
+            answerContent = answer.getContent();
+        }
+
+        /*
+         * 권한 검증과 현재 상태 조회를 마친 뒤 실제 SSE 연결을 생성한다.
+         *
+         * QaAnswerStreamService는 DB를 직접 조회하지 않고 전달받은 상태만으로
+         * 연결과 이벤트 전송을 관리한다.
+         */
+        return qaAnswerStreamService.subscribe(
+                question.getQuestionId(),
+                question.getStatus(),
+                answerId,
+                answerContent
+        );
+    }
+
+    private User getUserOrThrow(Long requesterId) {
+        return userRepository.findById(requesterId)
+                .orElseThrow(() ->
+                        new GeneralException(UserErrorCode.USER_NOT_FOUND)
+                );
+    }
+
+    private QaQuestion getQuestionOrThrow(Long questionId) {
+        /*
+         * findByIdWithTeam을 사용해 권한 검증에 필요한 targetTeam을
+         * 질문과 함께 조회한다.
+         */
+        return qaQuestionRepository.findByIdWithTeam(questionId)
+                .orElseThrow(() ->
+                        new GeneralException(QaErrorCode.QUESTION_NOT_FOUND)
+                );
+    }
+
+    private void validateProjectMember(
+            User requester,
+            QaQuestion question
+    ) {
+        /*
+         * 질문 대상 팀의 팀원만 구독할 수 있는 것이 아니다.
+         *
+         * 합의한 정책에 따라 같은 프로젝트의 모든 멤버가 Q&A 피드를
+         * 볼 수 있으므로 SSE 답변도 같은 프로젝트 멤버라면 구독할 수 있다.
+         */
+        boolean isProjectMember =
+                projectMemberRepository.existsByProjectAndUser(
+                        question.getTargetTeam().getProject(),
+                        requester
+                );
+
+        if (!isProjectMember) {
+            throw new GeneralException(QaErrorCode.NOT_PROJECT_MEMBER);
+        }
+    }
+}

--- a/src/test/java/com/_penLearning/Noddi/domain/qa/controller/QaControllerTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/qa/controller/QaControllerTest.java
@@ -5,6 +5,7 @@ import com._penLearning.Noddi.domain.qa.dto.QaResponseDto;
 import com._penLearning.Noddi.domain.qa.entity.AnswerType;
 import com._penLearning.Noddi.domain.qa.entity.QaStatus;
 import com._penLearning.Noddi.domain.qa.entity.SourceType;
+import com._penLearning.Noddi.domain.qa.service.QaAnswerStreamSubscriptionService;
 import com._penLearning.Noddi.domain.qa.service.QaAnswerUpdateService;
 import com._penLearning.Noddi.domain.qa.service.QaQuestionCommandService;
 import com._penLearning.Noddi.domain.qa.service.QaQuestionQueryService;
@@ -20,6 +21,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -28,6 +30,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
@@ -51,6 +54,9 @@ class QaControllerTest {
     @Mock
     private QaAnswerUpdateService qaAnswerUpdateService;
 
+    @Mock
+    private QaAnswerStreamSubscriptionService qaAnswerStreamSubscriptionService;
+
     private MockMvc mockMvc;
 
     @BeforeEach
@@ -58,7 +64,8 @@ class QaControllerTest {
         QaController controller = new QaController(
                 qaQuestionCommandService,
                 qaQuestionQueryService,
-                qaAnswerUpdateService
+                qaAnswerUpdateService,
+                qaAnswerStreamSubscriptionService
         );
 
         // 실제 JWT 필터를 실행하는 대신 로그인 완료 후 SecurityContext에 들어갈 인증 객체를 준비한다.
@@ -149,6 +156,27 @@ class QaControllerTest {
 
         // Then: 문자열 query parameter가 Long과 int로 변환되어 서비스에 정확히 전달된다.
         verify(qaQuestionQueryService).getTeamFeed(1L, 10L, 81L, 10);
+    }
+
+    @Test
+    void opensAnswerStreamForAuthenticatedUser() throws Exception {
+        // Given: 구독 서비스가 질문 101번의 장시간 SSE 연결을 생성한다.
+        SseEmitter emitter = new SseEmitter();
+        when(qaAnswerStreamSubscriptionService.subscribe(1L, 101L))
+                .thenReturn(emitter);
+
+        // When & Then: SSE 엔드포인트를 호출하면 일반 JSON 응답으로 끝나지 않고
+        // 비동기 요청을 시작해 이후 AI 이벤트를 계속 받을 수 있는 연결을 유지한다.
+        mockMvc.perform(get("/api/v1/qa/questions/{questionId}/answer-stream", 101L)
+                        .accept("text/event-stream"))
+                .andExpect(status().isOk())
+                .andExpect(request().asyncStarted());
+
+        // SecurityContext의 로그인 사용자 ID와 URL의 질문 ID가 구독 서비스에 전달된다.
+        verify(qaAnswerStreamSubscriptionService).subscribe(1L, 101L);
+
+        // 테스트가 끝난 뒤 열려 있는 비동기 요청을 정리한다.
+        emitter.complete();
     }
 
     private QaResponseDto.Feed createAnsweredFeed(LocalDateTime createdAt) {

--- a/src/test/java/com/_penLearning/Noddi/domain/qa/event/QaQuestionCreatedEventHandlerTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/qa/event/QaQuestionCreatedEventHandlerTest.java
@@ -6,6 +6,7 @@ import com._penLearning.Noddi.domain.qa.rag.generation.QaRagGeneration;
 import com._penLearning.Noddi.domain.qa.rag.retrieval.RetrievedKnowledge;
 import com._penLearning.Noddi.domain.qa.repository.QaQuestionRepository;
 import com._penLearning.Noddi.domain.qa.service.QaAiAnswerLifecycleService;
+import com._penLearning.Noddi.domain.qa.service.QaAnswerStreamService;
 import com._penLearning.Noddi.domain.team.entity.Team;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,6 +36,9 @@ class QaQuestionCreatedEventHandlerTest {
     private QaRagAnswerGenerator answerGenerator;
 
     @Mock
+    private QaAnswerStreamService answerStreamService;
+
+    @Mock
     private QaQuestion question;
 
     @Mock
@@ -42,6 +46,7 @@ class QaQuestionCreatedEventHandlerTest {
 
     @Test
     void combinesStreamChunksAndSavesCompletedAnswer() {
+        // Given: AI가 두 개의 텍스트 조각을 순서대로 생성한다.
         QaQuestionCreatedEventHandler handler = createHandler();
         when(answerLifecycleService.tryStart(1L)).thenReturn(true);
         when(qaQuestionRepository.findByIdWithTeam(1L)).thenReturn(Optional.of(question));
@@ -54,15 +59,34 @@ class QaQuestionCreatedEventHandlerTest {
                         sources,
                         Flux.just("8월 20일에 ", "배포합니다. [근거 1]")
                 )));
+        when(answerLifecycleService.complete(
+                1L,
+                "8월 20일에 배포합니다. [근거 1]",
+                sources
+        )).thenReturn(201L);
 
+        // When: 질문 생성 이벤트를 처리한다.
         handler.handle(new QaQuestionCreatedEvent(1L));
 
+        // Then: 스트림을 초기화하고 AI가 생성한 각 조각을 순서대로 SSE 서비스에 전달한다.
+        verify(answerStreamService).start(1L);
+        verify(answerStreamService).publishChunk(1L, "8월 20일에 ");
+        verify(answerStreamService).publishChunk(1L, "배포합니다. [근거 1]");
+
+        // 조각 전체를 결합한 최종 답변을 DB에 저장한 뒤 COMPLETED 이벤트를 발행한다.
         verify(answerLifecycleService).complete(1L, "8월 20일에 배포합니다. [근거 1]", sources);
+        verify(answerStreamService).publishCompleted(
+                1L,
+                201L,
+                "8월 20일에 배포합니다. [근거 1]"
+        );
         verify(answerLifecycleService, never()).fail(1L);
+        verify(answerStreamService, never()).publishFailed(1L);
     }
 
     @Test
     void marksQuestionAsFailedWhenGenerationFails() {
+        // Given: OpenAI 답변 스트림 처리 중 예외가 발생한다.
         QaQuestionCreatedEventHandler handler = createHandler();
         when(answerLifecycleService.tryStart(1L)).thenReturn(true);
         when(qaQuestionRepository.findByIdWithTeam(1L)).thenReturn(Optional.of(question));
@@ -75,24 +99,36 @@ class QaQuestionCreatedEventHandlerTest {
                         Flux.error(new RuntimeException("OpenAI failure"))
                 )));
 
+        // When: 질문 생성 이벤트를 처리한다.
         handler.handle(new QaQuestionCreatedEvent(1L));
 
+        // Then: 질문을 FAILED로 변경하고 SSE 구독자에게도 실패 이벤트를 보낸다.
+        verify(answerStreamService).start(1L);
         verify(answerLifecycleService).fail(1L);
+        verify(answerStreamService).publishFailed(1L);
         verify(answerLifecycleService, never()).complete(
                 org.mockito.ArgumentMatchers.anyLong(),
                 org.mockito.ArgumentMatchers.anyString(),
                 org.mockito.ArgumentMatchers.anyList()
         );
+        verify(answerStreamService, never()).publishCompleted(
+                org.mockito.ArgumentMatchers.anyLong(),
+                org.mockito.ArgumentMatchers.anyLong(),
+                org.mockito.ArgumentMatchers.anyString()
+        );
     }
 
     @Test
     void ignoresDuplicatedEventWhenGenerationCannotStart() {
+        // Given: 동일 질문의 AI 작업이 이미 실행 중이거나 완료되어 tryStart가 false를 반환한다.
         QaQuestionCreatedEventHandler handler = createHandler();
         when(answerLifecycleService.tryStart(1L)).thenReturn(false);
 
         handler.handle(new QaQuestionCreatedEvent(1L));
 
+        // Then: RAG 호출뿐 아니라 SSE 세션도 중복으로 시작하지 않는다.
         verifyNoInteractions(qaQuestionRepository, answerGenerator);
+        verifyNoInteractions(answerStreamService);
         verify(answerLifecycleService, never()).complete(
                 org.mockito.ArgumentMatchers.anyLong(),
                 org.mockito.ArgumentMatchers.anyString(),
@@ -105,7 +141,8 @@ class QaQuestionCreatedEventHandlerTest {
         return new QaQuestionCreatedEventHandler(
                 qaQuestionRepository,
                 answerLifecycleService,
-                answerGenerator
+                answerGenerator,
+                answerStreamService
         );
     }
 }

--- a/src/test/java/com/_penLearning/Noddi/domain/qa/service/QaAnswerStreamServiceTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/qa/service/QaAnswerStreamServiceTest.java
@@ -1,0 +1,177 @@
+package com._penLearning.Noddi.domain.qa.service;
+
+import com._penLearning.Noddi.domain.qa.entity.QaStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class QaAnswerStreamServiceTest {
+
+    /*
+     * 이 테스트는 Mock Repository를 사용하는 일반 서비스 단위 테스트와 달리,
+     * QaAnswerStreamService가 만든 SseEmitter를 간단한 테스트 컨트롤러에 연결한다.
+     *
+     * 이렇게 하면 DTO 메서드 호출 여부만 확인하는 대신 브라우저가 실제로 받게 될
+     * event: ... / data: ... 형식과 이벤트 순서까지 검증할 수 있다.
+     */
+
+    private QaAnswerStreamService service;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        service = new QaAnswerStreamService();
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new TestStreamController(service))
+                .build();
+    }
+
+    @Test
+    void sendsConnectedChunksAndCompletedEventInOrder() throws Exception {
+        // Given: AI 답변 생성이 시작된 질문을 사용자가 먼저 구독한다.
+        service.start(101L);
+        MvcResult subscription = openProcessingStream();
+
+        // When: AI가 두 조각을 생성하고 최종 답변을 DB에 저장했다고 알린다.
+        service.publishChunk(101L, "출시일은 ");
+        service.publishChunk(101L, "9월 5일입니다.");
+        service.publishCompleted(
+                101L,
+                201L,
+                "출시일은 9월 5일입니다."
+        );
+
+        // COMPLETED가 emitter를 닫은 후 비동기 결과를 최종 응답으로 가져온다.
+        mockMvc.perform(asyncDispatch(subscription))
+                .andExpect(status().isOk());
+
+        // MockHttpServletResponse의 기본 문자셋은 ISO-8859-1이므로
+        // 실제 JSON/SSE 응답 문자셋인 UTF-8로 명시해서 한글을 읽는다.
+        String body = subscription.getResponse()
+                .getContentAsString(StandardCharsets.UTF_8);
+
+        // Then: 연결, 두 조각, 완료 이벤트가 실제 SSE 형식으로 모두 전달된다.
+        assertThat(body)
+                .contains("event:connected")
+                .contains("event:chunk")
+                .contains("\"delta\":\"출시일은 \"")
+                .contains("\"delta\":\"9월 5일입니다.\"")
+                .contains("event:completed")
+                .contains("\"answerId\":201")
+                .contains("\"content\":\"출시일은 9월 5일입니다.\"");
+
+        // 이벤트가 발생한 순서도 connected -> chunk -> completed여야 한다.
+        assertThat(body.indexOf("event:connected"))
+                .isLessThan(body.indexOf("event:chunk"));
+        assertThat(body.lastIndexOf("event:chunk"))
+                .isLessThan(body.indexOf("event:completed"));
+    }
+
+    @Test
+    void sendsSnapshotBeforeNewChunksToLateSubscriber() throws Exception {
+        // Given: 구독자가 접속하기 전에 AI가 답변 일부를 이미 생성했다.
+        service.start(101L);
+        service.publishChunk(101L, "이미 생성된 답변");
+
+        // When: 사용자가 뒤늦게 구독한 뒤 새로운 조각과 완료 이벤트가 발생한다.
+        MvcResult subscription = openProcessingStream();
+        service.publishChunk(101L, " 뒤의 조각");
+        service.publishCompleted(
+                101L,
+                201L,
+                "이미 생성된 답변 뒤의 조각"
+        );
+
+        mockMvc.perform(asyncDispatch(subscription))
+                .andExpect(status().isOk());
+
+        String body = subscription.getResponse()
+                .getContentAsString(StandardCharsets.UTF_8);
+
+        // Then: 접속 전에 생성된 문자열은 snapshot 전체 내용으로 복구하고,
+        // 접속 후 새로 생성된 문자열부터 delta로 이어서 전달한다.
+        assertThat(body)
+                .contains("event:snapshot")
+                .contains("\"content\":\"이미 생성된 답변\"")
+                .contains("\"delta\":\" 뒤의 조각\"")
+                .contains("event:completed");
+
+        assertThat(body.indexOf("event:snapshot"))
+                .isLessThan(body.indexOf("event:chunk"));
+    }
+
+    @Test
+    void sendsFailedEventAndClosesStream() throws Exception {
+        // Given: 답변 생성 중인 질문을 사용자가 구독한다.
+        service.start(101L);
+        MvcResult subscription = openProcessingStream();
+
+        // When: AI 답변 생성이 실패한다.
+        service.publishFailed(101L);
+
+        mockMvc.perform(asyncDispatch(subscription))
+                .andExpect(status().isOk());
+
+        String body = subscription.getResponse()
+                .getContentAsString(StandardCharsets.UTF_8);
+
+        // Then: connected 이후 FAILED 상태를 담은 실패 이벤트가 전달되고 연결이 종료된다.
+        assertThat(body)
+                .contains("event:connected")
+                .contains("event:failed")
+                .contains("\"status\":\"FAILED\"");
+
+        assertThat(body.indexOf("event:connected"))
+                .isLessThan(body.indexOf("event:failed"));
+    }
+
+    private MvcResult openProcessingStream() throws Exception {
+        // SseEmitter는 응답을 즉시 끝내지 않으므로 asyncStarted 상태를 확인한다.
+        return mockMvc.perform(get("/test/qa/answer-stream")
+                        .accept(MediaType.TEXT_EVENT_STREAM))
+                .andExpect(status().isOk())
+                .andExpect(request().asyncStarted())
+                .andReturn();
+    }
+
+    /**
+     * QaAnswerStreamService의 SseEmitter를 MockMvc에 연결하기 위한 테스트 전용 컨트롤러다.
+     * 운영 코드의 QaController나 인증/권한 로직은 별도의 테스트에서 검증한다.
+     */
+    @RestController
+    private static class TestStreamController {
+
+        private final QaAnswerStreamService service;
+
+        private TestStreamController(QaAnswerStreamService service) {
+            this.service = service;
+        }
+
+        @GetMapping(
+                value = "/test/qa/answer-stream",
+                produces = MediaType.TEXT_EVENT_STREAM_VALUE
+        )
+        public SseEmitter subscribe() {
+            return service.subscribe(
+                    101L,
+                    QaStatus.PROCESSING,
+                    null,
+                    null
+            );
+        }
+    }
+}

--- a/src/test/java/com/_penLearning/Noddi/domain/qa/service/QaAnswerStreamSubscriptionServiceTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/qa/service/QaAnswerStreamSubscriptionServiceTest.java
@@ -1,0 +1,190 @@
+package com._penLearning.Noddi.domain.qa.service;
+
+import com._penLearning.Noddi.domain.project.entity.Project;
+import com._penLearning.Noddi.domain.project.repository.ProjectMemberRepository;
+import com._penLearning.Noddi.domain.qa.entity.QaAnswer;
+import com._penLearning.Noddi.domain.qa.entity.QaQuestion;
+import com._penLearning.Noddi.domain.qa.entity.QaStatus;
+import com._penLearning.Noddi.domain.qa.repository.QaAnswerRepository;
+import com._penLearning.Noddi.domain.qa.repository.QaQuestionRepository;
+import com._penLearning.Noddi.domain.team.entity.Team;
+import com._penLearning.Noddi.domain.user.entity.User;
+import com._penLearning.Noddi.domain.user.repository.UserRepository;
+import com._penLearning.Noddi.global.exception.GeneralException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class QaAnswerStreamSubscriptionServiceTest {
+
+    /*
+     * 이 테스트는 SSE의 실제 텍스트 전송보다 구독 직전의 DB 조회와 권한 판단을 검증한다.
+     *
+     * 1. 로그인 사용자와 질문을 조회한다.
+     * 2. 사용자가 질문 대상 팀과 같은 프로젝트의 멤버인지 확인한다.
+     * 3. 질문 상태에 따라 저장된 답변을 조회한다.
+     * 4. 스트림 서비스에 현재 상태를 정확하게 전달한다.
+     */
+
+    @Mock
+    private QaQuestionRepository qaQuestionRepository;
+
+    @Mock
+    private QaAnswerRepository qaAnswerRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ProjectMemberRepository projectMemberRepository;
+
+    @Mock
+    private QaAnswerStreamService qaAnswerStreamService;
+
+    @Mock
+    private User requester;
+
+    @Mock
+    private QaQuestion question;
+
+    @Mock
+    private Team targetTeam;
+
+    @Mock
+    private Project project;
+
+    private QaAnswerStreamSubscriptionService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new QaAnswerStreamSubscriptionService(
+                qaQuestionRepository,
+                qaAnswerRepository,
+                userRepository,
+                projectMemberRepository,
+                qaAnswerStreamService
+        );
+    }
+
+    @Test
+    void subscribesToProcessingQuestionWithoutStoredAnswer() {
+        // Given: 프로젝트 멤버가 아직 AI 답변을 생성 중인 질문을 구독한다.
+        allowProjectAccess();
+        when(question.getQuestionId()).thenReturn(101L);
+        when(question.getStatus()).thenReturn(QaStatus.PROCESSING);
+
+        SseEmitter expectedEmitter = mock(SseEmitter.class);
+        when(qaAnswerStreamService.subscribe(
+                101L,
+                QaStatus.PROCESSING,
+                null,
+                null
+        )).thenReturn(expectedEmitter);
+
+        // When: 답변 스트림 구독을 요청한다.
+        SseEmitter actualEmitter = service.subscribe(1L, 101L);
+
+        // Then: 생성 중에는 아직 DB에 QaAnswer가 없으므로 답변을 조회하지 않고
+        // answerId와 answerContent를 null로 전달해 실시간 연결만 생성한다.
+        assertThat(actualEmitter).isSameAs(expectedEmitter);
+        verify(qaAnswerStreamService).subscribe(
+                101L,
+                QaStatus.PROCESSING,
+                null,
+                null
+        );
+        verifyNoInteractions(qaAnswerRepository);
+    }
+
+    @Test
+    void returnsStoredAnswerWhenQuestionIsAlreadyAnswered() {
+        // Given: 프로젝트 멤버가 이미 답변 생성과 DB 저장이 끝난 질문을 구독한다.
+        allowProjectAccess();
+        when(question.getQuestionId()).thenReturn(101L);
+        when(question.getStatus()).thenReturn(QaStatus.ANSWERED);
+
+        QaAnswer answer = mock(QaAnswer.class);
+        when(qaAnswerRepository.findByQuestion(question)).thenReturn(Optional.of(answer));
+        when(answer.getAnswerId()).thenReturn(201L);
+        when(answer.getContent()).thenReturn("출시일은 9월 5일입니다.");
+
+        SseEmitter expectedEmitter = mock(SseEmitter.class);
+        when(qaAnswerStreamService.subscribe(
+                101L,
+                QaStatus.ANSWERED,
+                201L,
+                "출시일은 9월 5일입니다."
+        )).thenReturn(expectedEmitter);
+
+        // When: 완료된 질문의 스트림을 구독한다.
+        SseEmitter actualEmitter = service.subscribe(1L, 101L);
+
+        // Then: 메모리 스트림 유무와 관계없이 DB의 최종 답변을 COMPLETED 이벤트에
+        // 사용할 수 있도록 스트림 서비스에 함께 전달한다.
+        assertThat(actualEmitter).isSameAs(expectedEmitter);
+        verify(qaAnswerStreamService).subscribe(
+                101L,
+                QaStatus.ANSWERED,
+                201L,
+                "출시일은 9월 5일입니다."
+        );
+    }
+
+    @Test
+    void rejectsRequesterWhoIsNotProjectMember() {
+        // Given: 사용자와 질문은 존재하지만 사용자가 해당 프로젝트의 멤버가 아니다.
+        when(userRepository.findById(1L)).thenReturn(Optional.of(requester));
+        when(qaQuestionRepository.findByIdWithTeam(101L)).thenReturn(Optional.of(question));
+        when(question.getTargetTeam()).thenReturn(targetTeam);
+        when(targetTeam.getProject()).thenReturn(project);
+        when(projectMemberRepository.existsByProjectAndUser(project, requester))
+                .thenReturn(false);
+
+        // When & Then: 프로젝트 외부 사용자의 구독을 예외로 거절한다.
+        assertThatThrownBy(() -> service.subscribe(1L, 101L))
+                .isInstanceOf(GeneralException.class);
+
+        // 권한 검증에 실패하면 DB 답변 조회나 SSE 연결 생성까지 진행하지 않는다.
+        verifyNoInteractions(qaAnswerRepository, qaAnswerStreamService);
+    }
+
+    @Test
+    void rejectsMissingQuestionBeforeOpeningStream() {
+        // Given: 로그인 사용자는 존재하지만 요청한 질문 ID가 존재하지 않는다.
+        when(userRepository.findById(1L)).thenReturn(Optional.of(requester));
+        when(qaQuestionRepository.findByIdWithTeam(999L)).thenReturn(Optional.empty());
+
+        // When & Then: 존재하지 않는 질문의 SSE 연결을 만들지 않고 예외를 반환한다.
+        assertThatThrownBy(() -> service.subscribe(1L, 999L))
+                .isInstanceOf(GeneralException.class);
+
+        verifyNoInteractions(
+                projectMemberRepository,
+                qaAnswerRepository,
+                qaAnswerStreamService
+        );
+    }
+
+    private void allowProjectAccess() {
+        // 성공 테스트에서 반복되는 "요청자가 질문의 프로젝트 멤버인 상황"을 준비한다.
+        when(userRepository.findById(1L)).thenReturn(Optional.of(requester));
+        when(qaQuestionRepository.findByIdWithTeam(101L)).thenReturn(Optional.of(question));
+        when(question.getTargetTeam()).thenReturn(targetTeam);
+        when(targetTeam.getProject()).thenReturn(project);
+        when(projectMemberRepository.existsByProjectAndUser(project, requester))
+                .thenReturn(true);
+    }
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

## 🎋 작업 브랜치
- feature/45 -> develop
- #45  (관련이슈 번호)

## 💡 작업동기
- QA Feed에서 사용할 SSE 스트림을 구현했습니다

## 🔑 주요 변경사항
- AI 답변 실시간 SSE 스트리밍 API 구현
- 질문별 SSE 연결 및 다중 구독자 관리
- AI 답변 조각을 chunk 이벤트로 실시간 전달
- 늦은 접속 및 재연결을 위한 snapshot 제공
- 답변 DB 저장 후 completed 이벤트 전달
- AI 생성 실패 시 failed 이벤트 전달
- 프로젝트 멤버 구독 권한 검증
- 연결 종료·타임아웃 및 메모리 세션 정리
- SSE 서비스, 구독 서비스, 컨트롤러 및 이벤트 핸들러 테스트 추가

## 🏞 스크린샷 (선택)
> 스크린샷을 첨부해주세요.

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
