### PR TITLE
[fix] 팀 삭제 시 외래키 제약 조건 오류 해결

### DIFF
--- a/src/main/java/com/_penLearning/Noddi/domain/actionItem/repository/ActionItemRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/actionItem/repository/ActionItemRepository.java
@@ -1,7 +1,9 @@
 package com._penLearning.Noddi.domain.actionItem.repository;
 
 import com._penLearning.Noddi.domain.actionItem.entity.ActionItem;
+import com._penLearning.Noddi.domain.team.entity.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -44,4 +46,8 @@ public interface ActionItemRepository extends JpaRepository<ActionItem, Long> {
     List<ActionItem> findAllByAssigneeIdWithDetails(
             @Param("userId") Long userId
     );
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM ActionItem actionItem WHERE actionItem.meeting.team = :team")
+    void bulkDeleteByTeam(@Param("team") Team team);
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/repository/MeetingParticipantRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/repository/MeetingParticipantRepository.java
@@ -2,8 +2,12 @@ package com._penLearning.Noddi.domain.meeting.repository;
 
 import com._penLearning.Noddi.domain.meeting.entity.Meeting;
 import com._penLearning.Noddi.domain.meeting.entity.MeetingParticipant;
+import com._penLearning.Noddi.domain.team.entity.Team;
 import com._penLearning.Noddi.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,4 +17,8 @@ public interface MeetingParticipantRepository extends JpaRepository<MeetingParti
     Optional<MeetingParticipant> findByMeetingAndUser(Meeting meeting, User user);
     // 특정 회의의 전체 참가자 목록 조회
     List<MeetingParticipant> findAllByMeeting(Meeting meeting);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM MeetingParticipant participant WHERE participant.meeting.team = :team")
+    void bulkDeleteByTeam(@Param("team") Team team);
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/repository/MeetingRepository.java
@@ -27,6 +27,10 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
     List<Meeting> findAllByTeam(Team team);
     Optional<Meeting> findByRoomName(String roomName);
 
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM Meeting meeting WHERE meeting.team = :team")
+    void bulkDeleteByTeam(@Param("team") Team team);
+
     // Daily 웹훅 처리 중 동일 회의를 동시에 수정하지 못하도록 잠금을 건다.
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT m FROM Meeting m WHERE m.roomName = :roomName")

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/repository/QaAnswerRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/repository/QaAnswerRepository.java
@@ -2,8 +2,10 @@ package com._penLearning.Noddi.domain.qa.repository;
 
 import com._penLearning.Noddi.domain.qa.entity.QaAnswer;
 import com._penLearning.Noddi.domain.qa.entity.QaQuestion;
+import com._penLearning.Noddi.domain.team.entity.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -40,4 +42,8 @@ public interface QaAnswerRepository extends JpaRepository<QaAnswer, Long> {
     List<QaAnswer> findAllByQuestionsWithReviser(
             @Param("questions") Collection<QaQuestion> questions
     );
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM QaAnswer answer WHERE answer.question.targetTeam = :team")
+    void bulkDeleteByTeam(@Param("team") Team team);
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/repository/QaAnswerSourceRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/repository/QaAnswerSourceRepository.java
@@ -2,6 +2,7 @@ package com._penLearning.Noddi.domain.qa.repository;
 
 import com._penLearning.Noddi.domain.qa.entity.QaAnswer;
 import com._penLearning.Noddi.domain.qa.entity.QaAnswerSource;
+import com._penLearning.Noddi.domain.team.entity.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -29,4 +30,8 @@ public interface QaAnswerSourceRepository extends JpaRepository<QaAnswerSource, 
     List<QaAnswerSource> findAllByAnswersOrderByCitationIndex(
             @Param("answers") Collection<QaAnswer> answers
     );
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM QaAnswerSource source WHERE source.answer.question.targetTeam = :team")
+    void bulkDeleteByTeam(@Param("team") Team team);
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/repository/QaQuestionRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/repository/QaQuestionRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -83,4 +84,8 @@ public interface QaQuestionRepository extends JpaRepository<QaQuestion, Long> {
             @Param("cursor") Long cursor,
             Pageable pageable
     );
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM QaQuestion question WHERE question.targetTeam = :team")
+    void bulkDeleteByTeam(@Param("team") Team team);
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/summary/repository/MeetingSummaryRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/summary/repository/MeetingSummaryRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.domain.Pageable;
 
 import com._penLearning.Noddi.domain.meeting.code.AiStatus;
 import com._penLearning.Noddi.domain.qa.entity.SourceType;
+import com._penLearning.Noddi.domain.team.entity.Team;
+import org.springframework.data.jpa.repository.Modifying;
 
 import java.util.List;
 import java.util.Optional;
@@ -41,4 +43,8 @@ public interface MeetingSummaryRepository extends JpaRepository<MeetingSummary, 
             @Param("sourceType") SourceType sourceType,
             Pageable pageable
     );
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM MeetingSummary summary WHERE summary.meeting.team = :team")
+    void bulkDeleteByTeam(@Param("team") Team team);
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/team/service/TeamCommandService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/team/service/TeamCommandService.java
@@ -1,19 +1,16 @@
 package com._penLearning.Noddi.domain.team.service;
 
-import com._penLearning.Noddi.domain.announcement.repository.AnnouncementRepository;
 import com._penLearning.Noddi.domain.project.code.ProjectErrorCode;
 import com._penLearning.Noddi.domain.project.entity.Project;
 import com._penLearning.Noddi.domain.project.entity.ProjectMember;
 import com._penLearning.Noddi.domain.project.repository.ProjectMemberRepository;
 import com._penLearning.Noddi.domain.project.repository.ProjectRepository;
-import com._penLearning.Noddi.domain.qa.rag.indexing.KnowledgeDeletionService;
 import com._penLearning.Noddi.domain.team.code.TeamErrorCode;
 import com._penLearning.Noddi.domain.team.dto.TeamRequestDto;
 import com._penLearning.Noddi.domain.team.entity.*;
 import com._penLearning.Noddi.domain.team.repository.TeamInviteRepository;
 import com._penLearning.Noddi.domain.team.repository.TeamMemberRepository;
 import com._penLearning.Noddi.domain.team.repository.TeamRepository;
-import com._penLearning.Noddi.domain.teamPage.repository.TeamPageRepository;
 import com._penLearning.Noddi.domain.user.code.UserErrorCode;
 import com._penLearning.Noddi.domain.user.entity.User;
 import com._penLearning.Noddi.domain.user.repository.UserRepository;
@@ -34,9 +31,7 @@ public class TeamCommandService {
     private final ProjectMemberRepository projectMemberRepository;
     private final UserRepository userRepository;
     private final TeamInviteExpirationService teamInviteExpirationService;
-    private final TeamPageRepository teamPageRepository;
-    private final KnowledgeDeletionService knowledgeDeletionService;
-    private final AnnouncementRepository announcementRepository;
+    private final TeamResourceDeletionService teamResourceDeletionService;
 
     // 팀 생성 (생성자는 자동으로 LEADER 역할 부여)
     @Transactional
@@ -156,14 +151,8 @@ public class TeamCommandService {
 
         validateTeamLeader(team, requester);
 
-        // 팀 소유 자료가 외부 Vector DB에 남지 않도록 색인부터 정리한다.
-        knowledgeDeletionService.deleteTeamKnowledge(teamId);
-
-        // 하위 데이터 일괄 삭제 (FK 제약조건 방어)
-        announcementRepository.bulkDeleteByTeam(team);
-        teamPageRepository.bulkDeleteByTeam(team);
-        teamInviteRepository.deleteAllByTeam(team);
-        teamMemberRepository.deleteAllByTeam(team);
+        // 회의·Q&A를 포함한 팀 소유 데이터를 FK 의존 순서대로 일괄 삭제한다.
+        teamResourceDeletionService.deleteAllOwnedBy(team);
 
         // 팀 삭제
         teamRepository.delete(team);

--- a/src/main/java/com/_penLearning/Noddi/domain/team/service/TeamResourceDeletionService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/team/service/TeamResourceDeletionService.java
@@ -1,0 +1,62 @@
+package com._penLearning.Noddi.domain.team.service;
+
+import com._penLearning.Noddi.domain.actionItem.repository.ActionItemRepository;
+import com._penLearning.Noddi.domain.announcement.repository.AnnouncementRepository;
+import com._penLearning.Noddi.domain.meeting.repository.MeetingParticipantRepository;
+import com._penLearning.Noddi.domain.meeting.repository.MeetingRepository;
+import com._penLearning.Noddi.domain.qa.rag.indexing.KnowledgeDeletionService;
+import com._penLearning.Noddi.domain.qa.repository.QaAnswerRepository;
+import com._penLearning.Noddi.domain.qa.repository.QaAnswerSourceRepository;
+import com._penLearning.Noddi.domain.qa.repository.QaQuestionRepository;
+import com._penLearning.Noddi.domain.summary.repository.MeetingSummaryRepository;
+import com._penLearning.Noddi.domain.team.entity.Team;
+import com._penLearning.Noddi.domain.team.repository.TeamInviteRepository;
+import com._penLearning.Noddi.domain.team.repository.TeamMemberRepository;
+import com._penLearning.Noddi.domain.teamPage.repository.TeamPageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/** 팀 삭제 전에 팀을 참조하는 모든 하위 데이터를 FK 의존 순서대로 정리한다. */
+@Service
+@RequiredArgsConstructor
+public class TeamResourceDeletionService {
+
+    private final KnowledgeDeletionService knowledgeDeletionService;
+    private final QaAnswerSourceRepository qaAnswerSourceRepository;
+    private final QaAnswerRepository qaAnswerRepository;
+    private final QaQuestionRepository qaQuestionRepository;
+    private final ActionItemRepository actionItemRepository;
+    private final MeetingParticipantRepository meetingParticipantRepository;
+    private final MeetingSummaryRepository meetingSummaryRepository;
+    private final MeetingRepository meetingRepository;
+    private final AnnouncementRepository announcementRepository;
+    private final TeamPageRepository teamPageRepository;
+    private final TeamInviteRepository teamInviteRepository;
+    private final TeamMemberRepository teamMemberRepository;
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void deleteAllOwnedBy(Team team) {
+        Long teamId = team.getTeamId();
+
+        // Pinecone 벡터를 지우면서 팀을 참조하는 QaKnowledgeIndex도 함께 정리한다.
+        knowledgeDeletionService.deleteTeamKnowledge(teamId);
+
+        // 질문을 지우기 전에 답변의 출처와 답변부터 삭제해야 한다.
+        qaAnswerSourceRepository.bulkDeleteByTeam(team);
+        qaAnswerRepository.bulkDeleteByTeam(team);
+        qaQuestionRepository.bulkDeleteByTeam(team);
+
+        // 회의를 지우기 전에 회의를 참조하는 하위 데이터를 먼저 삭제해야 한다.
+        actionItemRepository.bulkDeleteByTeam(team);
+        meetingParticipantRepository.bulkDeleteByTeam(team);
+        meetingSummaryRepository.bulkDeleteByTeam(team);
+        meetingRepository.bulkDeleteByTeam(team);
+
+        announcementRepository.bulkDeleteByTeam(team);
+        teamPageRepository.bulkDeleteByTeam(team);
+        teamInviteRepository.deleteAllByTeam(team);
+        teamMemberRepository.deleteAllByTeam(team);
+    }
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

## 🎋 작업 브랜치
- `fix/#54-team-deletion` → `develop`
- #54

## 💡 작업동기
- 팀 삭제 시 회의록 등 팀과 연관된 데이터의 외래키 제약 조건으로 인해 삭제가 실패하는 문제를 해결했습니다.

## 🔑 주요 변경사항
- 팀 삭제 전 연관된 회의, 회의 요약, 참여자 및 액션 아이템 데이터를 순서대로 삭제하도록 수정했습니다.
- 팀에 등록된 Q&A 질문, 답변, 답변 출처 데이터를 함께 삭제하도록 처리했습니다.
- 팀과 연관된 RAG 지식 인덱스 및 Pinecone 데이터를 정리하도록 추가했습니다.
- 공지사항, 공유 페이지, 초대 및 팀원 데이터 등 팀의 하위 자원을 삭제한 후 팀을 삭제하도록 로직을 정리했습니다.
- 다량의 연관 데이터를 효율적으로 처리하도록 벌크 삭제 쿼리를 적용했습니다.

## 🏞 스크린샷 (선택)
> 스크린샷을 첨부해주세요.

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
