### PR TITLE
[Feat] 출처 조회 권한 및 수정 이력 보존 기능 구현

### DIFF
--- a/src/main/java/com/_penLearning/Noddi/domain/project/service/ProjectResourceDeletionService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/project/service/ProjectResourceDeletionService.java
@@ -9,6 +9,7 @@ import com._penLearning.Noddi.domain.project.repository.ProjectInviteRepository;
 import com._penLearning.Noddi.domain.project.repository.ProjectMemberRepository;
 import com._penLearning.Noddi.domain.qa.rag.indexing.KnowledgeDeletionService;
 import com._penLearning.Noddi.domain.qa.repository.QaAnswerRepository;
+import com._penLearning.Noddi.domain.qa.repository.QaAnswerRevisionRepository;
 import com._penLearning.Noddi.domain.qa.repository.QaAnswerSourceRepository;
 import com._penLearning.Noddi.domain.qa.repository.QaQuestionRepository;
 import com._penLearning.Noddi.domain.summary.repository.MeetingSummaryRepository;
@@ -29,6 +30,7 @@ public class ProjectResourceDeletionService {
     private final KnowledgeDeletionService knowledgeDeletionService;
     private final QaAnswerSourceRepository qaAnswerSourceRepository;
     private final QaAnswerRepository qaAnswerRepository;
+    private final QaAnswerRevisionRepository qaAnswerRevisionRepository;
     private final QaQuestionRepository qaQuestionRepository;
     private final ActionItemRepository actionItemRepository;
     private final MeetingParticipantRepository meetingParticipantRepository;
@@ -49,6 +51,7 @@ public class ProjectResourceDeletionService {
 
         // Q&A 질문을 참조하는 답변 출처와 답변부터 삭제한다.
         qaAnswerSourceRepository.bulkDeleteByProject(project);
+        qaAnswerRevisionRepository.bulkDeleteByProject(project);
         qaAnswerRepository.bulkDeleteByProject(project);
         qaQuestionRepository.bulkDeleteByProject(project);
 

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/code/QaApi.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/code/QaApi.java
@@ -73,7 +73,25 @@ public interface QaApi {
                 - failed: 답변 생성 실패
                 """
     )
-    SseEmitter subscribeAnswerStream(@Parameter(description = "질문 ID") @PathVariable Long questionId,
+    SseEmitter subscribeAnswerStream(@Parameter(description = "질문 ID")
+                                     @PathVariable Long questionId,
                                      @Parameter(hidden = true) AuthMember authMember);
-
+    @Operation(
+            summary = "AI 답변 수정 이력 조회",
+            description = """
+                특정 답변의 AI 최초 원문과 담당자 수정본을 조회합니다.
+                수정 이력은 versionNumber 오름차순으로 반환됩니다.
+                
+                같은 프로젝트의 구성원은 모든 버전의 답변 내용,
+                수정자, 생성 시간을 조회할 수 있습니다.
+                
+                AI 최초 답변의 회의록 및 팀 페이지 출처는
+                질문 대상 팀 구성원에게만 제공됩니다.
+                """
+    )
+    ApiResponse<QaResponseDto.AnswerRevisionHistory> getAnswerRevisions(
+            @Parameter(description = "답변 ID")
+            @PathVariable Long answerId,
+            @Parameter(hidden = true) AuthMember authMember
+    );
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/code/QaErrorCode.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/code/QaErrorCode.java
@@ -11,6 +11,7 @@ public enum QaErrorCode implements BaseErrorCode {
 
     INVALID_AI_ANSWER_CITATION(HttpStatus.INTERNAL_SERVER_ERROR, "QA500_2", "AI 답변에서 유효한 근거를 확인할 수 없습니다."),
     AI_ANSWER_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "QA500_1", "AI 답변을 생성하지 못했습니다."),
+    REVISION_HISTORY_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "QA500_3", "답변 수정 이력을 찾을 수 없습니다."),
 
     INVALID_FEED_SIZE(HttpStatus.BAD_REQUEST, "QA400_1", "피드 조회 크기는 1 이상 50 이하여야 합니다."),
     INVALID_FEED_CURSOR(HttpStatus.BAD_REQUEST, "QA400_2", "피드 커서는 1 이상이어야 합니다."),

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/controller/QaController.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/controller/QaController.java
@@ -4,10 +4,7 @@ import com._penLearning.Noddi.domain.auth.entity.AuthMember;
 import com._penLearning.Noddi.domain.qa.code.QaApi;
 import com._penLearning.Noddi.domain.qa.dto.QaRequestDto;
 import com._penLearning.Noddi.domain.qa.dto.QaResponseDto;
-import com._penLearning.Noddi.domain.qa.service.QaAnswerStreamSubscriptionService;
-import com._penLearning.Noddi.domain.qa.service.QaQuestionCommandService;
-import com._penLearning.Noddi.domain.qa.service.QaAnswerUpdateService;
-import com._penLearning.Noddi.domain.qa.service.QaQuestionQueryService;
+import com._penLearning.Noddi.domain.qa.service.*;
 import com._penLearning.Noddi.global.apiPayload.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +23,9 @@ public class QaController implements QaApi {
     private final QaQuestionCommandService qaQuestionCommandService;
     private final QaQuestionQueryService qaQuestionQueryService;
     private final QaAnswerUpdateService qaAnswerUpdateService;
+    private final QaAnswerRevisionQueryService qaAnswerRevisionQueryService;
     private final QaAnswerStreamSubscriptionService qaAnswerStreamSubscriptionService;
+
 
     // 질문 등록
     @Override
@@ -100,6 +99,24 @@ public class QaController implements QaApi {
                 request
         );
         return ApiResponse.onSuccess("AI 답변이 성공적으로 수정되었습니다.", response);
+    }
+
+    /**
+     * 특정 답변의 AI 최초 원문과 담당자 수정본을
+     * versionNumber 오름차순으로 조회한다.
+     */
+    @Override
+    @GetMapping("/qa/answers/{answerId}/revisions")
+    public ApiResponse<QaResponseDto.AnswerRevisionHistory> getAnswerRevisions(
+            @PathVariable Long answerId,
+            @AuthenticationPrincipal AuthMember authMember
+    ) {
+        QaResponseDto.AnswerRevisionHistory response = qaAnswerRevisionQueryService.getAnswerRevisions(
+                        authMember.getUserId(),
+                        answerId
+                );
+
+        return ApiResponse.onSuccess("답변 수정 이력 조회에 성공했습니다.", response);
     }
 
     /**

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/dto/QaResponseDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/dto/QaResponseDto.java
@@ -153,17 +153,26 @@ public class QaResponseDto {
         private Long teamId;
         private String teamName;
 
+        /*
+         * 현재 사용자가 이 팀의 구성원인지 나타낸다.
+         *
+         * true인 경우에만 AI 답변의 회의록·팀 페이지 출처를 제공한다.
+         * 프론트는 이 값과 sources를 기준으로 참고 자료 버튼을 표시한다.
+         */
+        private boolean canViewSources;
+
         private List<FeedItem> items;
 
         private Long nextCursor;
         private boolean hasNext;
 
-        public static Feed of(Team team, List<FeedItem> items, Long nextCursor, boolean hasNext) {
+        public static Feed of(Team team, List<FeedItem> items, Long nextCursor, boolean hasNext, boolean canViewSources) {
             return Feed.builder()
                     .projectId(team.getProject().getProjectId())
                     .projectName(team.getProject().getName())
                     .teamId(team.getTeamId())
                     .teamName(team.getName())
+                    .canViewSources(canViewSources)
                     .items(items)
                     .nextCursor(nextCursor)
                     .hasNext(hasNext)

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/dto/QaResponseDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/dto/QaResponseDto.java
@@ -6,6 +6,8 @@ import com._penLearning.Noddi.domain.qa.entity.QaAnswerSource;
 import com._penLearning.Noddi.domain.qa.entity.QaQuestion;
 import com._penLearning.Noddi.domain.qa.entity.QaStatus;
 import com._penLearning.Noddi.domain.qa.entity.SourceType;
+import com._penLearning.Noddi.domain.qa.entity.QaAnswerRevision;
+import com._penLearning.Noddi.domain.qa.entity.RevisionEditorType;
 import com._penLearning.Noddi.domain.team.entity.Team;
 import lombok.Builder;
 import lombok.Getter;
@@ -253,6 +255,125 @@ public class QaResponseDto {
                     .createdAt(answer.getCreatedAt())
                     .updatedAt(answer.getUpdatedAt())
                     .sources(sources.stream().map(AnswerSourceInfo::from).toList())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class AnswerRevisionHistory {
+
+        private Long answerId;
+
+        // 프론트가 "2/3"의 전체 개수를 표시할 때 사용한다.
+        private int totalVersions;
+
+        /*
+         * 현재 사용자가 AI 최초 답변의 출처를 볼 수 있는지 나타낸다.
+         *
+         * 질문 대상 팀 구성원만 true이고,
+         * 같은 프로젝트의 다른 팀 구성원에게는 false를 반환한다.
+         */
+        private boolean canViewSources;
+
+        // versionNumber 오름차순으로 반환한다.
+        private List<AnswerRevisionItem> revisions;
+
+        public static AnswerRevisionHistory of(
+                QaAnswer answer,
+                List<QaAnswerRevision> revisions,
+                List<QaAnswerSource> initialSources,
+                boolean canViewSources
+        ) {
+            List<AnswerRevisionItem> revisionItems = revisions.stream()
+                    .map(revision -> {
+                        /*
+                         * 출처는 AI 최초 답변인 version 1에만 연결한다.
+                         *
+                         * 담당자 수정본은 기존 AI 출처가 수정 내용을
+                         * 뒷받침한다고 보장할 수 없으므로 빈 목록을 반환한다.
+                         */
+                        boolean shouldExposeSources = canViewSources && revision.getVersionNumber() == 1;
+
+                        List<QaAnswerSource> visibleSources =
+                                shouldExposeSources
+                                        ? initialSources
+                                        : List.of();
+
+                        return AnswerRevisionItem.of(
+                                revision,
+                                visibleSources
+                        );
+                    })
+                    .toList();
+
+            return AnswerRevisionHistory.builder()
+                    .answerId(answer.getAnswerId())
+                    .totalVersions(revisionItems.size())
+                    .canViewSources(canViewSources)
+                    .revisions(revisionItems)
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class AnswerRevisionItem {
+
+        private int versionNumber;
+        private String content;
+
+        // AI 최초 답변인지, 담당자 수정본인지 구분한다.
+        private RevisionEditorType editorType;
+
+        /*
+         * AI는 User 엔티티가 아니므로:
+         * editorId   → null
+         * editorName → "AI"
+         *
+         * HUMAN은 실제 수정자 정보를 반환한다.
+         */
+        private Long editorId;
+        private String editorName;
+
+        /*
+         * 해당 버전이 생성된 시간이다.
+         *
+         * version 1에서는 AI 답변 생성 시간,
+         * version 2 이상에서는 담당자 수정 시간이 된다.
+         */
+        private LocalDateTime createdAt;
+
+        // 대상 팀원이 조회한 AI 최초 버전에만 값이 들어간다.
+        private List<AnswerSourceInfo> sources;
+
+        public static AnswerRevisionItem of(
+                QaAnswerRevision revision,
+                List<QaAnswerSource> sources
+        ) {
+            boolean editedByHuman =
+                    revision.getEditorType() == RevisionEditorType.HUMAN;
+
+            return AnswerRevisionItem.builder()
+                    .versionNumber(revision.getVersionNumber())
+                    .content(revision.getContent())
+                    .editorType(revision.getEditorType())
+                    .editorId(
+                            editedByHuman
+                                    ? revision.getRevisedBy().getUserId()
+                                    : null
+                    )
+                    .editorName(
+                            editedByHuman
+                                    ? revision.getRevisedBy().getName()
+                                    : "AI"
+                    )
+                    .createdAt(revision.getCreatedAt())
+                    .sources(
+                            sources.stream()
+                                    .map(AnswerSourceInfo::from)
+                                    .toList()
+                    )
                     .build();
         }
     }

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/entity/QaAnswerRevision.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/entity/QaAnswerRevision.java
@@ -1,0 +1,107 @@
+package com._penLearning.Noddi.domain.qa.entity;
+
+import com._penLearning.Noddi.domain.user.entity.User;
+import com._penLearning.Noddi.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 하나의 답변이 변경된 버전 이력을 저장한다.
+ *
+ * QaAnswer에는 피드에서 보여줄 최신 답변을 저장하고,
+ * QaAnswerRevision에는 AI 원문부터 모든 수정본을 누적 저장한다.
+ *
+ * 수정 이력은 생성된 이후 내용을 변경하지 않는 불변 데이터로 사용한다.
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "QaAnswerRevision",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_qa_answer_revision_version",
+                columnNames = {"answerId", "versionNumber"}
+        )
+)
+public class QaAnswerRevision extends BaseEntity {
+
+    private static final int AI_INITIAL_VERSION = 1;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long revisionId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "answerId", nullable = false)
+    private QaAnswer answer;
+
+    @Column(nullable = false)
+    private int versionNumber;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private RevisionEditorType editorType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "revisedById")
+    private User revisedBy;
+
+    //빌더패턴 적용하지 않음 - 필드 설정을 보장해주지 않기때문
+    private QaAnswerRevision(
+            QaAnswer answer,
+            int versionNumber,
+            String content,
+            RevisionEditorType editorType,
+            User revisedBy
+    ) {
+        this.answer = answer;
+        this.versionNumber = versionNumber;
+        this.content = content;
+        this.editorType = editorType;
+        this.revisedBy = revisedBy;
+    }
+
+    /**
+     * AI가 생성한 최초 답변을 버전 1로 만든다.
+     *
+     * AI는 User 엔티티가 아니므로 revisedBy를 null로 저장한다.
+     * 조회 DTO에서 editorType이 AI이면 수정자 이름을 "AI"로 변환한다.
+     */
+    public static QaAnswerRevision createAiInitial(
+            QaAnswer answer
+    ) {
+        return new QaAnswerRevision(
+                answer,
+                AI_INITIAL_VERSION,
+                answer.getContent(),
+                RevisionEditorType.AI,
+                null
+        );
+    }
+
+    /**
+     * 대상 팀 담당자가 수정한 버전을 만든다.
+     *
+     * versionNumber는 서비스에서 현재 마지막 버전을 조회한 뒤
+     * 1을 더해서 전달한다.
+     */
+    public static QaAnswerRevision createHumanRevision(
+            QaAnswer answer,
+            int versionNumber,
+            String content,
+            User reviser
+    ) {
+        return new QaAnswerRevision(
+                answer,
+                versionNumber,
+                content,
+                RevisionEditorType.HUMAN,
+                reviser
+        );
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/entity/RevisionEditorType.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/entity/RevisionEditorType.java
@@ -1,0 +1,7 @@
+package com._penLearning.Noddi.domain.qa.entity;
+
+public enum RevisionEditorType {
+
+    AI,
+    HUMAN
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/repository/QaAnswerRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/repository/QaAnswerRepository.java
@@ -51,4 +51,22 @@ public interface QaAnswerRepository extends JpaRepository<QaAnswer, Long> {
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE FROM QaAnswer answer WHERE answer.question.targetTeam.project = :project")
     void bulkDeleteByProject(@Param("project") Project project);
+
+    /**
+     * 수정 이력 조회에 필요한 답변, 질문, 대상 팀, 프로젝트를 함께 조회한다.
+     *
+     * 서비스에서 프로젝트 구성원 권한을 검사할 때
+     * 연관 엔티티가 각각 추가 조회되는 것을 방지한다.
+     */
+    @Query("""
+        SELECT answer
+        FROM QaAnswer answer
+        JOIN FETCH answer.question question
+        JOIN FETCH question.targetTeam targetTeam
+        JOIN FETCH targetTeam.project
+        WHERE answer.answerId = :answerId
+        """)
+    Optional<QaAnswer> findByIdWithQuestionTeamAndProject(
+            @Param("answerId") Long answerId
+    );
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/repository/QaAnswerRevisionRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/repository/QaAnswerRevisionRepository.java
@@ -1,8 +1,11 @@
 package com._penLearning.Noddi.domain.qa.repository;
 
+import com._penLearning.Noddi.domain.project.entity.Project;
 import com._penLearning.Noddi.domain.qa.entity.QaAnswer;
 import com._penLearning.Noddi.domain.qa.entity.QaAnswerRevision;
+import com._penLearning.Noddi.domain.team.entity.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -47,4 +50,24 @@ public interface QaAnswerRevisionRepository
     List<QaAnswerRevision> findAllByAnswerWithReviserOrderByVersionNumberAsc(
             @Param("answer") QaAnswer answer
     );
+
+    /**
+     * 팀 삭제 전에 해당 팀 질문의 모든 답변 수정 이력을 삭제한다.
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        DELETE FROM QaAnswerRevision revision
+        WHERE revision.answer.question.targetTeam = :team
+        """)
+    void bulkDeleteByTeam(@Param("team") Team team);
+
+    /**
+     * 프로젝트 삭제 전에 해당 프로젝트의 모든 답변 수정 이력을 삭제한다.
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        DELETE FROM QaAnswerRevision revision
+        WHERE revision.answer.question.targetTeam.project = :project
+        """)
+    void bulkDeleteByProject(@Param("project") Project project);
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/repository/QaAnswerRevisionRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/repository/QaAnswerRevisionRepository.java
@@ -1,0 +1,50 @@
+package com._penLearning.Noddi.domain.qa.repository;
+
+import com._penLearning.Noddi.domain.qa.entity.QaAnswer;
+import com._penLearning.Noddi.domain.qa.entity.QaAnswerRevision;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface QaAnswerRevisionRepository
+        extends JpaRepository<QaAnswerRevision, Long> {
+
+    /**
+     * AI 최초 답변의 버전 1이 이미 저장됐는지 확인한다.
+     *
+     * 질문 생성 이벤트가 중복 처리되더라도 최초 버전이
+     * 중복으로 생성되지 않게 방어하는 용도로 사용한다.
+     */
+    boolean existsByAnswer(QaAnswer answer);
+
+    /**
+     * 마지막 버전을 조회한다.
+     *
+     * 담당자 수정 시 마지막 버전 번호에 1을 더해
+     * 다음 버전 번호를 계산한다.
+     */
+    Optional<QaAnswerRevision> findTopByAnswerOrderByVersionNumberDesc(QaAnswer answer);
+
+    /**
+     * 답변의 모든 버전을 오래된 순서로 조회한다.
+     *
+     * HUMAN 버전에서 수정자 이름을 응답해야 하므로
+     * revisedBy를 LEFT JOIN FETCH로 함께 조회한다.
+     *
+     * AI 버전은 revisedBy가 null이기 때문에 일반 JOIN이 아닌
+     * LEFT JOIN을 사용해야 조회 결과에서 제외되지 않는다.
+     */
+    @Query("""
+            SELECT revision
+            FROM QaAnswerRevision revision
+            LEFT JOIN FETCH revision.revisedBy
+            WHERE revision.answer = :answer
+            ORDER BY revision.versionNumber ASC
+            """)
+    List<QaAnswerRevision> findAllByAnswerWithReviserOrderByVersionNumberAsc(
+            @Param("answer") QaAnswer answer
+    );
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaAiAnswerLifecycleService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaAiAnswerLifecycleService.java
@@ -1,7 +1,11 @@
 package com._penLearning.Noddi.domain.qa.service;
 
 import com._penLearning.Noddi.domain.qa.code.QaErrorCode;
-import com._penLearning.Noddi.domain.qa.entity.*;
+import com._penLearning.Noddi.domain.qa.entity.QaAnswer;
+import com._penLearning.Noddi.domain.qa.entity.QaAnswerRevision;
+import com._penLearning.Noddi.domain.qa.entity.QaAnswerSource;
+import com._penLearning.Noddi.domain.qa.entity.QaQuestion;
+import com._penLearning.Noddi.domain.qa.entity.QaStatus;
 import com._penLearning.Noddi.domain.qa.rag.generation.QaRagAnswerGenerator;
 import com._penLearning.Noddi.domain.qa.rag.retrieval.RetrievedKnowledge;
 import com._penLearning.Noddi.domain.qa.repository.QaAnswerRepository;

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaAiAnswerLifecycleService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaAiAnswerLifecycleService.java
@@ -1,13 +1,11 @@
 package com._penLearning.Noddi.domain.qa.service;
 
 import com._penLearning.Noddi.domain.qa.code.QaErrorCode;
-import com._penLearning.Noddi.domain.qa.entity.QaAnswer;
-import com._penLearning.Noddi.domain.qa.entity.QaAnswerSource;
-import com._penLearning.Noddi.domain.qa.entity.QaQuestion;
-import com._penLearning.Noddi.domain.qa.entity.QaStatus;
+import com._penLearning.Noddi.domain.qa.entity.*;
 import com._penLearning.Noddi.domain.qa.rag.generation.QaRagAnswerGenerator;
 import com._penLearning.Noddi.domain.qa.rag.retrieval.RetrievedKnowledge;
 import com._penLearning.Noddi.domain.qa.repository.QaAnswerRepository;
+import com._penLearning.Noddi.domain.qa.repository.QaAnswerRevisionRepository;
 import com._penLearning.Noddi.domain.qa.repository.QaAnswerSourceRepository;
 import com._penLearning.Noddi.domain.qa.repository.QaQuestionRepository;
 import com._penLearning.Noddi.global.exception.GeneralException;
@@ -37,6 +35,10 @@ public class QaAiAnswerLifecycleService {
     private final QaQuestionRepository qaQuestionRepository;
     private final QaAnswerRepository qaAnswerRepository;
     private final QaAnswerSourceRepository qaAnswerSourceRepository;
+    private final QaQuestionRepository qaQuestionRepository;
+    private final QaAnswerRepository qaAnswerRepository;
+    private final QaAnswerSourceRepository qaAnswerSourceRepository;
+    private final QaAnswerRevisionRepository qaAnswerRevisionRepository;
 
     @Value("${qa.ai.max-generation-attempts:3}")
     private int maxGenerationAttempts = 3;
@@ -74,6 +76,10 @@ public class QaAiAnswerLifecycleService {
 
         // AI가 생성한 최초 답변을 저장한다. 이후 담당자 수정 시 현재 내용으로 교체될 수 있다.
         QaAnswer answer = qaAnswerRepository.save(QaAnswer.createAiAnswer(question, content));
+
+        QaAnswerRevision initialRevision = QaAnswerRevision.createAiInitial(answer);
+        qaAnswerRevisionRepository.save(initialRevision);
+
         List<QaAnswerSource> answerSources = citedSourceIndexes.stream()
                 .map(citationIndex -> {
                     RetrievedKnowledge source = sources.get(citationIndex - 1);

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaAiAnswerLifecycleService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaAiAnswerLifecycleService.java
@@ -35,9 +35,6 @@ public class QaAiAnswerLifecycleService {
     private final QaQuestionRepository qaQuestionRepository;
     private final QaAnswerRepository qaAnswerRepository;
     private final QaAnswerSourceRepository qaAnswerSourceRepository;
-    private final QaQuestionRepository qaQuestionRepository;
-    private final QaAnswerRepository qaAnswerRepository;
-    private final QaAnswerSourceRepository qaAnswerSourceRepository;
     private final QaAnswerRevisionRepository qaAnswerRevisionRepository;
 
     @Value("${qa.ai.max-generation-attempts:3}")

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaAnswerRevisionQueryService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaAnswerRevisionQueryService.java
@@ -1,0 +1,85 @@
+package com._penLearning.Noddi.domain.qa.service;
+
+import com._penLearning.Noddi.domain.project.repository.ProjectMemberRepository;
+import com._penLearning.Noddi.domain.qa.code.QaErrorCode;
+import com._penLearning.Noddi.domain.qa.dto.QaResponseDto;
+import com._penLearning.Noddi.domain.qa.entity.QaAnswer;
+import com._penLearning.Noddi.domain.qa.entity.QaAnswerRevision;
+import com._penLearning.Noddi.domain.qa.entity.QaAnswerSource;
+import com._penLearning.Noddi.domain.qa.entity.QaQuestion;
+import com._penLearning.Noddi.domain.qa.repository.QaAnswerRepository;
+import com._penLearning.Noddi.domain.qa.repository.QaAnswerRevisionRepository;
+import com._penLearning.Noddi.domain.qa.repository.QaAnswerSourceRepository;
+import com._penLearning.Noddi.domain.team.entity.Team;
+import com._penLearning.Noddi.domain.team.repository.TeamMemberRepository;
+import com._penLearning.Noddi.domain.user.code.UserErrorCode;
+import com._penLearning.Noddi.domain.user.entity.User;
+import com._penLearning.Noddi.domain.user.repository.UserRepository;
+import com._penLearning.Noddi.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 특정 답변의 전체 수정 이력을 조회한다.
+ *
+ * 같은 프로젝트 구성원은 수정 이력의 내용은 모두 볼 수 있지만,
+ * AI 답변의 출처는 질문 대상 팀 구성원에게만 제공한다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class QaAnswerRevisionQueryService {
+
+
+    private final QaAnswerRepository qaAnswerRepository;
+    private final QaAnswerRevisionRepository qaAnswerRevisionRepository;
+    private final QaAnswerSourceRepository qaAnswerSourceRepository;
+
+    private final UserRepository userRepository;
+    private final ProjectMemberRepository projectMemberRepository;
+    private final TeamMemberRepository teamMemberRepository;
+
+    public QaResponseDto.AnswerRevisionHistory getAnswerRevisions(Long requesterId, Long answerId) {
+
+        QaAnswer answer = qaAnswerRepository.findByIdWithQuestionAndTeamForUpdate(answerId)
+                .orElseThrow(() -> new GeneralException(QaErrorCode.ANSWER_NOT_FOUND));
+
+        User requester = userRepository.findById(requesterId)
+                .orElseThrow(() -> new GeneralException(UserErrorCode.USER_NOT_FOUND));
+
+        QaQuestion question = answer.getQuestion();
+        Team targetTeam = question.getTargetTeam();
+
+        boolean isProjectMember = projectMemberRepository.existsByProjectAndUser(targetTeam.getProject(), requester);
+
+        if (!isProjectMember) {
+            throw new GeneralException(QaErrorCode.NOT_PROJECT_MEMBER);
+        }
+        boolean canViewSources = teamMemberRepository.existsByTeamAndUser(targetTeam, requester);
+
+        /*
+         * Repository 쿼리에서 versionNumber 오름차순으로 조회하므로
+         * 결과는 v1, v2, v3 순서다.
+         *
+         * HUMAN 버전의 revisedBy도 fetch join으로 함께 조회된다.
+         */
+        List<QaAnswerRevision> revisions = qaAnswerRevisionRepository.findAllByAnswerWithReviserOrderByVersionNumberAsc(answer);
+
+        if(revisions.isEmpty()){
+            throw new GeneralException(QaErrorCode.REVISION_HISTORY_NOT_FOUND);
+        }
+
+        List<QaAnswerSource> initialSources = canViewSources
+                ? qaAnswerSourceRepository.findByAnswer_AnswerIdOrderByCitationIndexAsc(answer.getAnswerId())
+                : List.of();
+
+        return QaResponseDto.AnswerRevisionHistory.of(
+                answer,
+                revisions,
+                initialSources,
+                canViewSources);
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaAnswerRevisionQueryService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaAnswerRevisionQueryService.java
@@ -44,7 +44,7 @@ public class QaAnswerRevisionQueryService {
 
     public QaResponseDto.AnswerRevisionHistory getAnswerRevisions(Long requesterId, Long answerId) {
 
-        QaAnswer answer = qaAnswerRepository.findByIdWithQuestionAndTeamForUpdate(answerId)
+        QaAnswer answer = qaAnswerRepository.findByIdWithQuestionTeamAndProject(answerId)
                 .orElseThrow(() -> new GeneralException(QaErrorCode.ANSWER_NOT_FOUND));
 
         User requester = userRepository.findById(requesterId)

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaAnswerUpdateService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaAnswerUpdateService.java
@@ -4,8 +4,9 @@ import com._penLearning.Noddi.domain.qa.code.QaErrorCode;
 import com._penLearning.Noddi.domain.qa.dto.QaRequestDto;
 import com._penLearning.Noddi.domain.qa.dto.QaResponseDto;
 import com._penLearning.Noddi.domain.qa.entity.QaAnswer;
+import com._penLearning.Noddi.domain.qa.entity.QaAnswerRevision;
 import com._penLearning.Noddi.domain.qa.repository.QaAnswerRepository;
-import com._penLearning.Noddi.domain.qa.repository.QaAnswerSourceRepository;
+import com._penLearning.Noddi.domain.qa.repository.QaAnswerRevisionRepository;
 import com._penLearning.Noddi.domain.team.repository.TeamMemberRepository;
 import com._penLearning.Noddi.domain.user.code.UserErrorCode;
 import com._penLearning.Noddi.domain.user.entity.User;
@@ -17,13 +18,14 @@ import org.springframework.transaction.annotation.Transactional;
 
 
 // 대상 팀 구성원이 AI 답변을 수정한다.
-// 수정 전 원문은 별도로 보관하지 않고 현재 답변과 마지막 수정자만 갱신한다.
+// QaAnswer에는 최신 답변을 반영하고,
+// QaAnswerRevision에는 AI 원문부터 모든 수정본을 누적 보관한다.
 @Service
 @RequiredArgsConstructor
 public class QaAnswerUpdateService {
 
     private final QaAnswerRepository qaAnswerRepository;
-    private final QaAnswerSourceRepository qaAnswerSourceRepository;
+    private final QaAnswerRevisionRepository qaAnswerRevisionRepository;
     private final UserRepository userRepository;
     private final TeamMemberRepository teamMemberRepository;
 
@@ -43,9 +45,21 @@ public class QaAnswerUpdateService {
             throw new GeneralException(QaErrorCode.NOT_TARGET_TEAM_MEMBER);
         }
 
+        QaAnswerRevision lastRevision = qaAnswerRevisionRepository.findTopByAnswerOrderByVersionNumberDesc(answer)
+                .orElseThrow(() -> new GeneralException(QaErrorCode.REVISION_HISTORY_NOT_FOUND));
+
+        int nextVersionNumber = lastRevision.getVersionNumber() + 1;
+
+        QaAnswerRevision newRevision = QaAnswerRevision.createHumanRevision(
+                answer,
+                nextVersionNumber,
+                request.getContent(),
+                reviser
+        );
+
+        qaAnswerRevisionRepository.save(newRevision);
+
         answer.revise(request.getContent(), reviser);
-        // 수정본은 AI 원문과 별개의 최종 답변이므로 기존 AI 인용 출처를 더 이상 노출하지 않는다.
-        qaAnswerSourceRepository.deleteAllByAnswerId(answer.getAnswerId());
         return QaResponseDto.ReviseAnswer.from(answer);
     }
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaQuestionQueryService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaQuestionQueryService.java
@@ -11,6 +11,7 @@ import com._penLearning.Noddi.domain.qa.repository.QaAnswerSourceRepository;
 import com._penLearning.Noddi.domain.qa.repository.QaQuestionRepository;
 import com._penLearning.Noddi.domain.team.code.TeamErrorCode;
 import com._penLearning.Noddi.domain.team.entity.Team;
+import com._penLearning.Noddi.domain.team.repository.TeamMemberRepository;
 import com._penLearning.Noddi.domain.team.repository.TeamRepository;
 import com._penLearning.Noddi.domain.user.code.UserErrorCode;
 import com._penLearning.Noddi.domain.user.entity.User;
@@ -45,6 +46,7 @@ public class QaQuestionQueryService {
     private final UserRepository userRepository;
     private final TeamRepository teamRepository;
     private final ProjectMemberRepository projectMemberRepository;
+    private final TeamMemberRepository teamMemberRepository;
 
     // 내가 작성한 질문 목록 조회
     public Page<QaResponseDto.QuestionInfo> getMyQuestions(Long userId, Pageable pageable) {
@@ -59,7 +61,7 @@ public class QaQuestionQueryService {
     public Page<QaResponseDto.QuestionInfo> getTeamQuestions(Long requesterId, Long teamId, Pageable pageable) {
         Team targetTeam = getTeamOrThrow(teamId);
 
-        validateProjectMembership(requesterId, targetTeam);
+        getProjectMemberOrThrow(requesterId, targetTeam);
 
         return qaQuestionRepository.findAllByTargetTeamWithUser(targetTeam, pageable)
                 .map(QaResponseDto.QuestionInfo::from);
@@ -70,7 +72,9 @@ public class QaQuestionQueryService {
 
         Team targetTeam = getTeamOrThrow(teamId);
 
-        validateProjectMembership(requesterId, targetTeam);
+        User requester = getProjectMemberOrThrow(requesterId, targetTeam);
+
+        boolean canViewSources = teamMemberRepository.existsByTeamAndUser(targetTeam, requester);
 
         List<QaQuestion> fetchedQuestions = qaQuestionRepository.findFeedByTargetTeam(
                 targetTeam, cursor, PageRequest.of(0, size + 1));
@@ -91,7 +95,27 @@ public class QaQuestionQueryService {
                         Function.identity()
                 ));
 
-        List<QaAnswerSource> sources = findSources(answers);
+        /*
+         * 출처는 다음 두 조건을 모두 만족할 때만 제공한다.
+         *
+         * 1. 요청자가 답변 대상 팀의 구성원이다.
+         * 2. 현재 답변이 담당자 수정본이 아닌 AI 최초 답변이다.
+         *
+         * 담당자가 수정한 내용은 기존 AI 근거가 수정본 전체를 뒷받침한다고
+         * 보장할 수 없으므로 피드에서는 출처를 표시하지 않는다.
+         */
+        List<QaAnswer> sourceVisibleAnswers = canViewSources
+                ? answers.stream()
+                .filter(answer -> !answer.isRevised())
+                .toList()
+                : List.of();
+
+        /*
+         * 권한이 없으면 빈 목록을 전달해 Repository 호출 자체를 생략한다.
+         * referenceId와 excerpt가 DB에서 불필요하게 조회되는 것도 방지한다.
+         */
+        List<QaAnswerSource> sources =
+                findSources(sourceVisibleAnswers);
 
         Map<Long, List<QaAnswerSource>> sourceByAnswerId = sources.stream()
                 .collect(Collectors.groupingBy(
@@ -111,7 +135,12 @@ public class QaQuestionQueryService {
 
         Collections.reverse(items);
 
-        return QaResponseDto.Feed.of(targetTeam, items, nextCursor, hasNext);
+        return QaResponseDto.Feed.of(
+                targetTeam,
+                items,
+                nextCursor,
+                hasNext,
+                canViewSources);
 
     }
 
@@ -120,12 +149,20 @@ public class QaQuestionQueryService {
         QaQuestion question = qaQuestionRepository.findByIdWithTeam(questionId)
                 .orElseThrow(() -> new GeneralException(QaErrorCode.QUESTION_NOT_FOUND));
 
-        validateProjectMembership(requesterId, question.getTargetTeam());
+        User requester = getProjectMemberOrThrow(requesterId, question.getTargetTeam());
 
         QaAnswer answer = qaAnswerRepository.findByQuestion(question).orElse(null);
-        List<QaAnswerSource> sources = answer == null
-                ? List.of()
-                : qaAnswerSourceRepository.findByAnswer_AnswerIdOrderByCitationIndexAsc(answer.getAnswerId());
+
+        boolean canViewSources = teamMemberRepository.existsByTeamAndUser(question.getTargetTeam(), requester);
+
+        boolean shouldLoadSources =
+                answer != null
+                        && canViewSources
+                        && !answer.isRevised();
+
+        List<QaAnswerSource> sources = shouldLoadSources
+                ? qaAnswerSourceRepository.findByAnswer_AnswerIdOrderByCitationIndexAsc(answer.getAnswerId())
+                : List.of();
         return QaResponseDto.QuestionDetail.of(question, answer, sources);
     }
 
@@ -135,13 +172,15 @@ public class QaQuestionQueryService {
     }
 
     // 공통 프로젝트 권한 검증 로직
-    private void validateProjectMembership(Long requesterId, Team targetTeam) {
+    private User getProjectMemberOrThrow(Long requesterId, Team targetTeam) {
         User requester = userRepository.findById(requesterId)
                 .orElseThrow(() -> new GeneralException(UserErrorCode.USER_NOT_FOUND));
 
         if (!projectMemberRepository.existsByProjectAndUser(targetTeam.getProject(), requester)) {
             throw new GeneralException(QaErrorCode.NOT_PROJECT_MEMBER);
         }
+
+        return requester;
     }
 
     private void validateFeedRequest(Long cursor, int size) {

--- a/src/main/java/com/_penLearning/Noddi/domain/team/service/TeamResourceDeletionService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/team/service/TeamResourceDeletionService.java
@@ -6,6 +6,7 @@ import com._penLearning.Noddi.domain.meeting.repository.MeetingParticipantReposi
 import com._penLearning.Noddi.domain.meeting.repository.MeetingRepository;
 import com._penLearning.Noddi.domain.qa.rag.indexing.KnowledgeDeletionService;
 import com._penLearning.Noddi.domain.qa.repository.QaAnswerRepository;
+import com._penLearning.Noddi.domain.qa.repository.QaAnswerRevisionRepository;
 import com._penLearning.Noddi.domain.qa.repository.QaAnswerSourceRepository;
 import com._penLearning.Noddi.domain.qa.repository.QaQuestionRepository;
 import com._penLearning.Noddi.domain.summary.repository.MeetingSummaryRepository;
@@ -25,6 +26,7 @@ public class TeamResourceDeletionService {
 
     private final KnowledgeDeletionService knowledgeDeletionService;
     private final QaAnswerSourceRepository qaAnswerSourceRepository;
+    private final QaAnswerRevisionRepository qaAnswerRevisionRepository;
     private final QaAnswerRepository qaAnswerRepository;
     private final QaQuestionRepository qaQuestionRepository;
     private final ActionItemRepository actionItemRepository;
@@ -45,6 +47,7 @@ public class TeamResourceDeletionService {
 
         // 질문을 지우기 전에 답변의 출처와 답변부터 삭제해야 한다.
         qaAnswerSourceRepository.bulkDeleteByTeam(team);
+        qaAnswerRevisionRepository.bulkDeleteByTeam(team);
         qaAnswerRepository.bulkDeleteByTeam(team);
         qaQuestionRepository.bulkDeleteByTeam(team);
 

--- a/src/test/java/com/_penLearning/Noddi/domain/project/service/ProjectResourceDeletionServiceTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/project/service/ProjectResourceDeletionServiceTest.java
@@ -1,0 +1,93 @@
+package com._penLearning.Noddi.domain.project.service;
+
+import com._penLearning.Noddi.domain.actionItem.repository.ActionItemRepository;
+import com._penLearning.Noddi.domain.announcement.repository.AnnouncementRepository;
+import com._penLearning.Noddi.domain.meeting.repository.MeetingParticipantRepository;
+import com._penLearning.Noddi.domain.meeting.repository.MeetingRepository;
+import com._penLearning.Noddi.domain.project.entity.Project;
+import com._penLearning.Noddi.domain.project.repository.ProjectInviteRepository;
+import com._penLearning.Noddi.domain.project.repository.ProjectMemberRepository;
+import com._penLearning.Noddi.domain.qa.rag.indexing.KnowledgeDeletionService;
+import com._penLearning.Noddi.domain.qa.repository.QaAnswerRepository;
+import com._penLearning.Noddi.domain.qa.repository.QaAnswerRevisionRepository;
+import com._penLearning.Noddi.domain.qa.repository.QaAnswerSourceRepository;
+import com._penLearning.Noddi.domain.qa.repository.QaQuestionRepository;
+import com._penLearning.Noddi.domain.summary.repository.MeetingSummaryRepository;
+import com._penLearning.Noddi.domain.team.repository.TeamInviteRepository;
+import com._penLearning.Noddi.domain.team.repository.TeamMemberRepository;
+import com._penLearning.Noddi.domain.team.repository.TeamRepository;
+import com._penLearning.Noddi.domain.teamPage.repository.TeamPageRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectResourceDeletionServiceTest {
+
+    @Mock private KnowledgeDeletionService knowledgeDeletionService;
+    @Mock private QaAnswerSourceRepository answerSourceRepository;
+    @Mock private QaAnswerRepository answerRepository;
+    @Mock private QaAnswerRevisionRepository answerRevisionRepository;
+    @Mock private QaQuestionRepository questionRepository;
+    @Mock private ActionItemRepository actionItemRepository;
+    @Mock private MeetingParticipantRepository meetingParticipantRepository;
+    @Mock private MeetingSummaryRepository meetingSummaryRepository;
+    @Mock private MeetingRepository meetingRepository;
+    @Mock private AnnouncementRepository announcementRepository;
+    @Mock private TeamPageRepository teamPageRepository;
+    @Mock private TeamInviteRepository teamInviteRepository;
+    @Mock private TeamMemberRepository teamMemberRepository;
+    @Mock private TeamRepository teamRepository;
+    @Mock private ProjectInviteRepository projectInviteRepository;
+    @Mock private ProjectMemberRepository projectMemberRepository;
+    @Mock private Project project;
+
+    @Test
+    void deletesQaResourcesInForeignKeyDependencyOrder() {
+        ProjectResourceDeletionService service = new ProjectResourceDeletionService(
+                knowledgeDeletionService,
+                answerSourceRepository,
+                answerRepository,
+                answerRevisionRepository,
+                questionRepository,
+                actionItemRepository,
+                meetingParticipantRepository,
+                meetingSummaryRepository,
+                meetingRepository,
+                announcementRepository,
+                teamPageRepository,
+                teamInviteRepository,
+                teamMemberRepository,
+                teamRepository,
+                projectInviteRepository,
+                projectMemberRepository
+        );
+
+        // Given: 수정 이력이 포함된 프로젝트 전체를 삭제하는 상황이다.
+        when(project.getProjectId()).thenReturn(100L);
+
+        // When: 프로젝트가 소유한 모든 하위 데이터를 정리한다.
+        service.deleteAllOwnedBy(project);
+
+        /*
+         * Then: 프로젝트 삭제에서도 Source와 Revision을 Answer보다 먼저 삭제하고,
+         * 마지막에 Question을 삭제하는 FK 의존 순서를 반드시 지켜야 한다.
+         */
+        InOrder qaDeletionOrder = inOrder(
+                answerSourceRepository,
+                answerRevisionRepository,
+                answerRepository,
+                questionRepository
+        );
+
+        qaDeletionOrder.verify(answerSourceRepository).bulkDeleteByProject(project);
+        qaDeletionOrder.verify(answerRevisionRepository).bulkDeleteByProject(project);
+        qaDeletionOrder.verify(answerRepository).bulkDeleteByProject(project);
+        qaDeletionOrder.verify(questionRepository).bulkDeleteByProject(project);
+    }
+}

--- a/src/test/java/com/_penLearning/Noddi/domain/qa/controller/QaControllerTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/qa/controller/QaControllerTest.java
@@ -4,7 +4,9 @@ import com._penLearning.Noddi.domain.auth.entity.AuthMember;
 import com._penLearning.Noddi.domain.qa.dto.QaResponseDto;
 import com._penLearning.Noddi.domain.qa.entity.AnswerType;
 import com._penLearning.Noddi.domain.qa.entity.QaStatus;
+import com._penLearning.Noddi.domain.qa.entity.RevisionEditorType;
 import com._penLearning.Noddi.domain.qa.entity.SourceType;
+import com._penLearning.Noddi.domain.qa.service.QaAnswerRevisionQueryService;
 import com._penLearning.Noddi.domain.qa.service.QaAnswerStreamSubscriptionService;
 import com._penLearning.Noddi.domain.qa.service.QaAnswerUpdateService;
 import com._penLearning.Noddi.domain.qa.service.QaQuestionCommandService;
@@ -55,6 +57,9 @@ class QaControllerTest {
     private QaAnswerUpdateService qaAnswerUpdateService;
 
     @Mock
+    private QaAnswerRevisionQueryService qaAnswerRevisionQueryService;
+
+    @Mock
     private QaAnswerStreamSubscriptionService qaAnswerStreamSubscriptionService;
 
     private MockMvc mockMvc;
@@ -65,6 +70,7 @@ class QaControllerTest {
                 qaQuestionCommandService,
                 qaQuestionQueryService,
                 qaAnswerUpdateService,
+                qaAnswerRevisionQueryService,
                 qaAnswerStreamSubscriptionService
         );
 
@@ -156,6 +162,75 @@ class QaControllerTest {
 
         // Then: 문자열 query parameter가 Long과 int로 변환되어 서비스에 정확히 전달된다.
         verify(qaQuestionQueryService).getTeamFeed(1L, 10L, 81L, 10);
+    }
+
+    @Test
+    void returnsAnswerRevisionHistoryForAuthenticatedProjectMember() throws Exception {
+        // Given: 수정 이력 조회 서비스가 AI 최초 답변과 담당자 수정본을 반환한다.
+        LocalDateTime aiCreatedAt = LocalDateTime.of(2026, 8, 17, 10, 0);
+        LocalDateTime revisedAt = LocalDateTime.of(2026, 8, 17, 11, 0);
+
+        QaResponseDto.AnswerSourceInfo source = QaResponseDto.AnswerSourceInfo.builder()
+                .citationIndex(1)
+                .sourceType(SourceType.TRANSCRIPT)
+                .referenceId(301L)
+                .sourceTitle("8월 기획 회의")
+                .excerpt("출시일은 9월 5일입니다.")
+                .build();
+
+        QaResponseDto.AnswerRevisionItem version1 =
+                QaResponseDto.AnswerRevisionItem.builder()
+                        .versionNumber(1)
+                        .content("AI 최초 답변")
+                        .editorType(RevisionEditorType.AI)
+                        .editorId(null)
+                        .editorName("AI")
+                        .createdAt(aiCreatedAt)
+                        .sources(List.of(source))
+                        .build();
+
+        QaResponseDto.AnswerRevisionItem version2 =
+                QaResponseDto.AnswerRevisionItem.builder()
+                        .versionNumber(2)
+                        .content("담당자가 수정한 최종 답변")
+                        .editorType(RevisionEditorType.HUMAN)
+                        .editorId(20L)
+                        .editorName("홍길동")
+                        .createdAt(revisedAt)
+                        .sources(List.of())
+                        .build();
+
+        QaResponseDto.AnswerRevisionHistory response =
+                QaResponseDto.AnswerRevisionHistory.builder()
+                        .answerId(201L)
+                        .totalVersions(2)
+                        .canViewSources(true)
+                        .revisions(List.of(version1, version2))
+                        .build();
+
+        when(qaAnswerRevisionQueryService.getAnswerRevisions(1L, 201L))
+                .thenReturn(response);
+
+        // When & Then: URL의 answerId와 인증 사용자의 ID가 서비스에 전달되고,
+        // 프론트가 화살표 UI에 사용할 전체 버전 배열이 공통 응답 형식으로 반환된다.
+        mockMvc.perform(get("/api/v1/qa/answers/{answerId}/revisions", 201L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.message").value("답변 수정 이력 조회에 성공했습니다."))
+                .andExpect(jsonPath("$.result.answerId").value(201L))
+                .andExpect(jsonPath("$.result.totalVersions").value(2))
+                .andExpect(jsonPath("$.result.canViewSources").value(true))
+                .andExpect(jsonPath("$.result.revisions[0].versionNumber").value(1))
+                .andExpect(jsonPath("$.result.revisions[0].editorType").value("AI"))
+                .andExpect(jsonPath("$.result.revisions[0].editorName").value("AI"))
+                .andExpect(jsonPath("$.result.revisions[0].sources[0].referenceId").value(301L))
+                .andExpect(jsonPath("$.result.revisions[1].versionNumber").value(2))
+                .andExpect(jsonPath("$.result.revisions[1].editorType").value("HUMAN"))
+                .andExpect(jsonPath("$.result.revisions[1].editorId").value(20L))
+                .andExpect(jsonPath("$.result.revisions[1].editorName").value("홍길동"))
+                .andExpect(jsonPath("$.result.revisions[1].sources").isEmpty());
+
+        verify(qaAnswerRevisionQueryService).getAnswerRevisions(1L, 201L);
     }
 
     @Test

--- a/src/test/java/com/_penLearning/Noddi/domain/qa/service/QaAiAnswerLifecycleServiceTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/qa/service/QaAiAnswerLifecycleServiceTest.java
@@ -1,12 +1,14 @@
 package com._penLearning.Noddi.domain.qa.service;
 
 import com._penLearning.Noddi.domain.qa.entity.QaAnswer;
+import com._penLearning.Noddi.domain.qa.entity.QaAnswerRevision;
 import com._penLearning.Noddi.domain.qa.entity.QaAnswerSource;
 import com._penLearning.Noddi.domain.qa.entity.QaQuestion;
 import com._penLearning.Noddi.domain.qa.entity.QaStatus;
 import com._penLearning.Noddi.domain.qa.entity.SourceType;
 import com._penLearning.Noddi.domain.qa.rag.retrieval.RetrievedKnowledge;
 import com._penLearning.Noddi.domain.qa.repository.QaAnswerRepository;
+import com._penLearning.Noddi.domain.qa.repository.QaAnswerRevisionRepository;
 import com._penLearning.Noddi.domain.qa.repository.QaAnswerSourceRepository;
 import com._penLearning.Noddi.domain.qa.repository.QaQuestionRepository;
 import org.junit.jupiter.api.Test;
@@ -39,6 +41,9 @@ class QaAiAnswerLifecycleServiceTest {
     private QaAnswerSourceRepository qaAnswerSourceRepository;
 
     @Mock
+    private QaAnswerRevisionRepository qaAnswerRevisionRepository;
+
+    @Mock
     private QaQuestion question;
 
     @Mock
@@ -49,7 +54,8 @@ class QaAiAnswerLifecycleServiceTest {
         QaAiAnswerLifecycleService service = new QaAiAnswerLifecycleService(
                 qaQuestionRepository,
                 qaAnswerRepository,
-                qaAnswerSourceRepository
+                qaAnswerSourceRepository,
+                qaAnswerRevisionRepository
         );
         List<RetrievedKnowledge> sources = List.of(
                 new RetrievedKnowledge(
@@ -77,8 +83,23 @@ class QaAiAnswerLifecycleServiceTest {
         when(qaAnswerRepository.existsByQuestion(question)).thenReturn(false);
         when(qaAnswerRepository.save(any(QaAnswer.class))).thenReturn(answer);
         when(answer.getAnswerId()).thenReturn(100L);
+        when(answer.getContent()).thenReturn("첫 번째 자료만 사용한 답변입니다. [근거 1]");
 
         Long answerId = service.complete(1L, "첫 번째 자료만 사용한 답변입니다. [근거 1]", sources);
+
+        // AI가 만든 답변은 현재 답변(QaAnswer)으로만 남는 것이 아니라,
+        // 담당자가 나중에 수정해도 원문을 볼 수 있도록 수정 이력 v1에도 저장되어야 한다.
+        ArgumentCaptor<QaAnswerRevision> revisionCaptor =
+                ArgumentCaptor.forClass(QaAnswerRevision.class);
+        verify(qaAnswerRevisionRepository).save(revisionCaptor.capture());
+
+        QaAnswerRevision initialRevision = revisionCaptor.getValue();
+        assertThat(initialRevision.getAnswer()).isSameAs(answer);
+        assertThat(initialRevision.getVersionNumber()).isEqualTo(1);
+        assertThat(initialRevision.getContent())
+                .isEqualTo("첫 번째 자료만 사용한 답변입니다. [근거 1]");
+        assertThat(initialRevision.getEditorType().name()).isEqualTo("AI");
+        assertThat(initialRevision.getRevisedBy()).isNull();
 
         @SuppressWarnings("unchecked")
         ArgumentCaptor<List<QaAnswerSource>> sourceCaptor = ArgumentCaptor.forClass(List.class);
@@ -110,7 +131,8 @@ class QaAiAnswerLifecycleServiceTest {
         QaAiAnswerLifecycleService service = new QaAiAnswerLifecycleService(
                 qaQuestionRepository,
                 qaAnswerRepository,
-                qaAnswerSourceRepository
+                qaAnswerSourceRepository,
+                qaAnswerRevisionRepository
         );
         List<RetrievedKnowledge> sources = List.of(new RetrievedKnowledge(
                 "knowledge-transcript-20-0",
@@ -130,6 +152,7 @@ class QaAiAnswerLifecycleServiceTest {
                 .isInstanceOf(com._penLearning.Noddi.global.exception.GeneralException.class);
 
         verify(qaAnswerRepository, never()).save(any(QaAnswer.class));
+        verify(qaAnswerRevisionRepository, never()).save(any(QaAnswerRevision.class));
         verify(question, never()).markAsAnswered();
     }
 
@@ -138,7 +161,8 @@ class QaAiAnswerLifecycleServiceTest {
         QaAiAnswerLifecycleService service = new QaAiAnswerLifecycleService(
                 qaQuestionRepository,
                 qaAnswerRepository,
-                qaAnswerSourceRepository
+                qaAnswerSourceRepository,
+                qaAnswerRevisionRepository
         );
         List<RetrievedKnowledge> sources = List.of(new RetrievedKnowledge(
                 "knowledge-transcript-20-0",
@@ -172,7 +196,8 @@ class QaAiAnswerLifecycleServiceTest {
         QaAiAnswerLifecycleService service = new QaAiAnswerLifecycleService(
                 qaQuestionRepository,
                 qaAnswerRepository,
-                qaAnswerSourceRepository
+                qaAnswerSourceRepository,
+                qaAnswerRevisionRepository
         );
         LocalDateTime threshold = LocalDateTime.now().minusMinutes(10);
 
@@ -190,7 +215,8 @@ class QaAiAnswerLifecycleServiceTest {
         QaAiAnswerLifecycleService service = new QaAiAnswerLifecycleService(
                 qaQuestionRepository,
                 qaAnswerRepository,
-                qaAnswerSourceRepository
+                qaAnswerSourceRepository,
+                qaAnswerRevisionRepository
         );
         LocalDateTime threshold = LocalDateTime.now().minusMinutes(10);
 

--- a/src/test/java/com/_penLearning/Noddi/domain/qa/service/QaAnswerRevisionQueryServiceTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/qa/service/QaAnswerRevisionQueryServiceTest.java
@@ -1,0 +1,205 @@
+package com._penLearning.Noddi.domain.qa.service;
+
+import com._penLearning.Noddi.domain.project.entity.Project;
+import com._penLearning.Noddi.domain.project.repository.ProjectMemberRepository;
+import com._penLearning.Noddi.domain.qa.dto.QaResponseDto;
+import com._penLearning.Noddi.domain.qa.entity.QaAnswer;
+import com._penLearning.Noddi.domain.qa.entity.QaAnswerRevision;
+import com._penLearning.Noddi.domain.qa.entity.QaAnswerSource;
+import com._penLearning.Noddi.domain.qa.entity.QaQuestion;
+import com._penLearning.Noddi.domain.qa.entity.RevisionEditorType;
+import com._penLearning.Noddi.domain.qa.entity.SourceType;
+import com._penLearning.Noddi.domain.qa.repository.QaAnswerRepository;
+import com._penLearning.Noddi.domain.qa.repository.QaAnswerRevisionRepository;
+import com._penLearning.Noddi.domain.qa.repository.QaAnswerSourceRepository;
+import com._penLearning.Noddi.domain.team.entity.Team;
+import com._penLearning.Noddi.domain.team.repository.TeamMemberRepository;
+import com._penLearning.Noddi.domain.user.entity.User;
+import com._penLearning.Noddi.domain.user.repository.UserRepository;
+import com._penLearning.Noddi.global.exception.GeneralException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class QaAnswerRevisionQueryServiceTest {
+
+    /*
+     * 수정 이력의 내용 권한과 AI 출처 권한은 서로 다르다.
+     *
+     * - 같은 프로젝트 구성원: 모든 답변 버전을 조회할 수 있다.
+     * - 질문 대상 팀 구성원: AI 최초 버전의 출처까지 조회할 수 있다.
+     * - 프로젝트 외부 사용자: 수정 이력 자체를 조회할 수 없다.
+     *
+     * 이 테스트는 위 세 경계를 각각 분리해서 검증한다.
+     */
+
+    @Mock private QaAnswerRepository answerRepository;
+    @Mock private QaAnswerRevisionRepository answerRevisionRepository;
+    @Mock private QaAnswerSourceRepository answerSourceRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private ProjectMemberRepository projectMemberRepository;
+    @Mock private TeamMemberRepository teamMemberRepository;
+
+    @Mock private QaAnswer answer;
+    @Mock private QaQuestion question;
+    @Mock private Team targetTeam;
+    @Mock private Project project;
+    @Mock private User requester;
+
+    private QaAnswerRevisionQueryService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new QaAnswerRevisionQueryService(
+                answerRepository,
+                answerRevisionRepository,
+                answerSourceRepository,
+                userRepository,
+                projectMemberRepository,
+                teamMemberRepository
+        );
+    }
+
+    @Test
+    void returnsAllRevisionsAndInitialSourcesToTargetTeamMember() {
+        // Given: 대상 팀 담당자가 AI 원문(v1)과 담당자 수정본(v2)을 조회한다.
+        allowAnswerAccess(true);
+
+        QaAnswerRevision aiRevision = org.mockito.Mockito.mock(QaAnswerRevision.class);
+        QaAnswerRevision humanRevision = org.mockito.Mockito.mock(QaAnswerRevision.class);
+        QaAnswerSource source = org.mockito.Mockito.mock(QaAnswerSource.class);
+        User reviser = org.mockito.Mockito.mock(User.class);
+
+        LocalDateTime aiCreatedAt = LocalDateTime.of(2026, 8, 17, 10, 0);
+        LocalDateTime revisedAt = LocalDateTime.of(2026, 8, 17, 11, 0);
+
+        when(answer.getAnswerId()).thenReturn(10L);
+
+        when(aiRevision.getVersionNumber()).thenReturn(1);
+        when(aiRevision.getContent()).thenReturn("AI 최초 답변");
+        when(aiRevision.getEditorType()).thenReturn(RevisionEditorType.AI);
+        when(aiRevision.getCreatedAt()).thenReturn(aiCreatedAt);
+
+        when(humanRevision.getVersionNumber()).thenReturn(2);
+        when(humanRevision.getContent()).thenReturn("담당자가 수정한 최종 답변");
+        when(humanRevision.getEditorType()).thenReturn(RevisionEditorType.HUMAN);
+        when(humanRevision.getRevisedBy()).thenReturn(reviser);
+        when(humanRevision.getCreatedAt()).thenReturn(revisedAt);
+        when(reviser.getUserId()).thenReturn(20L);
+        when(reviser.getName()).thenReturn("홍길동");
+
+        when(source.getCitationIndex()).thenReturn(1);
+        when(source.getSourceType()).thenReturn(SourceType.TRANSCRIPT);
+        when(source.getReferenceId()).thenReturn(30L);
+        when(source.getSourceTitle()).thenReturn("8월 기획 회의");
+        when(source.getExcerpt()).thenReturn("출시일은 9월 5일입니다.");
+
+        when(answerRevisionRepository.findAllByAnswerWithReviserOrderByVersionNumberAsc(answer))
+                .thenReturn(List.of(aiRevision, humanRevision));
+        when(answerSourceRepository.findByAnswer_AnswerIdOrderByCitationIndexAsc(10L))
+                .thenReturn(List.of(source));
+
+        // When: 답변 수정 이력을 조회한다.
+        QaResponseDto.AnswerRevisionHistory response =
+                service.getAnswerRevisions(1L, 10L);
+
+        // Then: 전체 버전은 시간 순서대로 제공하고, 대상 팀원에게만 v1 출처를 제공한다.
+        assertThat(response.getAnswerId()).isEqualTo(10L);
+        assertThat(response.getTotalVersions()).isEqualTo(2);
+        assertThat(response.isCanViewSources()).isTrue();
+        assertThat(response.getRevisions()).hasSize(2);
+
+        QaResponseDto.AnswerRevisionItem version1 = response.getRevisions().get(0);
+        assertThat(version1.getVersionNumber()).isEqualTo(1);
+        assertThat(version1.getContent()).isEqualTo("AI 최초 답변");
+        assertThat(version1.getEditorType()).isEqualTo(RevisionEditorType.AI);
+        assertThat(version1.getEditorId()).isNull();
+        assertThat(version1.getEditorName()).isEqualTo("AI");
+        assertThat(version1.getCreatedAt()).isEqualTo(aiCreatedAt);
+        assertThat(version1.getSources()).hasSize(1);
+        assertThat(version1.getSources().get(0).getReferenceId()).isEqualTo(30L);
+
+        QaResponseDto.AnswerRevisionItem version2 = response.getRevisions().get(1);
+        assertThat(version2.getVersionNumber()).isEqualTo(2);
+        assertThat(version2.getEditorId()).isEqualTo(20L);
+        assertThat(version2.getEditorName()).isEqualTo("홍길동");
+        assertThat(version2.getCreatedAt()).isEqualTo(revisedAt);
+        assertThat(version2.getSources()).isEmpty();
+    }
+
+    @Test
+    void hidesInitialSourcesFromProjectMemberOutsideTargetTeam() {
+        // Given: 같은 프로젝트 구성원이지만 질문 대상 팀에는 소속되지 않은 사용자가 조회한다.
+        allowAnswerAccess(false);
+
+        QaAnswerRevision aiRevision = org.mockito.Mockito.mock(QaAnswerRevision.class);
+        when(answer.getAnswerId()).thenReturn(10L);
+        when(aiRevision.getVersionNumber()).thenReturn(1);
+        when(aiRevision.getContent()).thenReturn("AI 최초 답변");
+        when(aiRevision.getEditorType()).thenReturn(RevisionEditorType.AI);
+        when(answerRevisionRepository.findAllByAnswerWithReviserOrderByVersionNumberAsc(answer))
+                .thenReturn(List.of(aiRevision));
+
+        // When: 수정 이력을 조회한다.
+        QaResponseDto.AnswerRevisionHistory response =
+                service.getAnswerRevisions(1L, 10L);
+
+        // Then: 답변 내용은 볼 수 있지만 출처 권한과 출처 목록은 제공하지 않는다.
+        assertThat(response.isCanViewSources()).isFalse();
+        assertThat(response.getRevisions()).hasSize(1);
+        assertThat(response.getRevisions().get(0).getContent()).isEqualTo("AI 최초 답변");
+        assertThat(response.getRevisions().get(0).getSources()).isEmpty();
+
+        // 민감한 회의록 발췌문이 DB에서 불필요하게 조회되지 않는지도 함께 검증한다.
+        verifyNoInteractions(answerSourceRepository);
+    }
+
+    @Test
+    void rejectsRequesterOutsideProjectBeforeLoadingRevisionContents() {
+        // Given: 답변과 사용자는 존재하지만 요청자가 답변이 속한 프로젝트의 멤버가 아니다.
+        when(answerRepository.findByIdWithQuestionTeamAndProject(10L))
+                .thenReturn(Optional.of(answer));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(requester));
+        when(answer.getQuestion()).thenReturn(question);
+        when(question.getTargetTeam()).thenReturn(targetTeam);
+        when(targetTeam.getProject()).thenReturn(project);
+        when(projectMemberRepository.existsByProjectAndUser(project, requester)).thenReturn(false);
+
+        // When & Then: 프로젝트 권한 단계에서 즉시 차단한다.
+        assertThatThrownBy(() -> service.getAnswerRevisions(1L, 10L))
+                .isInstanceOf(GeneralException.class);
+
+        // 권한이 없으므로 수정 내용과 출처에는 접근하지 않아야 한다.
+        verifyNoInteractions(
+                answerRevisionRepository,
+                answerSourceRepository,
+                teamMemberRepository
+        );
+    }
+
+    private void allowAnswerAccess(boolean targetTeamMember) {
+        // 성공 테스트에서 공통으로 필요한 답변 소속 관계와 프로젝트 권한을 준비한다.
+        when(answerRepository.findByIdWithQuestionTeamAndProject(10L))
+                .thenReturn(Optional.of(answer));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(requester));
+        when(answer.getQuestion()).thenReturn(question);
+        when(question.getTargetTeam()).thenReturn(targetTeam);
+        when(targetTeam.getProject()).thenReturn(project);
+        when(projectMemberRepository.existsByProjectAndUser(project, requester)).thenReturn(true);
+        when(teamMemberRepository.existsByTeamAndUser(targetTeam, requester))
+                .thenReturn(targetTeamMember);
+    }
+}

--- a/src/test/java/com/_penLearning/Noddi/domain/qa/service/QaAnswerUpdateServiceTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/qa/service/QaAnswerUpdateServiceTest.java
@@ -2,9 +2,10 @@ package com._penLearning.Noddi.domain.qa.service;
 
 import com._penLearning.Noddi.domain.qa.dto.QaRequestDto;
 import com._penLearning.Noddi.domain.qa.entity.QaAnswer;
+import com._penLearning.Noddi.domain.qa.entity.QaAnswerRevision;
 import com._penLearning.Noddi.domain.qa.entity.QaQuestion;
 import com._penLearning.Noddi.domain.qa.repository.QaAnswerRepository;
-import com._penLearning.Noddi.domain.qa.repository.QaAnswerSourceRepository;
+import com._penLearning.Noddi.domain.qa.repository.QaAnswerRevisionRepository;
 import com._penLearning.Noddi.domain.team.entity.Team;
 import com._penLearning.Noddi.domain.team.repository.TeamMemberRepository;
 import com._penLearning.Noddi.domain.user.entity.User;
@@ -16,6 +17,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -23,35 +27,79 @@ import static org.mockito.Mockito.when;
 class QaAnswerUpdateServiceTest {
 
     @Mock private QaAnswerRepository answerRepository;
-    @Mock private QaAnswerSourceRepository answerSourceRepository;
+    @Mock private QaAnswerRevisionRepository answerRevisionRepository;
     @Mock private UserRepository userRepository;
     @Mock private TeamMemberRepository teamMemberRepository;
     @Mock private QaAnswer answer;
+    @Mock private QaAnswerRevision lastRevision;
     @Mock private QaQuestion question;
     @Mock private Team team;
     @Mock private User reviser;
     @Mock private QaRequestDto.ReviseAnswer request;
 
     @Test
-    void removesAiSourcesWhenAnswerIsRevised() {
+    void savesNextRevisionAndUpdatesLatestAnswer() {
         QaAnswerUpdateService service = new QaAnswerUpdateService(
                 answerRepository,
-                answerSourceRepository,
+                answerRevisionRepository,
                 userRepository,
                 teamMemberRepository
         );
 
+        // Given: AI 최초 답변인 v1이 존재하고 대상 팀 담당자가 답변을 수정한다.
         when(answerRepository.findByIdWithQuestionAndTeamForUpdate(1L)).thenReturn(Optional.of(answer));
         when(userRepository.findById(2L)).thenReturn(Optional.of(reviser));
         when(answer.getQuestion()).thenReturn(question);
         when(question.getTargetTeam()).thenReturn(team);
         when(teamMemberRepository.existsByTeamAndUser(team, reviser)).thenReturn(true);
+        when(answerRevisionRepository.findTopByAnswerOrderByVersionNumberDesc(answer))
+                .thenReturn(Optional.of(lastRevision));
+        when(lastRevision.getVersionNumber()).thenReturn(1);
         when(request.getContent()).thenReturn("담당자가 수정한 최종 답변");
-        when(answer.getAnswerId()).thenReturn(1L);
 
+        // When: 담당자가 답변 수정을 요청한다.
         service.revise(1L, 2L, request);
 
+        // Then: 기존 AI v1은 변경하지 않고 담당자 수정 내용을 v2로 새로 저장한다.
+        org.mockito.ArgumentCaptor<QaAnswerRevision> revisionCaptor =
+                org.mockito.ArgumentCaptor.forClass(QaAnswerRevision.class);
+        verify(answerRevisionRepository).save(revisionCaptor.capture());
+
+        QaAnswerRevision savedRevision = revisionCaptor.getValue();
+        assertThat(savedRevision.getAnswer()).isSameAs(answer);
+        assertThat(savedRevision.getVersionNumber()).isEqualTo(2);
+        assertThat(savedRevision.getContent()).isEqualTo("담당자가 수정한 최종 답변");
+        assertThat(savedRevision.getEditorType().name()).isEqualTo("HUMAN");
+        assertThat(savedRevision.getRevisedBy()).isSameAs(reviser);
+
+        // 피드에서 바로 보여줄 QaAnswer도 같은 내용과 마지막 수정자로 갱신한다.
         verify(answer).revise("담당자가 수정한 최종 답변", reviser);
-        verify(answerSourceRepository).deleteAllByAnswerId(1L);
+    }
+
+    @Test
+    void doesNotSaveRevisionWhenRequesterIsNotTargetTeamMember() {
+        QaAnswerUpdateService service = new QaAnswerUpdateService(
+                answerRepository,
+                answerRevisionRepository,
+                userRepository,
+                teamMemberRepository
+        );
+
+        // Given: 답변과 사용자는 존재하지만 사용자가 질문 대상 팀 소속이 아니다.
+        when(answerRepository.findByIdWithQuestionAndTeamForUpdate(1L)).thenReturn(Optional.of(answer));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(reviser));
+        when(answer.getQuestion()).thenReturn(question);
+        when(question.getTargetTeam()).thenReturn(team);
+        when(teamMemberRepository.existsByTeamAndUser(team, reviser)).thenReturn(false);
+
+        // When: 권한 없는 사용자가 답변을 수정하려고 한다.
+        org.assertj.core.api.Assertions.assertThatThrownBy(
+                        () -> service.revise(1L, 2L, request)
+                )
+                .isInstanceOf(com._penLearning.Noddi.global.exception.GeneralException.class);
+
+        // Then: 새 수정 이력과 최신 답변 모두 변경되지 않는다.
+        verify(answerRevisionRepository, never()).save(any(QaAnswerRevision.class));
+        verify(answer, never()).revise(any(), any());
     }
 }

--- a/src/test/java/com/_penLearning/Noddi/domain/qa/service/QaQuestionQueryServiceTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/qa/service/QaQuestionQueryServiceTest.java
@@ -13,6 +13,7 @@ import com._penLearning.Noddi.domain.qa.repository.QaAnswerRepository;
 import com._penLearning.Noddi.domain.qa.repository.QaAnswerSourceRepository;
 import com._penLearning.Noddi.domain.qa.repository.QaQuestionRepository;
 import com._penLearning.Noddi.domain.team.entity.Team;
+import com._penLearning.Noddi.domain.team.repository.TeamMemberRepository;
 import com._penLearning.Noddi.domain.team.repository.TeamRepository;
 import com._penLearning.Noddi.domain.user.entity.User;
 import com._penLearning.Noddi.domain.user.repository.UserRepository;
@@ -72,6 +73,9 @@ class QaQuestionQueryServiceTest {
     private ProjectMemberRepository projectMemberRepository;
 
     @Mock
+    private TeamMemberRepository teamMemberRepository;
+
+    @Mock
     private Team targetTeam;
 
     @Mock
@@ -90,7 +94,8 @@ class QaQuestionQueryServiceTest {
                 qaAnswerSourceRepository,
                 userRepository,
                 teamRepository,
-                projectMemberRepository
+                projectMemberRepository,
+                teamMemberRepository
         );
     }
 
@@ -111,6 +116,8 @@ class QaQuestionQueryServiceTest {
         LocalDateTime answerTime = LocalDateTime.of(2026, 8, 15, 10, 0, 5);
 
         allowProjectAccess();
+        // 요청자가 대상 팀원이므로 AI 답변의 출처까지 조회할 수 있다.
+        when(teamMemberRepository.existsByTeamAndUser(targetTeam, requester)).thenReturn(true);
 
         when(newestQuestion.getQuestionId()).thenReturn(103L);
         when(newestQuestion.getQuestioner()).thenReturn(newestQuestioner);
@@ -211,6 +218,8 @@ class QaQuestionQueryServiceTest {
         LocalDateTime createdAt = LocalDateTime.of(2026, 8, 15, 11, 0);
 
         allowProjectAccess();
+        // 대상 팀원은 출처 조회 권한이 있지만, 이 답변에는 실제 인용 출처가 없는 상황이다.
+        when(teamMemberRepository.existsByTeamAndUser(targetTeam, requester)).thenReturn(true);
 
         when(question.getQuestionId()).thenReturn(101L);
         when(question.getQuestioner()).thenReturn(questioner);

--- a/src/test/java/com/_penLearning/Noddi/domain/team/service/TeamResourceDeletionServiceTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/team/service/TeamResourceDeletionServiceTest.java
@@ -1,0 +1,86 @@
+package com._penLearning.Noddi.domain.team.service;
+
+import com._penLearning.Noddi.domain.actionItem.repository.ActionItemRepository;
+import com._penLearning.Noddi.domain.announcement.repository.AnnouncementRepository;
+import com._penLearning.Noddi.domain.meeting.repository.MeetingParticipantRepository;
+import com._penLearning.Noddi.domain.meeting.repository.MeetingRepository;
+import com._penLearning.Noddi.domain.qa.rag.indexing.KnowledgeDeletionService;
+import com._penLearning.Noddi.domain.qa.repository.QaAnswerRepository;
+import com._penLearning.Noddi.domain.qa.repository.QaAnswerRevisionRepository;
+import com._penLearning.Noddi.domain.qa.repository.QaAnswerSourceRepository;
+import com._penLearning.Noddi.domain.qa.repository.QaQuestionRepository;
+import com._penLearning.Noddi.domain.summary.repository.MeetingSummaryRepository;
+import com._penLearning.Noddi.domain.team.entity.Team;
+import com._penLearning.Noddi.domain.team.repository.TeamInviteRepository;
+import com._penLearning.Noddi.domain.team.repository.TeamMemberRepository;
+import com._penLearning.Noddi.domain.teamPage.repository.TeamPageRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TeamResourceDeletionServiceTest {
+
+    @Mock private KnowledgeDeletionService knowledgeDeletionService;
+    @Mock private QaAnswerSourceRepository answerSourceRepository;
+    @Mock private QaAnswerRevisionRepository answerRevisionRepository;
+    @Mock private QaAnswerRepository answerRepository;
+    @Mock private QaQuestionRepository questionRepository;
+    @Mock private ActionItemRepository actionItemRepository;
+    @Mock private MeetingParticipantRepository meetingParticipantRepository;
+    @Mock private MeetingSummaryRepository meetingSummaryRepository;
+    @Mock private MeetingRepository meetingRepository;
+    @Mock private AnnouncementRepository announcementRepository;
+    @Mock private TeamPageRepository teamPageRepository;
+    @Mock private TeamInviteRepository teamInviteRepository;
+    @Mock private TeamMemberRepository teamMemberRepository;
+    @Mock private Team team;
+
+    @Test
+    void deletesQaResourcesInForeignKeyDependencyOrder() {
+        TeamResourceDeletionService service = new TeamResourceDeletionService(
+                knowledgeDeletionService,
+                answerSourceRepository,
+                answerRevisionRepository,
+                answerRepository,
+                questionRepository,
+                actionItemRepository,
+                meetingParticipantRepository,
+                meetingSummaryRepository,
+                meetingRepository,
+                announcementRepository,
+                teamPageRepository,
+                teamInviteRepository,
+                teamMemberRepository
+        );
+
+        // Given: 수정 이력이 존재하는 팀 전체를 삭제하는 상황이다.
+        when(team.getTeamId()).thenReturn(10L);
+
+        // When: 팀이 소유한 모든 하위 데이터를 정리한다.
+        service.deleteAllOwnedBy(team);
+
+        /*
+         * Then: QaAnswer를 참조하는 Source와 Revision을 먼저 삭제한 후
+         * Answer, Question 순서로 삭제해야 FK 제약 위반이 발생하지 않는다.
+         *
+         * InOrder는 단순 호출 여부뿐 아니라 호출 순서가 바뀌는 회귀까지 잡아낸다.
+         */
+        InOrder qaDeletionOrder = inOrder(
+                answerSourceRepository,
+                answerRevisionRepository,
+                answerRepository,
+                questionRepository
+        );
+
+        qaDeletionOrder.verify(answerSourceRepository).bulkDeleteByTeam(team);
+        qaDeletionOrder.verify(answerRevisionRepository).bulkDeleteByTeam(team);
+        qaDeletionOrder.verify(answerRepository).bulkDeleteByTeam(team);
+        qaDeletionOrder.verify(questionRepository).bulkDeleteByTeam(team);
+    }
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

## 🎋 작업 브랜치
- feature/53 -> develop
- #53  (관련이슈 번호)

## 💡 작업동기
- 기존의 출처를 타 팀에게도 노출하는 문제를 해결해 정책과 충돌되는 부분을 해결했습니다
- 수정 이력을 보존하고 프론트로 전달하도록 수정했습니다

## 🔑 주요 변경사항
- Q&A 피드에서 AI 답변 출처를 질문 대상 팀 구성원에게만 제공
- AI 최초 답변을 v1으로 저장하고 담당자 수정본을 v2, v3 형태로 누적 관리
- `QaAnswer`에는 피드에 노출할 최신 답변과 마지막 수정자 정보 유지
- 같은 프로젝트 구성원이 답변 수정 이력을 조회할 수 있는 API 추가
  - `GET /api/v1/qa/answers/{answerId}/revisions`
- AI 최초 버전의 회의록·팀 페이지 출처는 질문 대상 팀원에게만 노출
- 담당자 수정 후에도 AI 최초 답변의 출처 데이터 보존
- 팀·프로젝트 삭제 시 답변 수정 이력을 FK 의존 순서에 맞게 정리
- 답변 생성·수정·이력 조회·출처 권한·삭제 순서 관련 테스트 추가

## 🏞 스크린샷 (선택)
> 스크린샷을 첨부해주세요.

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
