### PR TITLE
[fix] 프로젝트 삭제 시 하위 데이터 외래키 제약 조건 오류 해결

### DIFF
--- a/src/main/java/com/_penLearning/Noddi/domain/actionItem/repository/ActionItemRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/actionItem/repository/ActionItemRepository.java
@@ -1,6 +1,7 @@
 package com._penLearning.Noddi.domain.actionItem.repository;
 
 import com._penLearning.Noddi.domain.actionItem.entity.ActionItem;
+import com._penLearning.Noddi.domain.project.entity.Project;
 import com._penLearning.Noddi.domain.team.entity.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -50,4 +51,8 @@ public interface ActionItemRepository extends JpaRepository<ActionItem, Long> {
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE FROM ActionItem actionItem WHERE actionItem.meeting.team = :team")
     void bulkDeleteByTeam(@Param("team") Team team);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM ActionItem actionItem WHERE actionItem.meeting.team.project = :project")
+    void bulkDeleteByProject(@Param("project") Project project);
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/repository/MeetingParticipantRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/repository/MeetingParticipantRepository.java
@@ -2,6 +2,7 @@ package com._penLearning.Noddi.domain.meeting.repository;
 
 import com._penLearning.Noddi.domain.meeting.entity.Meeting;
 import com._penLearning.Noddi.domain.meeting.entity.MeetingParticipant;
+import com._penLearning.Noddi.domain.project.entity.Project;
 import com._penLearning.Noddi.domain.team.entity.Team;
 import com._penLearning.Noddi.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -21,4 +22,8 @@ public interface MeetingParticipantRepository extends JpaRepository<MeetingParti
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE FROM MeetingParticipant participant WHERE participant.meeting.team = :team")
     void bulkDeleteByTeam(@Param("team") Team team);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM MeetingParticipant participant WHERE participant.meeting.team.project = :project")
+    void bulkDeleteByProject(@Param("project") Project project);
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/repository/MeetingRepository.java
@@ -2,6 +2,7 @@ package com._penLearning.Noddi.domain.meeting.repository;
 
 import com._penLearning.Noddi.domain.meeting.code.AiStatus;
 import com._penLearning.Noddi.domain.meeting.entity.Meeting;
+import com._penLearning.Noddi.domain.project.entity.Project;
 import com._penLearning.Noddi.domain.team.entity.Team;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -30,6 +31,10 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE FROM Meeting meeting WHERE meeting.team = :team")
     void bulkDeleteByTeam(@Param("team") Team team);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM Meeting meeting WHERE meeting.team.project = :project")
+    void bulkDeleteByProject(@Param("project") Project project);
 
     // Daily 웹훅 처리 중 동일 회의를 동시에 수정하지 못하도록 잠금을 건다.
     @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/src/main/java/com/_penLearning/Noddi/domain/project/service/ProjectResourceDeletionService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/service/ProjectResourceDeletionService.java
@@ -1,0 +1,72 @@
+package com._penLearning.Noddi.domain.project.service;
+
+import com._penLearning.Noddi.domain.actionItem.repository.ActionItemRepository;
+import com._penLearning.Noddi.domain.announcement.repository.AnnouncementRepository;
+import com._penLearning.Noddi.domain.meeting.repository.MeetingParticipantRepository;
+import com._penLearning.Noddi.domain.meeting.repository.MeetingRepository;
+import com._penLearning.Noddi.domain.project.entity.Project;
+import com._penLearning.Noddi.domain.project.repository.ProjectInviteRepository;
+import com._penLearning.Noddi.domain.project.repository.ProjectMemberRepository;
+import com._penLearning.Noddi.domain.qa.rag.indexing.KnowledgeDeletionService;
+import com._penLearning.Noddi.domain.qa.repository.QaAnswerRepository;
+import com._penLearning.Noddi.domain.qa.repository.QaAnswerSourceRepository;
+import com._penLearning.Noddi.domain.qa.repository.QaQuestionRepository;
+import com._penLearning.Noddi.domain.summary.repository.MeetingSummaryRepository;
+import com._penLearning.Noddi.domain.team.repository.TeamInviteRepository;
+import com._penLearning.Noddi.domain.team.repository.TeamMemberRepository;
+import com._penLearning.Noddi.domain.team.repository.TeamRepository;
+import com._penLearning.Noddi.domain.teamPage.repository.TeamPageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/** 프로젝트 삭제 전에 프로젝트가 소유한 모든 하위 데이터를 FK 의존 순서대로 정리한다. */
+@Service
+@RequiredArgsConstructor
+public class ProjectResourceDeletionService {
+
+    private final KnowledgeDeletionService knowledgeDeletionService;
+    private final QaAnswerSourceRepository qaAnswerSourceRepository;
+    private final QaAnswerRepository qaAnswerRepository;
+    private final QaQuestionRepository qaQuestionRepository;
+    private final ActionItemRepository actionItemRepository;
+    private final MeetingParticipantRepository meetingParticipantRepository;
+    private final MeetingSummaryRepository meetingSummaryRepository;
+    private final MeetingRepository meetingRepository;
+    private final AnnouncementRepository announcementRepository;
+    private final TeamPageRepository teamPageRepository;
+    private final TeamInviteRepository teamInviteRepository;
+    private final TeamMemberRepository teamMemberRepository;
+    private final TeamRepository teamRepository;
+    private final ProjectInviteRepository projectInviteRepository;
+    private final ProjectMemberRepository projectMemberRepository;
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void deleteAllOwnedBy(Project project) {
+        // Pinecone 벡터와 MySQL의 QaKnowledgeIndex를 팀 삭제 전에 함께 정리한다.
+        knowledgeDeletionService.deleteProjectKnowledge(project.getProjectId());
+
+        // Q&A 질문을 참조하는 답변 출처와 답변부터 삭제한다.
+        qaAnswerSourceRepository.bulkDeleteByProject(project);
+        qaAnswerRepository.bulkDeleteByProject(project);
+        qaQuestionRepository.bulkDeleteByProject(project);
+
+        // 회의를 참조하는 하위 데이터를 먼저 삭제한 뒤 회의를 삭제한다.
+        actionItemRepository.bulkDeleteByProject(project);
+        meetingParticipantRepository.bulkDeleteByProject(project);
+        meetingSummaryRepository.bulkDeleteByProject(project);
+        meetingRepository.bulkDeleteByProject(project);
+
+        // 팀 소유 자료와 팀 관계 데이터를 지운 뒤 팀 자체를 삭제한다.
+        announcementRepository.bulkDeleteByProject(project);
+        teamPageRepository.bulkDeleteByProject(project);
+        teamInviteRepository.bulkDeleteByProject(project);
+        teamMemberRepository.bulkDeleteByProject(project);
+        teamRepository.bulkDeleteByProject(project);
+
+        // 마지막으로 프로젝트를 직접 참조하는 초대와 멤버 관계를 정리한다.
+        projectInviteRepository.deleteBulkByProject(project);
+        projectMemberRepository.bulkDeleteByProject(project);
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/project/service/ProjectService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/service/ProjectService.java
@@ -1,20 +1,13 @@
 package com._penLearning.Noddi.domain.project.service;
 
-import com._penLearning.Noddi.domain.announcement.repository.AnnouncementRepository;
 import com._penLearning.Noddi.domain.project.code.ProjectErrorCode;
 import com._penLearning.Noddi.domain.project.dto.ProjectRequestDto;
 import com._penLearning.Noddi.domain.project.dto.ProjectResponseDto;
 import com._penLearning.Noddi.domain.project.entity.Project;
 import com._penLearning.Noddi.domain.project.entity.ProjectMember;
 import com._penLearning.Noddi.domain.project.entity.ProjectRole;
-import com._penLearning.Noddi.domain.project.repository.ProjectInviteRepository;
 import com._penLearning.Noddi.domain.project.repository.ProjectMemberRepository;
 import com._penLearning.Noddi.domain.project.repository.ProjectRepository;
-import com._penLearning.Noddi.domain.qa.rag.indexing.KnowledgeDeletionService;
-import com._penLearning.Noddi.domain.team.repository.TeamInviteRepository;
-import com._penLearning.Noddi.domain.team.repository.TeamMemberRepository;
-import com._penLearning.Noddi.domain.team.repository.TeamRepository;
-import com._penLearning.Noddi.domain.teamPage.repository.TeamPageRepository;
 import com._penLearning.Noddi.domain.user.code.UserErrorCode;
 import com._penLearning.Noddi.domain.user.entity.User;
 import com._penLearning.Noddi.domain.user.repository.UserRepository;
@@ -33,14 +26,8 @@ public class ProjectService {
 
     private final ProjectRepository projectRepository;
     private final ProjectMemberRepository projectMemberRepository;
-    private final ProjectInviteRepository projectInviteRepository;
     private final UserRepository userRepository;
-    private final TeamRepository teamRepository;
-    private final TeamInviteRepository teamInviteRepository;
-    private final TeamMemberRepository teamMemberRepository;
-    private final TeamPageRepository teamPageRepository;
-    private final KnowledgeDeletionService knowledgeDeletionService;
-    private final AnnouncementRepository announcementRepository;
+    private final ProjectResourceDeletionService projectResourceDeletionService;
 
     // 프로젝트 생성
     @Transactional
@@ -101,17 +88,8 @@ public class ProjectService {
         // 1. 요청자가 해당 프로젝트의 LEADER인지 검증
         validateProjectLeader(project, requesterId);
 
-        // 프로젝트 하위 팀 자료가 외부 Vector DB에 남지 않도록 색인부터 정리한다.
-        knowledgeDeletionService.deleteProjectKnowledge(projectId);
-
-        // FK 제약조건을 고려해 팀의 하위 데이터부터 삭제한다.
-        announcementRepository.bulkDeleteByProject(project);
-        teamPageRepository.bulkDeleteByProject(project);
-        teamInviteRepository.bulkDeleteByProject(project);
-        teamMemberRepository.bulkDeleteByProject(project);
-        teamRepository.bulkDeleteByProject(project);
-        projectInviteRepository.deleteBulkByProject(project);
-        projectMemberRepository.bulkDeleteByProject(project);
+        // 회의·Q&A를 포함한 프로젝트 소유 데이터를 FK 의존 순서대로 일괄 삭제한다.
+        projectResourceDeletionService.deleteAllOwnedBy(project);
 
         // 3. 프로젝트 삭제
         projectRepository.delete(project);

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/repository/QaAnswerRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/repository/QaAnswerRepository.java
@@ -2,6 +2,7 @@ package com._penLearning.Noddi.domain.qa.repository;
 
 import com._penLearning.Noddi.domain.qa.entity.QaAnswer;
 import com._penLearning.Noddi.domain.qa.entity.QaQuestion;
+import com._penLearning.Noddi.domain.project.entity.Project;
 import com._penLearning.Noddi.domain.team.entity.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
@@ -46,4 +47,8 @@ public interface QaAnswerRepository extends JpaRepository<QaAnswer, Long> {
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE FROM QaAnswer answer WHERE answer.question.targetTeam = :team")
     void bulkDeleteByTeam(@Param("team") Team team);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM QaAnswer answer WHERE answer.question.targetTeam.project = :project")
+    void bulkDeleteByProject(@Param("project") Project project);
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/repository/QaAnswerSourceRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/repository/QaAnswerSourceRepository.java
@@ -2,6 +2,7 @@ package com._penLearning.Noddi.domain.qa.repository;
 
 import com._penLearning.Noddi.domain.qa.entity.QaAnswer;
 import com._penLearning.Noddi.domain.qa.entity.QaAnswerSource;
+import com._penLearning.Noddi.domain.project.entity.Project;
 import com._penLearning.Noddi.domain.team.entity.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -34,4 +35,8 @@ public interface QaAnswerSourceRepository extends JpaRepository<QaAnswerSource, 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE FROM QaAnswerSource source WHERE source.answer.question.targetTeam = :team")
     void bulkDeleteByTeam(@Param("team") Team team);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM QaAnswerSource source WHERE source.answer.question.targetTeam.project = :project")
+    void bulkDeleteByProject(@Param("project") Project project);
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/repository/QaQuestionRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/repository/QaQuestionRepository.java
@@ -2,6 +2,7 @@ package com._penLearning.Noddi.domain.qa.repository;
 
 import com._penLearning.Noddi.domain.qa.entity.QaQuestion;
 import com._penLearning.Noddi.domain.qa.entity.QaStatus;
+import com._penLearning.Noddi.domain.project.entity.Project;
 import com._penLearning.Noddi.domain.team.entity.Team;
 import com._penLearning.Noddi.domain.user.entity.User;
 import jakarta.persistence.LockModeType;
@@ -88,4 +89,8 @@ public interface QaQuestionRepository extends JpaRepository<QaQuestion, Long> {
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE FROM QaQuestion question WHERE question.targetTeam = :team")
     void bulkDeleteByTeam(@Param("team") Team team);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM QaQuestion question WHERE question.targetTeam.project = :project")
+    void bulkDeleteByProject(@Param("project") Project project);
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/summary/repository/MeetingSummaryRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/summary/repository/MeetingSummaryRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.data.domain.Pageable;
 
 import com._penLearning.Noddi.domain.meeting.code.AiStatus;
+import com._penLearning.Noddi.domain.project.entity.Project;
 import com._penLearning.Noddi.domain.qa.entity.SourceType;
 import com._penLearning.Noddi.domain.team.entity.Team;
 import org.springframework.data.jpa.repository.Modifying;
@@ -47,4 +48,8 @@ public interface MeetingSummaryRepository extends JpaRepository<MeetingSummary, 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE FROM MeetingSummary summary WHERE summary.meeting.team = :team")
     void bulkDeleteByTeam(@Param("team") Team team);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM MeetingSummary summary WHERE summary.meeting.team.project = :project")
+    void bulkDeleteByProject(@Param("project") Project project);
 }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

## 🎋 작업 브랜치
- `fix/#56-project-deletion` → `develop`
- #56

## 💡 작업동기
- 프로젝트 삭제 시 팀에 연결된 회의록, Q&A 등의 하위 데이터가 남아 있어 외래키 제약 조건으로 삭제가 실패하는 문제를 해결했습니다.

## 🔑 주요 변경사항
- 프로젝트 하위 데이터를 FK 의존 순서대로 삭제하는 `ProjectResourceDeletionService`를 추가했습니다.
- Q&A 답변 출처, 답변, 질문에 프로젝트 단위 벌크 삭제를 적용했습니다.
- 액션 아이템, 회의 참여자, 회의 요약 및 회의에 프로젝트 단위 벌크 삭제를 적용했습니다.
- 공지사항, 공유페이지, 팀 초대, 팀원 및 팀 데이터를 삭제한 후 프로젝트를 삭제하도록 순서를 정리했습니다.
- 프로젝트 삭제 시 Pinecone 벡터와 지식 인덱스도 함께 정리하도록 처리했습니다.

## 🏞 스크린샷 (선택)
> 스크린샷을 첨부해주세요.

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
