### PR TITLE
[feat] AI 답변 최종 실패 / 팀원 직접 답변 기능 구현 및 qa관련 이벤트 발행

### DIFF
--- a/src/main/java/com/_penLearning/Noddi/domain/qa/code/QaApi.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/code/QaApi.java
@@ -52,7 +52,10 @@ public interface QaApi {
             @Parameter(description = "질문 ID") @PathVariable Long questionId, @Parameter(hidden = true) AuthMember authMember
     );
 
-    @Operation(summary = "AI 답변 수정", description = "대상 팀 멤버가 AI 답변을 수정하고 마지막 수정자를 기록합니다.")
+    @Operation(
+            summary = "답변 작성 및 수정",
+            description = "대상 팀 멤버가 AI 답변을 수정하거나 AI 최종 실패 질문에 직접 답변합니다."
+    )
     ApiResponse<QaResponseDto.ReviseAnswer> reviseAnswer(
             @Parameter(description = "답변 ID") @PathVariable Long answerId,
             QaRequestDto.ReviseAnswer request,

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/controller/QaController.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/controller/QaController.java
@@ -87,7 +87,7 @@ public class QaController implements QaApi {
         return ApiResponse.onSuccess("질문 상세 조회에 성공했습니다.", response);
     }
 
-    // AI 답변 수정
+    // AI 답변 수정 또는 최종 실패 질문에 대한 대상 팀의 직접 답변
     @Override
     @PatchMapping("/qa/answers/{answerId}")
     public ApiResponse<QaResponseDto.ReviseAnswer> reviseAnswer(
@@ -99,7 +99,7 @@ public class QaController implements QaApi {
                 authMember.getUserId(),
                 request
         );
-        return ApiResponse.onSuccess("AI 답변이 성공적으로 수정되었습니다.", response);
+        return ApiResponse.onSuccess("답변이 성공적으로 저장되었습니다.", response);
     }
 
     /**

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/dto/QaAnswerStreamEventDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/dto/QaAnswerStreamEventDto.java
@@ -47,7 +47,8 @@ public record QaAnswerStreamEventDto(
      */
     public static QaAnswerStreamEventDto snapshot(
             Long questionId,
-            String content
+            String content,
+            int attempt
     ) {
         return new QaAnswerStreamEventDto(
                 EventType.SNAPSHOT,
@@ -56,7 +57,7 @@ public record QaAnswerStreamEventDto(
                 QaStatus.PROCESSING,
                 content,
                 null,
-                null
+                attempt
         );
     }
 
@@ -67,7 +68,8 @@ public record QaAnswerStreamEventDto(
      */
     public static QaAnswerStreamEventDto chunk(
             Long questionId,
-            String delta
+            String delta,
+            int attempt
     ) {
         return new QaAnswerStreamEventDto(
                 EventType.CHUNK,
@@ -76,7 +78,7 @@ public record QaAnswerStreamEventDto(
                 QaStatus.PROCESSING,
                 null,
                 delta,
-                null
+                attempt
         );
     }
 

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/dto/QaAnswerStreamEventDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/dto/QaAnswerStreamEventDto.java
@@ -12,7 +12,8 @@ public record QaAnswerStreamEventDto(
         Long answerId,
         QaStatus status,
         String content,
-        String delta
+        String delta,
+        Integer attempt
 ) {
 
     /**
@@ -30,6 +31,7 @@ public record QaAnswerStreamEventDto(
                 questionId,
                 null,
                 status,
+                null,
                 null,
                 null
         );
@@ -53,6 +55,7 @@ public record QaAnswerStreamEventDto(
                 null,
                 QaStatus.PROCESSING,
                 content,
+                null,
                 null
         );
     }
@@ -72,7 +75,8 @@ public record QaAnswerStreamEventDto(
                 null,
                 QaStatus.PROCESSING,
                 null,
-                delta
+                delta,
+                null
         );
     }
 
@@ -94,6 +98,7 @@ public record QaAnswerStreamEventDto(
                 answerId,
                 QaStatus.ANSWERED,
                 content,
+                null,
                 null
         );
     }
@@ -109,6 +114,35 @@ public record QaAnswerStreamEventDto(
                 questionId,
                 null,
                 QaStatus.FAILED,
+                null,
+                null,
+                null
+        );
+    }
+
+    public static QaAnswerStreamEventDto retrying(Long questionId, int attempt) {
+        return new QaAnswerStreamEventDto(
+                EventType.RETRYING,
+                questionId,
+                null,
+                QaStatus.FAILED,
+                null,
+                null,
+                attempt
+        );
+    }
+
+    public static QaAnswerStreamEventDto manualRequired(
+            Long questionId,
+            Long answerId,
+            String content
+    ) {
+        return new QaAnswerStreamEventDto(
+                EventType.MANUAL_REQUIRED,
+                questionId,
+                answerId,
+                QaStatus.MANUAL_REQUIRED,
+                content,
                 null,
                 null
         );
@@ -133,6 +167,12 @@ public record QaAnswerStreamEventDto(
 
         // 최종 답변 저장 완료
         COMPLETED("completed"),
+
+        // AI 생성 실패 후 자동 재시도 대기
+        RETRYING("retrying"),
+
+        // 자동 재시도 최종 실패 후 대상 팀 답변 대기
+        MANUAL_REQUIRED("manual_required"),
 
         // 답변 생성 실패
         FAILED("failed");

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/dto/QaAnswerStreamEventDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/dto/QaAnswerStreamEventDto.java
@@ -1,6 +1,5 @@
 package com._penLearning.Noddi.domain.qa.dto;
 
-import com._penLearning.Noddi.domain.qa.entity.QaStatus;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
@@ -10,7 +9,7 @@ public record QaAnswerStreamEventDto(
         EventType type,
         Long questionId,
         Long answerId,
-        QaStatus status,
+        QaResponseStatus status,
         String content,
         String delta,
         Integer attempt
@@ -24,7 +23,7 @@ public record QaAnswerStreamEventDto(
      */
     public static QaAnswerStreamEventDto connected(
             Long questionId,
-            QaStatus status
+            QaResponseStatus status
     ) {
         return new QaAnswerStreamEventDto(
                 EventType.CONNECTED,
@@ -54,7 +53,7 @@ public record QaAnswerStreamEventDto(
                 EventType.SNAPSHOT,
                 questionId,
                 null,
-                QaStatus.PROCESSING,
+                QaResponseStatus.PROCESSING,
                 content,
                 null,
                 attempt
@@ -75,7 +74,7 @@ public record QaAnswerStreamEventDto(
                 EventType.CHUNK,
                 questionId,
                 null,
-                QaStatus.PROCESSING,
+                QaResponseStatus.PROCESSING,
                 null,
                 delta,
                 attempt
@@ -98,7 +97,7 @@ public record QaAnswerStreamEventDto(
                 EventType.COMPLETED,
                 questionId,
                 answerId,
-                QaStatus.ANSWERED,
+                QaResponseStatus.ANSWERED,
                 content,
                 null,
                 null
@@ -115,7 +114,7 @@ public record QaAnswerStreamEventDto(
                 EventType.FAILED,
                 questionId,
                 null,
-                QaStatus.FAILED,
+                QaResponseStatus.FAILED,
                 null,
                 null,
                 null
@@ -127,23 +126,23 @@ public record QaAnswerStreamEventDto(
                 EventType.RETRYING,
                 questionId,
                 null,
-                QaStatus.FAILED,
+                QaResponseStatus.FAILED,
                 null,
                 null,
                 attempt
         );
     }
 
-    public static QaAnswerStreamEventDto manualRequired(
+    public static QaAnswerStreamEventDto teamAnswerPending(
             Long questionId,
             Long answerId,
             String content
     ) {
         return new QaAnswerStreamEventDto(
-                EventType.MANUAL_REQUIRED,
+                EventType.TEAM_ANSWER_PENDING,
                 questionId,
                 answerId,
-                QaStatus.MANUAL_REQUIRED,
+                QaResponseStatus.TEAM_ANSWER_PENDING,
                 content,
                 null,
                 null
@@ -173,8 +172,8 @@ public record QaAnswerStreamEventDto(
         // AI 생성 실패 후 자동 재시도 대기
         RETRYING("retrying"),
 
-        // 자동 재시도 최종 실패 후 대상 팀 답변 대기
-        MANUAL_REQUIRED("manual_required"),
+        // 담당 팀의 직접 답변 대기
+        TEAM_ANSWER_PENDING("team_answer_pending"),
 
         // 답변 생성 실패
         FAILED("failed");

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/dto/QaResponseDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/dto/QaResponseDto.java
@@ -79,11 +79,13 @@ public class QaResponseDto {
         private String questionerName;
         private AnswerInfo answer;
         private List<AnswerSourceInfo> sources;
+        private boolean canAnswer;
 
         public static QuestionDetail of(
                 QaQuestion question,
                 QaAnswer answer,
-                List<QaAnswerSource> sources
+                List<QaAnswerSource> sources,
+                boolean canAnswer
         ) {
             return QuestionDetail.builder()
                     .questionId(question.getQuestionId())
@@ -95,6 +97,7 @@ public class QaResponseDto {
                     .questionerName(question.getQuestioner().getName())
                     .answer(answer != null ? AnswerInfo.from(answer) : null)
                     .sources(sources.stream().map(AnswerSourceInfo::from).toList())
+                    .canAnswer(canAnswer)
                     .build();
         }
     }
@@ -177,14 +180,21 @@ public class QaResponseDto {
         private FeedQuestion question;
         private QaStatus status;
         private FeedAnswer answer;
+        private boolean canAnswer;
 
-        public static FeedItem of(QaQuestion question, QaAnswer answer, List<QaAnswerSource> sources) {
+        public static FeedItem of(
+                QaQuestion question,
+                QaAnswer answer,
+                List<QaAnswerSource> sources,
+                boolean canAnswer
+        ) {
             return FeedItem.builder()
                     .question(FeedQuestion.from(question))
                     .status(question.getStatus())
                     .answer(
                             answer != null ? FeedAnswer.from(answer, sources) : null
                     )
+                    .canAnswer(canAnswer)
                     .build();
         }
     }

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/dto/QaResponseDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/dto/QaResponseDto.java
@@ -52,10 +52,14 @@ public class QaResponseDto {
         private Long questionerId;
         private String questionerName;
         private String content;
-        private QaStatus status;
+        private QaResponseStatus status;
         private LocalDateTime createdAt;
 
         public static QuestionInfo from(QaQuestion question) {
+            return from(question, false);
+        }
+
+        public static QuestionInfo from(QaQuestion question, boolean canViewFailureStatus) {
             return QuestionInfo.builder()
                     .questionId(question.getQuestionId())
                     .targetTeamId(question.getTargetTeam().getTeamId())
@@ -63,7 +67,7 @@ public class QaResponseDto {
                     .questionerId(question.getQuestioner().getUserId())
                     .questionerName(question.getQuestioner().getName())
                     .content(question.getContent())
-                    .status(question.getStatus())
+                    .status(QaResponseStatus.from(question.getStatus(), canViewFailureStatus))
                     .createdAt(question.getCreatedAt())
                     .build();
         }
@@ -74,7 +78,7 @@ public class QaResponseDto {
     public static class QuestionDetail {
         private Long questionId;
         private String content;
-        private QaStatus status;
+        private QaResponseStatus status;
         private String targetTeamName;
         private LocalDateTime createdAt;
         private Long questionerId;
@@ -87,12 +91,13 @@ public class QaResponseDto {
                 QaQuestion question,
                 QaAnswer answer,
                 List<QaAnswerSource> sources,
-                boolean canAnswer
+                boolean canAnswer,
+                boolean canViewFailureStatus
         ) {
             return QuestionDetail.builder()
                     .questionId(question.getQuestionId())
                     .content(question.getContent())
-                    .status(question.getStatus())
+                    .status(QaResponseStatus.from(question.getStatus(), canViewFailureStatus))
                     .targetTeamName(question.getTargetTeam().getName())
                     .createdAt(question.getCreatedAt())
                     .questionerId(question.getQuestioner().getUserId())
@@ -189,7 +194,7 @@ public class QaResponseDto {
     @Builder
     public static class FeedItem {
         private FeedQuestion question;
-        private QaStatus status;
+        private QaResponseStatus status;
         private FeedAnswer answer;
         private boolean canAnswer;
 
@@ -197,11 +202,12 @@ public class QaResponseDto {
                 QaQuestion question,
                 QaAnswer answer,
                 List<QaAnswerSource> sources,
-                boolean canAnswer
+                boolean canAnswer,
+                boolean canViewFailureStatus
         ) {
             return FeedItem.builder()
                     .question(FeedQuestion.from(question))
-                    .status(question.getStatus())
+                    .status(QaResponseStatus.from(question.getStatus(), canViewFailureStatus))
                     .answer(
                             answer != null ? FeedAnswer.from(answer, sources) : null
                     )

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/dto/QaResponseStatus.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/dto/QaResponseStatus.java
@@ -1,0 +1,26 @@
+package com._penLearning.Noddi.domain.qa.dto;
+
+import com._penLearning.Noddi.domain.qa.entity.QaStatus;
+
+/**
+ * 내부 AI 처리 상태를 사용자 권한에 맞게 변환한 Q&A 응답 상태다.
+ * 대상 팀원이 아닌 사용자에게는 재시도 실패나 수동 답변 필요 여부를 직접 노출하지 않는다.
+ */
+public enum QaResponseStatus {
+    PENDING,
+    PROCESSING,
+    ANSWERED,
+    FAILED,
+    MANUAL_REQUIRED,
+    TEAM_ANSWER_PENDING;
+
+    public static QaResponseStatus from(QaStatus status, boolean canViewFailureStatus) {
+        if (!canViewFailureStatus && status == QaStatus.FAILED) {
+            return PROCESSING;
+        }
+        if (!canViewFailureStatus && status == QaStatus.MANUAL_REQUIRED) {
+            return TEAM_ANSWER_PENDING;
+        }
+        return valueOf(status.name());
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/entity/AnswerType.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/entity/AnswerType.java
@@ -1,6 +1,7 @@
 package com._penLearning.Noddi.domain.qa.entity;
 
 public enum AnswerType {
-    // 최초 답변은 항상 AI가 생성하며, 담당자가 수정해도 생성 주체는 AI로 유지한다.
-    AI
+    AI,     // AI가 생성한 답변
+    SYSTEM, // AI 최종 실패 시 생성한 안내 답변
+    TEAM    // 대상 팀원이 직접 작성한 답변
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/entity/QaAnswer.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/entity/QaAnswer.java
@@ -57,10 +57,23 @@ public class QaAnswer extends BaseEntity {
         return new QaAnswer(question, content);
     }
 
+    public static QaAnswer createSystemNotice(QaQuestion question, String content) {
+        QaAnswer answer = new QaAnswer(question, content);
+        answer.answerType = AnswerType.SYSTEM;
+        return answer;
+    }
+
     // 현재 답변을 수정하고 마지막 수정자를 기록한다
     public void revise(String content, User reviser) {
         this.content = content;
         this.revisedBy = reviser;
+    }
+
+    public void provideByTeam(String content) {
+        this.content = content;
+        // 시스템 안내문을 실제 답변으로 교체하는 최초 작성이므로 '수정됨'으로 표시하지 않는다.
+        this.revisedBy = null;
+        this.answerType = AnswerType.TEAM;
     }
 
     // 수정 여부 판단

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/entity/QaQuestion.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/entity/QaQuestion.java
@@ -71,8 +71,28 @@ public class QaQuestion extends BaseEntity {
         this.status = QaStatus.FAILED;
     }
 
+    public void markAsManualRequired() {
+        if (status != QaStatus.PROCESSING && status != QaStatus.FAILED) {
+            throw new GeneralException(QaErrorCode.INVALID_QUESTION_STATUS);
+        }
+        this.status = QaStatus.MANUAL_REQUIRED;
+    }
+
+    public void completeManualAnswer() {
+        if (status != QaStatus.MANUAL_REQUIRED) {
+            throw new GeneralException(QaErrorCode.INVALID_QUESTION_STATUS);
+        }
+        this.status = QaStatus.ANSWERED;
+    }
+
+    public boolean isCurrentAttempt(int attempt) {
+        return generationAttempts == attempt;
+    }
+
     public boolean canRetry(int maxAttempts) {
-        return status != QaStatus.ANSWERED && generationAttempts < maxAttempts;
+        return status != QaStatus.ANSWERED
+                && status != QaStatus.MANUAL_REQUIRED
+                && generationAttempts < maxAttempts;
     }
 
     private void validateProcessing() {

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/entity/QaStatus.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/entity/QaStatus.java
@@ -4,5 +4,6 @@ public enum QaStatus {
     PENDING,    // 질문 등록 후 AI 처리 대기
     PROCESSING, // AI 답변 생성 중
     ANSWERED,   // AI 답변 생성 완료
-    FAILED      // AI 답변 생성 실패
+    FAILED,     // AI 답변 생성 실패, 자동 재시도 가능
+    MANUAL_REQUIRED // AI 최종 실패, 대상 팀의 직접 답변 대기
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/event/QaAiFinalFailureEvent.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/event/QaAiFinalFailureEvent.java
@@ -1,0 +1,11 @@
+package com._penLearning.Noddi.domain.qa.event;
+
+/** AI 자동 재시도가 모두 실패해 대상 팀의 직접 답변이 필요해졌음을 알린다. */
+public record QaAiFinalFailureEvent(
+        Long questionId,
+        Long questionerId,
+        Long targetTeamId,
+        Long answerId,
+        String noticeContent
+) {
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/event/QaAiFinalFailureEventHandler.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/event/QaAiFinalFailureEventHandler.java
@@ -18,7 +18,7 @@ public class QaAiFinalFailureEventHandler {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handle(QaAiFinalFailureEvent event) {
         try {
-            answerStreamService.publishManualRequired(
+            answerStreamService.publishTeamAnswerPending(
                     event.questionId(),
                     event.answerId(),
                     event.noticeContent()

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/event/QaAiFinalFailureEventHandler.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/event/QaAiFinalFailureEventHandler.java
@@ -1,0 +1,31 @@
+package com._penLearning.Noddi.domain.qa.event;
+
+import com._penLearning.Noddi.domain.qa.service.QaAnswerStreamService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/** 최종 실패 DB 반영이 커밋된 뒤 SSE와 후속 알림이 사용할 이벤트 지점이다. */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class QaAiFinalFailureEventHandler {
+
+    private final QaAnswerStreamService answerStreamService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(QaAiFinalFailureEvent event) {
+        try {
+            answerStreamService.publishManualRequired(
+                    event.questionId(),
+                    event.answerId(),
+                    event.noticeContent()
+            );
+        } catch (RuntimeException exception) {
+            // 최종 실패 상태와 안내 답변은 이미 커밋됐으므로 SSE 장애를 다시 DB 실패로 전파하지 않는다.
+            log.warn("Q&A manual-required SSE publishing failed. questionId={}", event.questionId(), exception);
+        }
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/event/QaAnswerPublishType.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/event/QaAnswerPublishType.java
@@ -1,0 +1,8 @@
+package com._penLearning.Noddi.domain.qa.event;
+
+/** 사용자에게 노출되는 답변이 어떤 경로로 등록 또는 변경됐는지 나타낸다. */
+public enum QaAnswerPublishType {
+    AI_GENERATED,
+    TEAM_PROVIDED,
+    ANSWER_REVISED
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/event/QaAnswerPublishedEvent.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/event/QaAnswerPublishedEvent.java
@@ -1,0 +1,16 @@
+package com._penLearning.Noddi.domain.qa.event;
+
+/**
+ * 사용자에게 노출할 답변이 등록되거나 변경됐음을 알리는 도메인 이벤트다.
+ * 알림 도메인은 publishType에 따라 수신자와 문구를 결정한다.
+ * actorId는 답변을 작성 또는 수정한 사용자이며 AI가 생성한 경우 null이다.
+ */
+public record QaAnswerPublishedEvent(
+        Long questionId,
+        Long answerId,
+        Long questionerId,
+        Long targetTeamId,
+        Long actorId,
+        QaAnswerPublishType publishType
+) {
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/event/QaQuestionCreatedEventHandler.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/event/QaQuestionCreatedEventHandler.java
@@ -6,7 +6,9 @@ import com._penLearning.Noddi.domain.qa.rag.generation.QaRagAnswerGenerator;
 import com._penLearning.Noddi.domain.qa.rag.generation.QaRagGeneration;
 import com._penLearning.Noddi.domain.qa.repository.QaQuestionRepository;
 import com._penLearning.Noddi.domain.qa.service.QaAiAnswerLifecycleService;
+import com._penLearning.Noddi.domain.qa.service.QaAiFailureOutcome;
 import com._penLearning.Noddi.domain.qa.service.QaAnswerStreamService;
+import com._penLearning.Noddi.domain.qa.scheduler.QaAiRetryScheduler;
 import com._penLearning.Noddi.global.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,6 +17,8 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.OptionalInt;
 
 /**
  * 질문 저장이 완료된 뒤 RAG 답변 생성을 시작한다.
@@ -36,16 +40,22 @@ public class QaQuestionCreatedEventHandler {
     private final QaAiAnswerLifecycleService answerLifecycleService;
     private final QaRagAnswerGenerator answerGenerator;
     private final QaAnswerStreamService answerStreamService;
+    private final QaAiRetryScheduler retryScheduler;
 
     @Async // 질문 등록 API가 OpenAI 응답을 기다리지 않음
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT) // 질문 DB 저장이 확정된 후에만 AI 생성을 시작함
+    @TransactionalEventListener(
+            phase = TransactionPhase.AFTER_COMMIT,
+            fallbackExecution = true
+    ) // 최초 질문은 커밋 후, 이미 커밋된 FAILED 질문의 예약 재시도 이벤트는 즉시 처리한다.
     public void handle(QaQuestionCreatedEvent event) {
         Long questionId = event.questionId();
 
         // 같은 이벤트가 중복 전달되더라도 하나의 생성 작업만 PROCESSING 상태를 획득한다.
-        if (!answerLifecycleService.tryStart(questionId)) { // 중복 이벤트가 들어와도 OpenAI를 여러 번 호출하지 않도록 방지
+        OptionalInt startedAttempt = answerLifecycleService.tryStart(questionId);
+        if (startedAttempt.isEmpty()) { // 중복 이벤트가 들어와도 OpenAI를 여러 번 호출하지 않도록 방지
             return;
         }
+        int attempt = startedAttempt.getAsInt();
 
         /*
          * 이전 실패나 재시도 과정에서 남은 누적 답변을 초기화한다.
@@ -79,12 +89,16 @@ public class QaQuestionCreatedEventHandler {
                     ))
                     .block();
 
-            Long answerId = answerLifecycleService.complete(questionId, answer, generation.sources()); // 답변과 근거 저장
+            Long answerId = answerLifecycleService.complete(
+                    questionId,
+                    attempt,
+                    answer,
+                    generation.sources()
+            ); // 답변과 근거 저장
 
             publishCompletedSafely(questionId, answerId, answer);
         } catch (Exception exception) {
-            failQuestionSafely(questionId);
-            publishFailedSafely(questionId);
+            handleFailureSafely(questionId, attempt);
             log.error("Q&A AI answer generation failed. questionId={}", questionId, exception);
         }
     }
@@ -155,36 +169,36 @@ public class QaQuestionCreatedEventHandler {
         }
     }
 
-    /**
-     * AI 답변 생성 실패를 SSE 구독자에게 알린다.
-     */
-    private void publishFailedSafely(Long questionId) {
+    private void handleFailureSafely(Long questionId, int attempt) {
         try {
-            answerStreamService.publishFailed(questionId);
-        } catch (RuntimeException exception) {
-            log.warn(
-                    "Q&A SSE failure publishing failed. questionId={}",
-                    questionId,
-                    exception
-            );
-        }
-    }
-
-    /**
-     * 질문 상태를 FAILED로 변경한다.
-     *
-     * 실패 상태 저장 자체에서 추가 예외가 발생하더라도 원래 발생한
-     * AI 생성 예외가 사라지지 않게 별도로 처리한다.
-     */
-    private void failQuestionSafely(Long questionId) {
-        try {
-            answerLifecycleService.fail(questionId);
+            QaAiFailureOutcome outcome = answerLifecycleService.fail(questionId, attempt);
+            if (outcome == QaAiFailureOutcome.RETRYABLE) {
+                scheduleRetrySafely(questionId, attempt);
+                publishRetryingSafely(questionId, attempt);
+            }
         } catch (RuntimeException exception) {
             log.error(
                     "Q&A question failure state update failed. questionId={}",
                     questionId,
                     exception
             );
+        }
+    }
+
+    private void scheduleRetrySafely(Long questionId, int attempt) {
+        try {
+            retryScheduler.scheduleRetry(questionId, attempt);
+        } catch (RuntimeException exception) {
+            // 예약 실패 시에도 장기 복구 스케줄러가 FAILED 상태를 다시 수습할 수 있다.
+            log.error("Q&A AI retry scheduling failed. questionId={}", questionId, exception);
+        }
+    }
+
+    private void publishRetryingSafely(Long questionId, int attempt) {
+        try {
+            answerStreamService.publishRetrying(questionId, attempt);
+        } catch (RuntimeException exception) {
+            log.warn("Q&A retrying SSE publishing failed. questionId={}", questionId, exception);
         }
     }
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/event/QaQuestionCreatedEventHandler.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/event/QaQuestionCreatedEventHandler.java
@@ -22,7 +22,6 @@ import java.util.OptionalInt;
 
 /**
  * 질문 저장이 완료된 뒤 RAG 답변 생성을 시작한다.
- *
  * 생성되는 답변 조각은 SSE 구독자에게 실시간으로 전달하고,
  * 생성이 끝나면 최종 답변과 근거를 DB에 저장한다.
  */
@@ -63,7 +62,7 @@ public class QaQuestionCreatedEventHandler {
          * SSE 초기화가 실패하더라도 AI 답변 생성과 DB 저장은 계속되어야 하므로
          * 안전하게 감싼 메서드를 사용한다.
          */
-        startStreamSafely(questionId);
+        startStreamSafely(questionId, attempt);
 
         try {
             QaQuestion question = qaQuestionRepository.findByIdWithTeam(questionId)
@@ -80,7 +79,7 @@ public class QaQuestionCreatedEventHandler {
             }
 
             String answer = generation.answerChunks()
-                    .doOnNext(chunk -> publishChunkSafely(questionId, chunk))
+                    .doOnNext(chunk -> publishChunkSafely(questionId, attempt, chunk))
                     .collectList()
                     .map(chunks -> String.join("", chunks))
                     .filter(content -> !content.isBlank())
@@ -107,9 +106,9 @@ public class QaQuestionCreatedEventHandler {
      * SSE 처리 장애가 AI 답변 생성 자체를 중단시키지 않도록
      * 스트림 시작 과정의 예외를 이 메서드 안에서 처리한다.
      */
-    private void startStreamSafely(Long questionId) {
+    private void startStreamSafely(Long questionId, int attempt) {
         try {
-            answerStreamService.start(questionId);
+            answerStreamService.start(questionId, attempt);
         } catch (RuntimeException exception) {
             log.warn(
                     "Q&A SSE stream initialization failed. questionId={}",
@@ -127,10 +126,11 @@ public class QaQuestionCreatedEventHandler {
      */
     private void publishChunkSafely(
             Long questionId,
+            int attempt,
             String chunk
     ) {
         try {
-            answerStreamService.publishChunk(questionId, chunk);
+            answerStreamService.publishChunk(questionId, attempt, chunk);
         } catch (RuntimeException exception) {
             log.warn(
                     "Q&A SSE chunk publishing failed. questionId={}",

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/scheduler/QaAiRecoveryScheduler.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/scheduler/QaAiRecoveryScheduler.java
@@ -5,13 +5,13 @@ import com._penLearning.Noddi.domain.qa.entity.QaStatus;
 import com._penLearning.Noddi.domain.qa.event.QaQuestionCreatedEvent;
 import com._penLearning.Noddi.domain.qa.repository.QaQuestionRepository;
 import com._penLearning.Noddi.domain.qa.service.QaAiAnswerLifecycleService;
+import com._penLearning.Noddi.domain.qa.service.QaAiRecoveryOutcome;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -39,7 +39,6 @@ public class QaAiRecoveryScheduler {
             cron = "${scheduler.qa-ai.recovery-cron:0 */5 * * * *}",
             zone = "${scheduler.qa-ai.zone:Asia/Seoul}"
     )
-    @Transactional
     public void retryStalledAnswers() {
         LocalDateTime threshold = LocalDateTime.now().minusMinutes(processingTimeoutMinutes);
         List<QaQuestion> candidates = qaQuestionRepository
@@ -47,9 +46,23 @@ public class QaAiRecoveryScheduler {
 
         int recoveredCount = 0;
         for (QaQuestion question : candidates) {
-            if (answerLifecycleService.prepareRecovery(question.getQuestionId(), threshold)) {
-                eventPublisher.publishEvent(new QaQuestionCreatedEvent(question.getQuestionId()));
-                recoveredCount++;
+            try {
+                // 외부 트랜잭션 없이 호출해 후보마다 lifecycleService의 독립 트랜잭션을 사용한다.
+                QaAiRecoveryOutcome outcome = answerLifecycleService.prepareRecovery(
+                        question.getQuestionId(),
+                        threshold
+                );
+                if (outcome == QaAiRecoveryOutcome.RETRY) {
+                    eventPublisher.publishEvent(new QaQuestionCreatedEvent(question.getQuestionId()));
+                    recoveredCount++;
+                }
+            } catch (RuntimeException exception) {
+                // 한 질문의 불일치나 잠금 실패가 나머지 복구 후보를 막지 않도록 격리한다.
+                log.error(
+                        "[QaAiRecoveryScheduler] AI 답변 복구 실패. questionId={}",
+                        question.getQuestionId(),
+                        exception
+                );
             }
         }
 

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/scheduler/QaAiRetryScheduler.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/scheduler/QaAiRetryScheduler.java
@@ -1,0 +1,46 @@
+package com._penLearning.Noddi.domain.qa.scheduler;
+
+import com._penLearning.Noddi.domain.qa.event.QaQuestionCreatedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+
+/** 정상적인 AI 호출 실패를 짧은 지수 backoff 후 다시 실행한다. */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class QaAiRetryScheduler {
+
+    private static final int MAX_BACKOFF_EXPONENT = 10;
+
+    private final TaskScheduler taskScheduler;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Value("${qa.ai.retry-base-delay-millis:2000}")
+    private long retryBaseDelayMillis;
+
+    public void scheduleRetry(Long questionId, int failedAttempt) {
+        int exponent = Math.min(Math.max(failedAttempt - 1, 0), MAX_BACKOFF_EXPONENT);
+        long delayMillis = retryBaseDelayMillis * (1L << exponent);
+        Instant retryAt = Instant.now().plusMillis(delayMillis);
+
+        taskScheduler.schedule(
+                () -> publishRetryEvent(questionId),
+                retryAt
+        );
+    }
+
+    private void publishRetryEvent(Long questionId) {
+        try {
+            eventPublisher.publishEvent(new QaQuestionCreatedEvent(questionId));
+        } catch (RuntimeException exception) {
+            // 예약 재시도 자체가 실패해도 장기 복구 스케줄러가 FAILED 질문을 다시 수습한다.
+            log.error("Q&A AI retry event publishing failed. questionId={}", questionId, exception);
+        }
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaAiAnswerLifecycleService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaAiAnswerLifecycleService.java
@@ -5,6 +5,9 @@ import com._penLearning.Noddi.domain.qa.entity.QaAnswer;
 import com._penLearning.Noddi.domain.qa.entity.QaAnswerSource;
 import com._penLearning.Noddi.domain.qa.entity.QaQuestion;
 import com._penLearning.Noddi.domain.qa.entity.QaStatus;
+import com._penLearning.Noddi.domain.qa.event.QaAnswerPublishedEvent;
+import com._penLearning.Noddi.domain.qa.event.QaAnswerPublishType;
+import com._penLearning.Noddi.domain.qa.event.QaAiFinalFailureEvent;
 import com._penLearning.Noddi.domain.qa.rag.generation.QaRagAnswerGenerator;
 import com._penLearning.Noddi.domain.qa.rag.retrieval.RetrievedKnowledge;
 import com._penLearning.Noddi.domain.qa.repository.QaAnswerRepository;
@@ -13,12 +16,14 @@ import com._penLearning.Noddi.domain.qa.repository.QaQuestionRepository;
 import com._penLearning.Noddi.global.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -33,36 +38,39 @@ import java.util.regex.Pattern;
 public class QaAiAnswerLifecycleService {
 
     private static final Pattern CITATION_PATTERN = Pattern.compile("\\[근거\\s*(\\d+)]");
+    public static final String MANUAL_ANSWER_NOTICE =
+            "AI 답변 생성이 원활하지 않아 대상 팀에 답변을 요청했습니다. 팀원이 확인 후 직접 답변드릴 예정입니다.";
 
     private final QaQuestionRepository qaQuestionRepository;
     private final QaAnswerRepository qaAnswerRepository;
     private final QaAnswerSourceRepository qaAnswerSourceRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Value("${qa.ai.max-generation-attempts:3}")
     private int maxGenerationAttempts = 3;
 
     // 같은 질문에 답변을 두 번 생성하지 않기 위한 장치
-    public boolean tryStart(Long questionId) {
+    public OptionalInt tryStart(Long questionId) {
         QaQuestion question = getQuestionWithLock(questionId);
 
         // 이벤트가 중복 전달되더라도 동일 질문의 AI 생성 작업은 하나만 실행한다.
         if (question.getStatus() == QaStatus.PROCESSING || question.getStatus() == QaStatus.ANSWERED) {
-            return false;
+            return OptionalInt.empty();
         }
         if (!question.canRetry(maxGenerationAttempts)) {
-            return false;
+            return OptionalInt.empty();
         }
 
         question.startProcessing();
-        return true;
+        return OptionalInt.of(question.getGenerationAttempts());
     }
 
     // AI가 최종 답변을 생성한 후 호출하는 메서드
     // 최종 답변과 프롬프트에 제공한 근거를 하나의 트랜잭션으로 저장한다
-    public Long complete(Long questionId, String content, List<RetrievedKnowledge> sources) {
+    public Long complete(Long questionId, int attempt, String content, List<RetrievedKnowledge> sources) {
         QaQuestion question = getQuestionWithLock(questionId);
 
-        if (question.getStatus() != QaStatus.PROCESSING) {
+        if (question.getStatus() != QaStatus.PROCESSING || !question.isCurrentAttempt(attempt)) {
             throw new GeneralException(QaErrorCode.INVALID_QUESTION_STATUS);
         }
         if (qaAnswerRepository.existsByQuestion(question)) {
@@ -90,30 +98,80 @@ public class QaAiAnswerLifecycleService {
         qaAnswerSourceRepository.saveAll(answerSources);
 
         question.markAsAnswered();
+        eventPublisher.publishEvent(new QaAnswerPublishedEvent(
+                question.getQuestionId(),
+                answer.getAnswerId(),
+                question.getQuestioner().getUserId(),
+                question.getTargetTeam().getTeamId(),
+                null,
+                QaAnswerPublishType.AI_GENERATED
+        ));
         return answer.getAnswerId();
     }
 
     // AI 호출 중 오류가 발생했을 때 호출된다
-    public void fail(Long questionId) {
+    public QaAiFailureOutcome fail(Long questionId, int attempt) {
         QaQuestion question = getQuestionWithLock(questionId);
 
-        // 완료 처리와 실패 처리가 경합한 경우 완료된 질문을 다시 FAILED로 바꾸지 않는다.
-        if (question.getStatus() == QaStatus.PROCESSING) {
-            question.markAsFailed();
+        // 이전 시도의 늦은 결과가 현재 재시도 상태를 변경하지 못하도록 차단한다.
+        if (question.getStatus() != QaStatus.PROCESSING || !question.isCurrentAttempt(attempt)) {
+            return QaAiFailureOutcome.IGNORED;
         }
+
+        if (question.canRetry(maxGenerationAttempts)) {
+            question.markAsFailed();
+            return QaAiFailureOutcome.RETRYABLE;
+        }
+
+        finalizeManualAnswer(question);
+        return QaAiFailureOutcome.FINALIZED;
     }
 
-    /** 오래 멈춘 작업을 재시도 가능한 상태로 바꾸고, 이벤트 재발행 여부를 반환한다. */
-    public boolean prepareRecovery(Long questionId, LocalDateTime threshold) {
+    /** 오래 멈춘 작업을 재시도하거나 최종 실패 상태로 확정한다. */
+    public QaAiRecoveryOutcome prepareRecovery(Long questionId, LocalDateTime threshold) {
         QaQuestion question = getQuestionWithLock(questionId);
+        QaStatus status = question.getStatus();
 
-        if (question.getUpdatedAt().isAfter(threshold) || !question.canRetry(maxGenerationAttempts)) {
-            return false;
+        if (question.getUpdatedAt().isAfter(threshold)
+                || status == QaStatus.ANSWERED
+                || status == QaStatus.MANUAL_REQUIRED) {
+            return QaAiRecoveryOutcome.NONE;
         }
-        if (question.getStatus() == QaStatus.PROCESSING) {
+
+        if (!question.canRetry(maxGenerationAttempts)) {
+            if (status == QaStatus.PROCESSING || status == QaStatus.FAILED) {
+                finalizeManualAnswer(question);
+                return QaAiRecoveryOutcome.FINALIZED;
+            }
+            return QaAiRecoveryOutcome.NONE;
+        }
+
+        if (status == QaStatus.PROCESSING) {
             question.markAsFailed();
+            return QaAiRecoveryOutcome.RETRY;
         }
-        return question.getStatus() == QaStatus.PENDING || question.getStatus() == QaStatus.FAILED;
+        return status == QaStatus.PENDING || status == QaStatus.FAILED
+                ? QaAiRecoveryOutcome.RETRY
+                : QaAiRecoveryOutcome.NONE;
+    }
+
+    private void finalizeManualAnswer(QaQuestion question) {
+        if (qaAnswerRepository.existsByQuestion(question)) {
+            throw new GeneralException(QaErrorCode.ALREADY_ANSWERED);
+        }
+
+        question.markAsManualRequired();
+        QaAnswer notice = qaAnswerRepository.save(
+                QaAnswer.createSystemNotice(question, MANUAL_ANSWER_NOTICE)
+        );
+
+        eventPublisher.publishEvent(new QaAiFinalFailureEvent(
+                question.getQuestionId(),
+                question.getQuestioner().getUserId(),
+                question.getTargetTeam().getTeamId(),
+                notice.getAnswerId(),
+                notice.getContent()
+        ));
     }
 
     private List<Integer> citedSourceIndexes(String content, int sourceCount) {

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaAiAnswerLifecycleService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaAiAnswerLifecycleService.java
@@ -41,7 +41,7 @@ public class QaAiAnswerLifecycleService {
 
     private static final Pattern CITATION_PATTERN = Pattern.compile("\\[근거\\s*(\\d+)]");
     public static final String MANUAL_ANSWER_NOTICE =
-            "AI 답변 생성이 원활하지 않아 대상 팀에 답변을 요청했습니다. 팀원이 확인 후 직접 답변드릴 예정입니다.";
+            "담당 팀원이 질문을 확인하고 있습니다. 답변이 등록되면 알려드리겠습니다.";
 
     private final QaQuestionRepository qaQuestionRepository;
     private final QaAnswerRepository qaAnswerRepository;

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaAiFailureOutcome.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaAiFailureOutcome.java
@@ -1,0 +1,7 @@
+package com._penLearning.Noddi.domain.qa.service;
+
+public enum QaAiFailureOutcome {
+    RETRYABLE,
+    FINALIZED,
+    IGNORED
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaAiRecoveryOutcome.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaAiRecoveryOutcome.java
@@ -1,0 +1,7 @@
+package com._penLearning.Noddi.domain.qa.service;
+
+public enum QaAiRecoveryOutcome {
+    RETRY,
+    FINALIZED,
+    NONE
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaAnswerStreamService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaAnswerStreamService.java
@@ -55,7 +55,7 @@ public class QaAnswerStreamService {
      * 기존 SSE 연결 목록은 유지한다. 따라서 자동 재시도가 시작되더라도
      * 사용자는 같은 연결에서 새 답변을 받을 수 있다.
      */
-    public void start(Long questionId) {
+    public void start(Long questionId, int attempt) {
         StreamSession session = sessions.computeIfAbsent(
                 questionId,
                 ignored -> new StreamSession()
@@ -63,6 +63,12 @@ public class QaAnswerStreamService {
 
         //여러 스레드가 동시에 실행하지 못하게 세션별로 잠금
         synchronized (session) {
+            // 이전 시도의 늦은 시작 요청이 현재 재시도 세션을 되돌리지 못하게 한다.
+            if (attempt < session.activeAttempt) {
+                return;
+            }
+
+            session.activeAttempt = attempt;
             session.content.setLength(0);
             session.terminalEvent = null;
             session.terminatedAt = null;
@@ -175,7 +181,8 @@ public class QaAnswerStreamService {
                         emitter,
                         QaAnswerStreamEventDto.snapshot(
                                 questionId,
-                                session.content.toString()
+                                session.content.toString(),
+                                session.activeAttempt
                         )
                 );
             }
@@ -187,7 +194,7 @@ public class QaAnswerStreamService {
     /**
      * AI가 생성한 답변 조각 하나를 누적하고 모든 구독자에게 전달한다.
      */
-    public void publishChunk(Long questionId, String delta) {
+    public void publishChunk(Long questionId, int attempt, String delta) {
         /*
          * 공백 문자열도 AI 답변 구성에 필요할 수 있다.
          *
@@ -205,9 +212,9 @@ public class QaAnswerStreamService {
 
         synchronized (session) {
             /*
-             * AI 답변이 종료된 이후 뒤늦게 도착한 chunk는 무시한다.
+             * AI 답변이 종료되었거나 이전 재시도에서 뒤늦게 도착한 chunk는 무시한다.
              */
-            if (session.terminalEvent != null) {
+            if (session.terminalEvent != null || session.activeAttempt != attempt) {
                 return;
             }
 
@@ -215,7 +222,7 @@ public class QaAnswerStreamService {
 
             broadcast(
                     session,
-                    QaAnswerStreamEventDto.chunk(questionId, delta)
+                    QaAnswerStreamEventDto.chunk(questionId, delta, attempt)
             );
         }
     }
@@ -429,6 +436,9 @@ public class QaAnswerStreamService {
      * 일시적인 상태이므로 QaAnswerStreamService 내부 클래스로 둔다.
      */
     private static class StreamSession {
+
+        // 현재 SSE 세션이 받아들일 AI 생성 시도 번호
+        private int activeAttempt;
 
         // 현재까지 생성된 답변 전체
         private final StringBuilder content = new StringBuilder();

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaAnswerStreamService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaAnswerStreamService.java
@@ -1,6 +1,7 @@
 package com._penLearning.Noddi.domain.qa.service;
 
 import com._penLearning.Noddi.domain.qa.dto.QaAnswerStreamEventDto;
+import com._penLearning.Noddi.domain.qa.dto.QaResponseStatus;
 import com._penLearning.Noddi.domain.qa.entity.QaStatus;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -99,7 +100,7 @@ public class QaAnswerStreamService {
         if (currentStatus == QaStatus.ANSWERED) {
             sendEvent(
                     emitter,
-                    QaAnswerStreamEventDto.connected(questionId, currentStatus)
+                    QaAnswerStreamEventDto.connected(questionId, QaResponseStatus.from(currentStatus, false))
             );
             sendEvent(
                     emitter,
@@ -116,11 +117,11 @@ public class QaAnswerStreamService {
         if (currentStatus == QaStatus.MANUAL_REQUIRED) {
             sendEvent(
                     emitter,
-                    QaAnswerStreamEventDto.connected(questionId, currentStatus)
+                    QaAnswerStreamEventDto.connected(questionId, QaResponseStatus.TEAM_ANSWER_PENDING)
             );
             sendEvent(
                     emitter,
-                    QaAnswerStreamEventDto.manualRequired(
+                    QaAnswerStreamEventDto.teamAnswerPending(
                             questionId,
                             answerId,
                             answerContent
@@ -149,7 +150,7 @@ public class QaAnswerStreamService {
 
             boolean connected = sendEvent(
                     emitter,
-                    QaAnswerStreamEventDto.connected(questionId, currentStatus)
+                    QaAnswerStreamEventDto.connected(questionId, QaResponseStatus.from(currentStatus, true))
             );
 
             if (!connected) {
@@ -283,14 +284,14 @@ public class QaAnswerStreamService {
     }
 
     /** AI 최종 실패와 대상 팀 직접 답변 대기 상태를 전송하고 연결을 종료한다. */
-    public void publishManualRequired(Long questionId, Long answerId, String content) {
+    public void publishTeamAnswerPending(Long questionId, Long answerId, String content) {
         StreamSession session = sessions.computeIfAbsent(
                 questionId,
                 ignored -> new StreamSession()
         );
         terminate(
                 session,
-                QaAnswerStreamEventDto.manualRequired(questionId, answerId, content)
+                QaAnswerStreamEventDto.teamAnswerPending(questionId, answerId, content)
         );
     }
 

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaAnswerStreamService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaAnswerStreamService.java
@@ -107,14 +107,18 @@ public class QaAnswerStreamService {
             return emitter;
         }
 
-        if (currentStatus == QaStatus.FAILED) {
+        if (currentStatus == QaStatus.MANUAL_REQUIRED) {
             sendEvent(
                     emitter,
                     QaAnswerStreamEventDto.connected(questionId, currentStatus)
             );
             sendEvent(
                     emitter,
-                    QaAnswerStreamEventDto.failed(questionId)
+                    QaAnswerStreamEventDto.manualRequired(
+                            questionId,
+                            answerId,
+                            answerContent
+                    )
             );
             emitter.complete();
             return emitter;
@@ -254,6 +258,32 @@ public class QaAnswerStreamService {
         terminate(
                 session,
                 QaAnswerStreamEventDto.failed(questionId)
+        );
+    }
+
+    /** 자동 재시도가 예정된 실패를 알리되 SSE 연결은 유지한다. */
+    public void publishRetrying(Long questionId, int attempt) {
+        StreamSession session = sessions.computeIfAbsent(
+                questionId,
+                ignored -> new StreamSession()
+        );
+
+        synchronized (session) {
+            if (session.terminalEvent == null) {
+                broadcast(session, QaAnswerStreamEventDto.retrying(questionId, attempt));
+            }
+        }
+    }
+
+    /** AI 최종 실패와 대상 팀 직접 답변 대기 상태를 전송하고 연결을 종료한다. */
+    public void publishManualRequired(Long questionId, Long answerId, String content) {
+        StreamSession session = sessions.computeIfAbsent(
+                questionId,
+                ignored -> new StreamSession()
+        );
+        terminate(
+                session,
+                QaAnswerStreamEventDto.manualRequired(questionId, answerId, content)
         );
     }
 

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaAnswerStreamSubscriptionService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaAnswerStreamSubscriptionService.java
@@ -57,7 +57,8 @@ public class QaAnswerStreamSubscriptionService {
          * ANSWERED 상태라면 메모리 스트림이 이미 사라졌거나 서버가 재시작됐어도
          * DB에 저장된 최종 답변을 즉시 전달할 수 있어야 한다.
          */
-        if (question.getStatus() == QaStatus.ANSWERED) {
+        if (question.getStatus() == QaStatus.ANSWERED
+                || question.getStatus() == QaStatus.MANUAL_REQUIRED) {
             QaAnswer answer = qaAnswerRepository.findByQuestion(question)
                     .orElseThrow(() ->
                             new GeneralException(QaErrorCode.ANSWER_NOT_FOUND)

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaAnswerUpdateService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaAnswerUpdateService.java
@@ -4,16 +4,24 @@ import com._penLearning.Noddi.domain.qa.code.QaErrorCode;
 import com._penLearning.Noddi.domain.qa.dto.QaRequestDto;
 import com._penLearning.Noddi.domain.qa.dto.QaResponseDto;
 import com._penLearning.Noddi.domain.qa.entity.QaAnswer;
+import com._penLearning.Noddi.domain.qa.entity.QaQuestion;
+import com._penLearning.Noddi.domain.qa.entity.QaStatus;
+import com._penLearning.Noddi.domain.qa.event.QaAnswerPublishedEvent;
+import com._penLearning.Noddi.domain.qa.event.QaAnswerPublishType;
 import com._penLearning.Noddi.domain.qa.repository.QaAnswerRepository;
 import com._penLearning.Noddi.domain.qa.repository.QaAnswerSourceRepository;
+import com._penLearning.Noddi.domain.qa.repository.QaQuestionRepository;
 import com._penLearning.Noddi.domain.team.repository.TeamMemberRepository;
 import com._penLearning.Noddi.domain.user.code.UserErrorCode;
 import com._penLearning.Noddi.domain.user.entity.User;
 import com._penLearning.Noddi.domain.user.repository.UserRepository;
 import com._penLearning.Noddi.global.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
 
 
 // 대상 팀 구성원이 AI 답변을 수정한다.
@@ -24,8 +32,10 @@ public class QaAnswerUpdateService {
 
     private final QaAnswerRepository qaAnswerRepository;
     private final QaAnswerSourceRepository qaAnswerSourceRepository;
+    private final QaQuestionRepository qaQuestionRepository;
     private final UserRepository userRepository;
     private final TeamMemberRepository teamMemberRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public QaResponseDto.ReviseAnswer revise(
@@ -43,9 +53,37 @@ public class QaAnswerUpdateService {
             throw new GeneralException(QaErrorCode.NOT_TARGET_TEAM_MEMBER);
         }
 
-        answer.revise(request.getContent(), reviser);
+        QaQuestion question = qaQuestionRepository.findByIdWithLock(
+                        answer.getQuestion().getQuestionId()
+                )
+                .orElseThrow(() -> new GeneralException(QaErrorCode.QUESTION_NOT_FOUND));
+
+        QaAnswerPublishType publishType;
+        if (question.getStatus() == QaStatus.MANUAL_REQUIRED) {
+            answer.provideByTeam(request.getContent());
+            question.completeManualAnswer();
+            publishType = QaAnswerPublishType.TEAM_PROVIDED;
+        } else if (question.getStatus() == QaStatus.ANSWERED) {
+            // 네트워크 재전송 등으로 동일한 내용이 들어오면 수정·출처 삭제·알림 이벤트를 반복하지 않는다.
+            if (Objects.equals(answer.getContent(), request.getContent())) {
+                return QaResponseDto.ReviseAnswer.from(answer);
+            }
+            answer.revise(request.getContent(), reviser);
+            publishType = QaAnswerPublishType.ANSWER_REVISED;
+        } else {
+            throw new GeneralException(QaErrorCode.INVALID_QUESTION_STATUS);
+        }
+
         // 수정본은 AI 원문과 별개의 최종 답변이므로 기존 AI 인용 출처를 더 이상 노출하지 않는다.
         qaAnswerSourceRepository.deleteAllByAnswerId(answer.getAnswerId());
+        eventPublisher.publishEvent(new QaAnswerPublishedEvent(
+                question.getQuestionId(),
+                answer.getAnswerId(),
+                question.getQuestioner().getUserId(),
+                question.getTargetTeam().getTeamId(),
+                reviser.getUserId(),
+                publishType
+        ));
         return QaResponseDto.ReviseAnswer.from(answer);
     }
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaQuestionQueryService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaQuestionQueryService.java
@@ -6,12 +6,14 @@ import com._penLearning.Noddi.domain.qa.dto.QaResponseDto;
 import com._penLearning.Noddi.domain.qa.entity.QaAnswer;
 import com._penLearning.Noddi.domain.qa.entity.QaAnswerSource;
 import com._penLearning.Noddi.domain.qa.entity.QaQuestion;
+import com._penLearning.Noddi.domain.qa.entity.QaStatus;
 import com._penLearning.Noddi.domain.qa.repository.QaAnswerRepository;
 import com._penLearning.Noddi.domain.qa.repository.QaAnswerSourceRepository;
 import com._penLearning.Noddi.domain.qa.repository.QaQuestionRepository;
 import com._penLearning.Noddi.domain.team.code.TeamErrorCode;
 import com._penLearning.Noddi.domain.team.entity.Team;
 import com._penLearning.Noddi.domain.team.repository.TeamRepository;
+import com._penLearning.Noddi.domain.team.repository.TeamMemberRepository;
 import com._penLearning.Noddi.domain.user.code.UserErrorCode;
 import com._penLearning.Noddi.domain.user.entity.User;
 import com._penLearning.Noddi.domain.user.repository.UserRepository;
@@ -45,6 +47,7 @@ public class QaQuestionQueryService {
     private final UserRepository userRepository;
     private final TeamRepository teamRepository;
     private final ProjectMemberRepository projectMemberRepository;
+    private final TeamMemberRepository teamMemberRepository;
 
     // 내가 작성한 질문 목록 조회
     public Page<QaResponseDto.QuestionInfo> getMyQuestions(Long userId, Pageable pageable) {
@@ -70,7 +73,8 @@ public class QaQuestionQueryService {
 
         Team targetTeam = getTeamOrThrow(teamId);
 
-        validateProjectMembership(requesterId, targetTeam);
+        User requester = validateProjectMembership(requesterId, targetTeam);
+        boolean targetTeamMember = teamMemberRepository.existsByTeamAndUser(targetTeam, requester);
 
         List<QaQuestion> fetchedQuestions = qaQuestionRepository.findFeedByTargetTeam(
                 targetTeam, cursor, PageRequest.of(0, size + 1));
@@ -105,7 +109,9 @@ public class QaQuestionQueryService {
                     List<QaAnswerSource> answerSources =
                             answer == null ? List.of() : sourceByAnswerId.getOrDefault(answer.getAnswerId(), List.of());
 
-                    return QaResponseDto.FeedItem.of(question, answer, answerSources);
+                    boolean canAnswer = targetTeamMember
+                            && question.getStatus() == QaStatus.MANUAL_REQUIRED;
+                    return QaResponseDto.FeedItem.of(question, answer, answerSources, canAnswer);
                 })
                 .collect(Collectors.toCollection(ArrayList::new));
 
@@ -120,13 +126,15 @@ public class QaQuestionQueryService {
         QaQuestion question = qaQuestionRepository.findByIdWithTeam(questionId)
                 .orElseThrow(() -> new GeneralException(QaErrorCode.QUESTION_NOT_FOUND));
 
-        validateProjectMembership(requesterId, question.getTargetTeam());
+        User requester = validateProjectMembership(requesterId, question.getTargetTeam());
+        boolean canAnswer = question.getStatus() == QaStatus.MANUAL_REQUIRED
+                && teamMemberRepository.existsByTeamAndUser(question.getTargetTeam(), requester);
 
         QaAnswer answer = qaAnswerRepository.findByQuestion(question).orElse(null);
         List<QaAnswerSource> sources = answer == null
                 ? List.of()
                 : qaAnswerSourceRepository.findByAnswer_AnswerIdOrderByCitationIndexAsc(answer.getAnswerId());
-        return QaResponseDto.QuestionDetail.of(question, answer, sources);
+        return QaResponseDto.QuestionDetail.of(question, answer, sources, canAnswer);
     }
 
     private Team getTeamOrThrow(Long teamId) {
@@ -135,13 +143,14 @@ public class QaQuestionQueryService {
     }
 
     // 공통 프로젝트 권한 검증 로직
-    private void validateProjectMembership(Long requesterId, Team targetTeam) {
+    private User validateProjectMembership(Long requesterId, Team targetTeam) {
         User requester = userRepository.findById(requesterId)
                 .orElseThrow(() -> new GeneralException(UserErrorCode.USER_NOT_FOUND));
 
         if (!projectMemberRepository.existsByProjectAndUser(targetTeam.getProject(), requester)) {
             throw new GeneralException(QaErrorCode.NOT_PROJECT_MEMBER);
         }
+        return requester;
     }
 
     private void validateFeedRequest(Long cursor, int size) {

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaQuestionQueryService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/service/QaQuestionQueryService.java
@@ -62,10 +62,11 @@ public class QaQuestionQueryService {
     public Page<QaResponseDto.QuestionInfo> getTeamQuestions(Long requesterId, Long teamId, Pageable pageable) {
         Team targetTeam = getTeamOrThrow(teamId);
 
-        validateProjectMembership(requesterId, targetTeam);
+        User requester = validateProjectMembership(requesterId, targetTeam);
+        boolean targetTeamMember = teamMemberRepository.existsByTeamAndUser(targetTeam, requester);
 
         return qaQuestionRepository.findAllByTargetTeamWithUser(targetTeam, pageable)
-                .map(QaResponseDto.QuestionInfo::from);
+                .map(question -> QaResponseDto.QuestionInfo.from(question, targetTeamMember));
     }
 
     public QaResponseDto.Feed  getTeamFeed(Long requesterId, Long teamId, Long cursor, int size) {
@@ -115,7 +116,13 @@ public class QaQuestionQueryService {
 
                     boolean canAnswer = targetTeamMember
                             && question.getStatus() == QaStatus.MANUAL_REQUIRED;
-                    return QaResponseDto.FeedItem.of(question, answer, answerSources, canAnswer);
+                    return QaResponseDto.FeedItem.of(
+                            question,
+                            answer,
+                            answerSources,
+                            canAnswer,
+                            targetTeamMember
+                    );
                 })
                 .collect(Collectors.toCollection(ArrayList::new));
 
@@ -138,7 +145,13 @@ public class QaQuestionQueryService {
         List<QaAnswerSource> sources = answer != null && targetTeamMember && !answer.isRevised()
                 ? qaAnswerSourceRepository.findByAnswer_AnswerIdOrderByCitationIndexAsc(answer.getAnswerId())
                 : List.of();
-        return QaResponseDto.QuestionDetail.of(question, answer, sources, canAnswer);
+        return QaResponseDto.QuestionDetail.of(
+                question,
+                answer,
+                sources,
+                canAnswer,
+                targetTeamMember
+        );
     }
 
     private Team getTeamOrThrow(Long teamId) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -95,6 +95,8 @@ openai:
 qa:
   ai:
     max-generation-attempts: ${QA_AI_MAX_GENERATION_ATTEMPTS:3}
+    # 정상적인 AI 호출 실패는 2초, 4초 순으로 짧게 재시도한다.
+    retry-base-delay-millis: ${QA_AI_RETRY_BASE_DELAY_MILLIS:2000}
   rag:
     top-k: ${QA_RAG_TOP_K:5} # 사용자의 질문과 가장 유사한 청크를 몇 개까지 가져올 것인지 설정
     similarity-threshold: ${QA_RAG_SIMILARITY_THRESHOLD:0.2} # 현재 검증 데이터 기준 하한선이며 평가 결과에 따라 환경변수로 조정

--- a/src/test/java/com/_penLearning/Noddi/domain/qa/controller/QaControllerTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/qa/controller/QaControllerTest.java
@@ -285,7 +285,7 @@ class QaControllerTest {
 
         QaResponseDto.FeedItem item = QaResponseDto.FeedItem.builder()
                 .question(question)
-                .status(QaStatus.ANSWERED)
+                .status(com._penLearning.Noddi.domain.qa.dto.QaResponseStatus.ANSWERED)
                 .answer(answer)
                 .build();
 

--- a/src/test/java/com/_penLearning/Noddi/domain/qa/event/QaQuestionCreatedEventHandlerTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/qa/event/QaQuestionCreatedEventHandlerTest.java
@@ -5,7 +5,9 @@ import com._penLearning.Noddi.domain.qa.rag.generation.QaRagAnswerGenerator;
 import com._penLearning.Noddi.domain.qa.rag.generation.QaRagGeneration;
 import com._penLearning.Noddi.domain.qa.rag.retrieval.RetrievedKnowledge;
 import com._penLearning.Noddi.domain.qa.repository.QaQuestionRepository;
+import com._penLearning.Noddi.domain.qa.scheduler.QaAiRetryScheduler;
 import com._penLearning.Noddi.domain.qa.service.QaAiAnswerLifecycleService;
+import com._penLearning.Noddi.domain.qa.service.QaAiFailureOutcome;
 import com._penLearning.Noddi.domain.qa.service.QaAnswerStreamService;
 import com._penLearning.Noddi.domain.team.entity.Team;
 import org.junit.jupiter.api.Test;
@@ -17,6 +19,7 @@ import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -39,6 +42,9 @@ class QaQuestionCreatedEventHandlerTest {
     private QaAnswerStreamService answerStreamService;
 
     @Mock
+    private QaAiRetryScheduler retryScheduler;
+
+    @Mock
     private QaQuestion question;
 
     @Mock
@@ -48,7 +54,7 @@ class QaQuestionCreatedEventHandlerTest {
     void combinesStreamChunksAndSavesCompletedAnswer() {
         // Given: AI가 두 개의 텍스트 조각을 순서대로 생성한다.
         QaQuestionCreatedEventHandler handler = createHandler();
-        when(answerLifecycleService.tryStart(1L)).thenReturn(true);
+        when(answerLifecycleService.tryStart(1L)).thenReturn(OptionalInt.of(1));
         when(qaQuestionRepository.findByIdWithTeam(1L)).thenReturn(Optional.of(question));
         when(question.getTargetTeam()).thenReturn(team);
         when(team.getTeamId()).thenReturn(10L);
@@ -61,6 +67,7 @@ class QaQuestionCreatedEventHandlerTest {
                 )));
         when(answerLifecycleService.complete(
                 1L,
+                1,
                 "8월 20일에 배포합니다. [근거 1]",
                 sources
         )).thenReturn(201L);
@@ -74,13 +81,13 @@ class QaQuestionCreatedEventHandlerTest {
         verify(answerStreamService).publishChunk(1L, "배포합니다. [근거 1]");
 
         // 조각 전체를 결합한 최종 답변을 DB에 저장한 뒤 COMPLETED 이벤트를 발행한다.
-        verify(answerLifecycleService).complete(1L, "8월 20일에 배포합니다. [근거 1]", sources);
+        verify(answerLifecycleService).complete(1L, 1, "8월 20일에 배포합니다. [근거 1]", sources);
         verify(answerStreamService).publishCompleted(
                 1L,
                 201L,
                 "8월 20일에 배포합니다. [근거 1]"
         );
-        verify(answerLifecycleService, never()).fail(1L);
+        verify(answerLifecycleService, never()).fail(1L, 1);
         verify(answerStreamService, never()).publishFailed(1L);
     }
 
@@ -88,7 +95,8 @@ class QaQuestionCreatedEventHandlerTest {
     void marksQuestionAsFailedWhenGenerationFails() {
         // Given: OpenAI 답변 스트림 처리 중 예외가 발생한다.
         QaQuestionCreatedEventHandler handler = createHandler();
-        when(answerLifecycleService.tryStart(1L)).thenReturn(true);
+        when(answerLifecycleService.tryStart(1L)).thenReturn(OptionalInt.of(1));
+        when(answerLifecycleService.fail(1L, 1)).thenReturn(QaAiFailureOutcome.RETRYABLE);
         when(qaQuestionRepository.findByIdWithTeam(1L)).thenReturn(Optional.of(question));
         when(question.getTargetTeam()).thenReturn(team);
         when(team.getTeamId()).thenReturn(10L);
@@ -104,10 +112,12 @@ class QaQuestionCreatedEventHandlerTest {
 
         // Then: 질문을 FAILED로 변경하고 SSE 구독자에게도 실패 이벤트를 보낸다.
         verify(answerStreamService).start(1L);
-        verify(answerLifecycleService).fail(1L);
-        verify(answerStreamService).publishFailed(1L);
+        verify(answerLifecycleService).fail(1L, 1);
+        verify(answerStreamService).publishRetrying(1L, 1);
+        verify(retryScheduler).scheduleRetry(1L, 1);
         verify(answerLifecycleService, never()).complete(
                 org.mockito.ArgumentMatchers.anyLong(),
+                org.mockito.ArgumentMatchers.anyInt(),
                 org.mockito.ArgumentMatchers.anyString(),
                 org.mockito.ArgumentMatchers.anyList()
         );
@@ -122,7 +132,7 @@ class QaQuestionCreatedEventHandlerTest {
     void ignoresDuplicatedEventWhenGenerationCannotStart() {
         // Given: 동일 질문의 AI 작업이 이미 실행 중이거나 완료되어 tryStart가 false를 반환한다.
         QaQuestionCreatedEventHandler handler = createHandler();
-        when(answerLifecycleService.tryStart(1L)).thenReturn(false);
+        when(answerLifecycleService.tryStart(1L)).thenReturn(OptionalInt.empty());
 
         handler.handle(new QaQuestionCreatedEvent(1L));
 
@@ -131,10 +141,14 @@ class QaQuestionCreatedEventHandlerTest {
         verifyNoInteractions(answerStreamService);
         verify(answerLifecycleService, never()).complete(
                 org.mockito.ArgumentMatchers.anyLong(),
+                org.mockito.ArgumentMatchers.anyInt(),
                 org.mockito.ArgumentMatchers.anyString(),
                 org.mockito.ArgumentMatchers.anyList()
         );
-        verify(answerLifecycleService, never()).fail(org.mockito.ArgumentMatchers.anyLong());
+        verify(answerLifecycleService, never()).fail(
+                org.mockito.ArgumentMatchers.anyLong(),
+                org.mockito.ArgumentMatchers.anyInt()
+        );
     }
 
     private QaQuestionCreatedEventHandler createHandler() {
@@ -142,7 +156,8 @@ class QaQuestionCreatedEventHandlerTest {
                 qaQuestionRepository,
                 answerLifecycleService,
                 answerGenerator,
-                answerStreamService
+                answerStreamService,
+                retryScheduler
         );
     }
 }

--- a/src/test/java/com/_penLearning/Noddi/domain/qa/event/QaQuestionCreatedEventHandlerTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/qa/event/QaQuestionCreatedEventHandlerTest.java
@@ -76,9 +76,9 @@ class QaQuestionCreatedEventHandlerTest {
         handler.handle(new QaQuestionCreatedEvent(1L));
 
         // Then: 스트림을 초기화하고 AI가 생성한 각 조각을 순서대로 SSE 서비스에 전달한다.
-        verify(answerStreamService).start(1L);
-        verify(answerStreamService).publishChunk(1L, "8월 20일에 ");
-        verify(answerStreamService).publishChunk(1L, "배포합니다. [근거 1]");
+        verify(answerStreamService).start(1L, 1);
+        verify(answerStreamService).publishChunk(1L, 1, "8월 20일에 ");
+        verify(answerStreamService).publishChunk(1L, 1, "배포합니다. [근거 1]");
 
         // 조각 전체를 결합한 최종 답변을 DB에 저장한 뒤 COMPLETED 이벤트를 발행한다.
         verify(answerLifecycleService).complete(1L, 1, "8월 20일에 배포합니다. [근거 1]", sources);
@@ -111,7 +111,7 @@ class QaQuestionCreatedEventHandlerTest {
         handler.handle(new QaQuestionCreatedEvent(1L));
 
         // Then: 질문을 FAILED로 변경하고 SSE 구독자에게도 실패 이벤트를 보낸다.
-        verify(answerStreamService).start(1L);
+        verify(answerStreamService).start(1L, 1);
         verify(answerLifecycleService).fail(1L, 1);
         verify(answerStreamService).publishRetrying(1L, 1);
         verify(retryScheduler).scheduleRetry(1L, 1);

--- a/src/test/java/com/_penLearning/Noddi/domain/qa/scheduler/QaAiRecoverySchedulerTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/qa/scheduler/QaAiRecoverySchedulerTest.java
@@ -5,6 +5,7 @@ import com._penLearning.Noddi.domain.qa.entity.QaStatus;
 import com._penLearning.Noddi.domain.qa.event.QaQuestionCreatedEvent;
 import com._penLearning.Noddi.domain.qa.repository.QaQuestionRepository;
 import com._penLearning.Noddi.domain.qa.service.QaAiAnswerLifecycleService;
+import com._penLearning.Noddi.domain.qa.service.QaAiRecoveryOutcome;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -39,6 +40,9 @@ class QaAiRecoverySchedulerTest {
     @Mock
     private QaQuestion question;
 
+    @Mock
+    private QaQuestion anotherQuestion;
+
     @Test
     void republishesEventOnlyForRecoverableQuestion() {
         QaAiRecoveryScheduler scheduler = new QaAiRecoveryScheduler(
@@ -53,7 +57,8 @@ class QaAiRecoverySchedulerTest {
                 org.mockito.ArgumentMatchers.<Collection<QaStatus>>any(),
                 any(LocalDateTime.class)
         )).thenReturn(List.of(question));
-        when(lifecycleService.prepareRecovery(eq(7L), any(LocalDateTime.class))).thenReturn(true);
+        when(lifecycleService.prepareRecovery(eq(7L), any(LocalDateTime.class)))
+                .thenReturn(QaAiRecoveryOutcome.RETRY);
 
         scheduler.retryStalledAnswers();
 
@@ -77,10 +82,39 @@ class QaAiRecoverySchedulerTest {
                 org.mockito.ArgumentMatchers.<Collection<QaStatus>>any(),
                 any(LocalDateTime.class)
         )).thenReturn(List.of(question));
-        when(lifecycleService.prepareRecovery(eq(7L), any(LocalDateTime.class))).thenReturn(false);
+        when(lifecycleService.prepareRecovery(eq(7L), any(LocalDateTime.class)))
+                .thenReturn(QaAiRecoveryOutcome.NONE);
 
         scheduler.retryStalledAnswers();
 
         verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    void continuesRecoveringOtherQuestionsWhenOneCandidateFails() {
+        QaAiRecoveryScheduler scheduler = new QaAiRecoveryScheduler(
+                questionRepository,
+                lifecycleService,
+                eventPublisher
+        );
+        ReflectionTestUtils.setField(scheduler, "processingTimeoutMinutes", 10L);
+
+        when(question.getQuestionId()).thenReturn(7L);
+        when(anotherQuestion.getQuestionId()).thenReturn(8L);
+        when(questionRepository.findTop100ByStatusInAndUpdatedAtBeforeOrderByUpdatedAtAsc(
+                org.mockito.ArgumentMatchers.<Collection<QaStatus>>any(),
+                any(LocalDateTime.class)
+        )).thenReturn(List.of(question, anotherQuestion));
+        when(lifecycleService.prepareRecovery(eq(7L), any(LocalDateTime.class)))
+                .thenThrow(new RuntimeException("lock timeout"));
+        when(lifecycleService.prepareRecovery(eq(8L), any(LocalDateTime.class)))
+                .thenReturn(QaAiRecoveryOutcome.RETRY);
+
+        scheduler.retryStalledAnswers();
+
+        ArgumentCaptor<QaQuestionCreatedEvent> eventCaptor =
+                ArgumentCaptor.forClass(QaQuestionCreatedEvent.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        assertThat(eventCaptor.getValue().questionId()).isEqualTo(8L);
     }
 }

--- a/src/test/java/com/_penLearning/Noddi/domain/qa/service/QaAiAnswerLifecycleServiceTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/qa/service/QaAiAnswerLifecycleServiceTest.java
@@ -5,15 +5,21 @@ import com._penLearning.Noddi.domain.qa.entity.QaAnswerSource;
 import com._penLearning.Noddi.domain.qa.entity.QaQuestion;
 import com._penLearning.Noddi.domain.qa.entity.QaStatus;
 import com._penLearning.Noddi.domain.qa.entity.SourceType;
+import com._penLearning.Noddi.domain.qa.event.QaAiFinalFailureEvent;
+import com._penLearning.Noddi.domain.qa.event.QaAnswerPublishedEvent;
+import com._penLearning.Noddi.domain.qa.event.QaAnswerPublishType;
 import com._penLearning.Noddi.domain.qa.rag.retrieval.RetrievedKnowledge;
 import com._penLearning.Noddi.domain.qa.repository.QaAnswerRepository;
 import com._penLearning.Noddi.domain.qa.repository.QaAnswerSourceRepository;
 import com._penLearning.Noddi.domain.qa.repository.QaQuestionRepository;
+import com._penLearning.Noddi.domain.team.entity.Team;
+import com._penLearning.Noddi.domain.user.entity.User;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.util.List;
 import java.util.Optional;
@@ -25,6 +31,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 @ExtendWith(MockitoExtension.class)
 class QaAiAnswerLifecycleServiceTest {
@@ -39,17 +47,27 @@ class QaAiAnswerLifecycleServiceTest {
     private QaAnswerSourceRepository qaAnswerSourceRepository;
 
     @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @Mock
     private QaQuestion question;
 
     @Mock
     private QaAnswer answer;
+
+    @Mock
+    private User questioner;
+
+    @Mock
+    private Team targetTeam;
 
     @Test
     void savesAnswerAndRetrievedSourcesTogether() {
         QaAiAnswerLifecycleService service = new QaAiAnswerLifecycleService(
                 qaQuestionRepository,
                 qaAnswerRepository,
-                qaAnswerSourceRepository
+                qaAnswerSourceRepository,
+                eventPublisher
         );
         List<RetrievedKnowledge> sources = List.of(
                 new RetrievedKnowledge(
@@ -74,11 +92,13 @@ class QaAiAnswerLifecycleServiceTest {
 
         when(qaQuestionRepository.findByIdWithLock(1L)).thenReturn(Optional.of(question));
         when(question.getStatus()).thenReturn(QaStatus.PROCESSING);
+        when(question.isCurrentAttempt(1)).thenReturn(true);
         when(qaAnswerRepository.existsByQuestion(question)).thenReturn(false);
         when(qaAnswerRepository.save(any(QaAnswer.class))).thenReturn(answer);
         when(answer.getAnswerId()).thenReturn(100L);
+        stubAnswerPublishedEventPayload();
 
-        Long answerId = service.complete(1L, "첫 번째 자료만 사용한 답변입니다. [근거 1]", sources);
+        Long answerId = service.complete(1L, 1, "첫 번째 자료만 사용한 답변입니다. [근거 1]", sources);
 
         @SuppressWarnings("unchecked")
         ArgumentCaptor<List<QaAnswerSource>> sourceCaptor = ArgumentCaptor.forClass(List.class);
@@ -103,6 +123,17 @@ class QaAiAnswerLifecycleServiceTest {
                         )
                 );
         verify(question).markAsAnswered();
+        ArgumentCaptor<QaAnswerPublishedEvent> eventCaptor =
+                ArgumentCaptor.forClass(QaAnswerPublishedEvent.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        assertThat(eventCaptor.getValue()).isEqualTo(new QaAnswerPublishedEvent(
+                1L,
+                100L,
+                10L,
+                20L,
+                null,
+                QaAnswerPublishType.AI_GENERATED
+        ));
     }
 
     @Test
@@ -110,7 +141,8 @@ class QaAiAnswerLifecycleServiceTest {
         QaAiAnswerLifecycleService service = new QaAiAnswerLifecycleService(
                 qaQuestionRepository,
                 qaAnswerRepository,
-                qaAnswerSourceRepository
+                qaAnswerSourceRepository,
+                eventPublisher
         );
         List<RetrievedKnowledge> sources = List.of(new RetrievedKnowledge(
                 "knowledge-transcript-20-0",
@@ -124,13 +156,15 @@ class QaAiAnswerLifecycleServiceTest {
 
         when(qaQuestionRepository.findByIdWithLock(1L)).thenReturn(Optional.of(question));
         when(question.getStatus()).thenReturn(QaStatus.PROCESSING);
+        when(question.isCurrentAttempt(1)).thenReturn(true);
         when(qaAnswerRepository.existsByQuestion(question)).thenReturn(false);
 
-        assertThatThrownBy(() -> service.complete(1L, "8월 20일에 배포합니다.", sources))
+        assertThatThrownBy(() -> service.complete(1L, 1, "8월 20일에 배포합니다.", sources))
                 .isInstanceOf(com._penLearning.Noddi.global.exception.GeneralException.class);
 
         verify(qaAnswerRepository, never()).save(any(QaAnswer.class));
         verify(question, never()).markAsAnswered();
+        verify(eventPublisher, never()).publishEvent(any());
     }
 
     @Test
@@ -138,7 +172,8 @@ class QaAiAnswerLifecycleServiceTest {
         QaAiAnswerLifecycleService service = new QaAiAnswerLifecycleService(
                 qaQuestionRepository,
                 qaAnswerRepository,
-                qaAnswerSourceRepository
+                qaAnswerSourceRepository,
+                eventPublisher
         );
         List<RetrievedKnowledge> sources = List.of(new RetrievedKnowledge(
                 "knowledge-transcript-20-0",
@@ -152,12 +187,15 @@ class QaAiAnswerLifecycleServiceTest {
 
         when(qaQuestionRepository.findByIdWithLock(1L)).thenReturn(Optional.of(question));
         when(question.getStatus()).thenReturn(QaStatus.PROCESSING);
+        when(question.isCurrentAttempt(1)).thenReturn(true);
         when(qaAnswerRepository.existsByQuestion(question)).thenReturn(false);
         when(qaAnswerRepository.save(any(QaAnswer.class))).thenReturn(answer);
         when(answer.getAnswerId()).thenReturn(100L);
+        stubAnswerPublishedEventPayload();
 
         Long answerId = service.complete(
                 1L,
+                1,
                 com._penLearning.Noddi.domain.qa.rag.generation.QaRagAnswerGenerator.INSUFFICIENT_EVIDENCE_MESSAGE,
                 sources
         );
@@ -172,16 +210,17 @@ class QaAiAnswerLifecycleServiceTest {
         QaAiAnswerLifecycleService service = new QaAiAnswerLifecycleService(
                 qaQuestionRepository,
                 qaAnswerRepository,
-                qaAnswerSourceRepository
+                qaAnswerSourceRepository,
+                eventPublisher
         );
         LocalDateTime threshold = LocalDateTime.now().minusMinutes(10);
 
         when(qaQuestionRepository.findByIdWithLock(1L)).thenReturn(Optional.of(question));
         when(question.getUpdatedAt()).thenReturn(threshold.minusSeconds(1));
         when(question.canRetry(3)).thenReturn(true);
-        when(question.getStatus()).thenReturn(QaStatus.PROCESSING, QaStatus.FAILED);
+        when(question.getStatus()).thenReturn(QaStatus.PROCESSING);
 
-        assertThat(service.prepareRecovery(1L, threshold)).isTrue();
+        assertThat(service.prepareRecovery(1L, threshold)).isEqualTo(QaAiRecoveryOutcome.RETRY);
         verify(question).markAsFailed();
     }
 
@@ -190,14 +229,85 @@ class QaAiAnswerLifecycleServiceTest {
         QaAiAnswerLifecycleService service = new QaAiAnswerLifecycleService(
                 qaQuestionRepository,
                 qaAnswerRepository,
-                qaAnswerSourceRepository
+                qaAnswerSourceRepository,
+                eventPublisher
         );
         LocalDateTime threshold = LocalDateTime.now().minusMinutes(10);
 
         when(qaQuestionRepository.findByIdWithLock(1L)).thenReturn(Optional.of(question));
         when(question.getUpdatedAt()).thenReturn(threshold.plusSeconds(1));
 
-        assertThat(service.prepareRecovery(1L, threshold)).isFalse();
+        assertThat(service.prepareRecovery(1L, threshold)).isEqualTo(QaAiRecoveryOutcome.NONE);
         verify(question, never()).markAsFailed();
+    }
+
+    @Test
+    void createsSystemNoticeAndPublishesEventAfterThirdFailure() {
+        QaAiAnswerLifecycleService service = new QaAiAnswerLifecycleService(
+                qaQuestionRepository,
+                qaAnswerRepository,
+                qaAnswerSourceRepository,
+                eventPublisher
+        );
+        com._penLearning.Noddi.domain.user.entity.User questioner = mock(
+                com._penLearning.Noddi.domain.user.entity.User.class
+        );
+        com._penLearning.Noddi.domain.team.entity.Team targetTeam = mock(
+                com._penLearning.Noddi.domain.team.entity.Team.class
+        );
+
+        when(qaQuestionRepository.findByIdWithLock(1L)).thenReturn(Optional.of(question));
+        when(question.getStatus()).thenReturn(QaStatus.PROCESSING);
+        when(question.isCurrentAttempt(3)).thenReturn(true);
+        when(question.canRetry(3)).thenReturn(false);
+        when(question.getQuestionId()).thenReturn(1L);
+        when(question.getQuestioner()).thenReturn(questioner);
+        when(question.getTargetTeam()).thenReturn(targetTeam);
+        when(questioner.getUserId()).thenReturn(10L);
+        when(targetTeam.getTeamId()).thenReturn(20L);
+        when(qaAnswerRepository.existsByQuestion(question)).thenReturn(false);
+        when(qaAnswerRepository.save(any(QaAnswer.class))).thenAnswer(invocation -> {
+            QaAnswer saved = invocation.getArgument(0);
+            org.springframework.test.util.ReflectionTestUtils.setField(saved, "answerId", 30L);
+            return saved;
+        });
+
+        QaAiFailureOutcome outcome = service.fail(1L, 3);
+
+        assertThat(outcome).isEqualTo(QaAiFailureOutcome.FINALIZED);
+        verify(question).markAsManualRequired();
+        ArgumentCaptor<QaAiFinalFailureEvent> eventCaptor =
+                ArgumentCaptor.forClass(QaAiFinalFailureEvent.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        assertThat(eventCaptor.getValue().answerId()).isEqualTo(30L);
+        assertThat(eventCaptor.getValue().noticeContent())
+                .isEqualTo(QaAiAnswerLifecycleService.MANUAL_ANSWER_NOTICE);
+    }
+
+    @Test
+    void ignoresFailureFromOlderAttempt() {
+        QaAiAnswerLifecycleService service = new QaAiAnswerLifecycleService(
+                qaQuestionRepository,
+                qaAnswerRepository,
+                qaAnswerSourceRepository,
+                eventPublisher
+        );
+        when(qaQuestionRepository.findByIdWithLock(1L)).thenReturn(Optional.of(question));
+        when(question.getStatus()).thenReturn(QaStatus.PROCESSING);
+        when(question.isCurrentAttempt(1)).thenReturn(false);
+
+        assertThat(service.fail(1L, 1)).isEqualTo(QaAiFailureOutcome.IGNORED);
+
+        verify(question, never()).markAsFailed();
+        verify(question, never()).markAsManualRequired();
+        verifyNoInteractions(qaAnswerRepository, eventPublisher);
+    }
+
+    private void stubAnswerPublishedEventPayload() {
+        when(question.getQuestionId()).thenReturn(1L);
+        when(question.getQuestioner()).thenReturn(questioner);
+        when(question.getTargetTeam()).thenReturn(targetTeam);
+        when(questioner.getUserId()).thenReturn(10L);
+        when(targetTeam.getTeamId()).thenReturn(20L);
     }
 }

--- a/src/test/java/com/_penLearning/Noddi/domain/qa/service/QaAnswerStreamServiceTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/qa/service/QaAnswerStreamServiceTest.java
@@ -202,4 +202,32 @@ class QaAnswerStreamServiceTest {
             );
         }
     }
+
+    @Test
+    void hidesFinalAiFailureAndSendsTeamAnswerPendingEvent() throws Exception {
+        // Given: 질문자가 AI 답변 생성 스트림을 구독하고 있다.
+        service.start(101L, 3);
+        MvcResult subscription = openProcessingStream();
+
+        // When: AI 생성이 최종 실패하여 담당 팀의 직접 답변을 기다리게 된다.
+        service.publishTeamAnswerPending(
+                101L,
+                201L,
+                "담당 팀원이 질문을 확인하고 있습니다. 답변이 등록되면 알려드리겠습니다."
+        );
+
+        mockMvc.perform(asyncDispatch(subscription))
+                .andExpect(status().isOk());
+
+        String body = subscription.getResponse()
+                .getContentAsString(StandardCharsets.UTF_8);
+
+        // Then: 질문자에게 AI 실패 및 수동 답변 필요 상태를 노출하지 않는다.
+        assertThat(body)
+                .contains("event:team_answer_pending")
+                .contains("\"status\":\"TEAM_ANSWER_PENDING\"")
+                .contains("담당 팀원이 질문을 확인하고 있습니다.")
+                .doesNotContain("event:manual_required")
+                .doesNotContain("\"status\":\"MANUAL_REQUIRED\"");
+    }
 }

--- a/src/test/java/com/_penLearning/Noddi/domain/qa/service/QaAnswerStreamServiceTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/qa/service/QaAnswerStreamServiceTest.java
@@ -43,12 +43,12 @@ class QaAnswerStreamServiceTest {
     @Test
     void sendsConnectedChunksAndCompletedEventInOrder() throws Exception {
         // Given: AI 답변 생성이 시작된 질문을 사용자가 먼저 구독한다.
-        service.start(101L);
+        service.start(101L, 1);
         MvcResult subscription = openProcessingStream();
 
         // When: AI가 두 조각을 생성하고 최종 답변을 DB에 저장했다고 알린다.
-        service.publishChunk(101L, "출시일은 ");
-        service.publishChunk(101L, "9월 5일입니다.");
+        service.publishChunk(101L, 1, "출시일은 ");
+        service.publishChunk(101L, 1, "9월 5일입니다.");
         service.publishCompleted(
                 101L,
                 201L,
@@ -84,12 +84,12 @@ class QaAnswerStreamServiceTest {
     @Test
     void sendsSnapshotBeforeNewChunksToLateSubscriber() throws Exception {
         // Given: 구독자가 접속하기 전에 AI가 답변 일부를 이미 생성했다.
-        service.start(101L);
-        service.publishChunk(101L, "이미 생성된 답변");
+        service.start(101L, 1);
+        service.publishChunk(101L, 1, "이미 생성된 답변");
 
         // When: 사용자가 뒤늦게 구독한 뒤 새로운 조각과 완료 이벤트가 발생한다.
         MvcResult subscription = openProcessingStream();
-        service.publishChunk(101L, " 뒤의 조각");
+        service.publishChunk(101L, 1, " 뒤의 조각");
         service.publishCompleted(
                 101L,
                 201L,
@@ -115,9 +115,37 @@ class QaAnswerStreamServiceTest {
     }
 
     @Test
+    void ignoresLateChunkFromPreviousAttemptAfterRetryStarts() throws Exception {
+        service.start(101L, 1);
+        MvcResult subscription = openProcessingStream();
+        service.publishChunk(101L, 1, "1차 생성 조각");
+
+        service.publishRetrying(101L, 1);
+        service.start(101L, 2);
+
+        // 2차 시도가 시작된 뒤 도착한 1차 조각은 새 답변에 섞이면 안 된다.
+        service.publishChunk(101L, 1, "뒤늦은 1차 조각");
+        service.publishChunk(101L, 2, "2차 생성 조각");
+        service.publishCompleted(101L, 201L, "2차 생성 조각");
+
+        mockMvc.perform(asyncDispatch(subscription))
+                .andExpect(status().isOk());
+
+        String body = subscription.getResponse()
+                .getContentAsString(StandardCharsets.UTF_8);
+
+        assertThat(body)
+                .contains("\"delta\":\"1차 생성 조각\"")
+                .contains("event:retrying")
+                .contains("\"delta\":\"2차 생성 조각\"")
+                .contains("\"attempt\":2")
+                .doesNotContain("뒤늦은 1차 조각");
+    }
+
+    @Test
     void sendsFailedEventAndClosesStream() throws Exception {
         // Given: 답변 생성 중인 질문을 사용자가 구독한다.
-        service.start(101L);
+        service.start(101L, 1);
         MvcResult subscription = openProcessingStream();
 
         // When: AI 답변 생성이 실패한다.

--- a/src/test/java/com/_penLearning/Noddi/domain/qa/service/QaAnswerUpdateServiceTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/qa/service/QaAnswerUpdateServiceTest.java
@@ -3,20 +3,30 @@ package com._penLearning.Noddi.domain.qa.service;
 import com._penLearning.Noddi.domain.qa.dto.QaRequestDto;
 import com._penLearning.Noddi.domain.qa.entity.QaAnswer;
 import com._penLearning.Noddi.domain.qa.entity.QaQuestion;
+import com._penLearning.Noddi.domain.qa.entity.QaStatus;
+import com._penLearning.Noddi.domain.qa.event.QaAnswerPublishedEvent;
+import com._penLearning.Noddi.domain.qa.event.QaAnswerPublishType;
 import com._penLearning.Noddi.domain.qa.repository.QaAnswerRepository;
 import com._penLearning.Noddi.domain.qa.repository.QaAnswerSourceRepository;
+import com._penLearning.Noddi.domain.qa.repository.QaQuestionRepository;
 import com._penLearning.Noddi.domain.team.entity.Team;
 import com._penLearning.Noddi.domain.team.repository.TeamMemberRepository;
 import com._penLearning.Noddi.domain.user.entity.User;
 import com._penLearning.Noddi.domain.user.repository.UserRepository;
+import com._penLearning.Noddi.global.exception.GeneralException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.ArgumentCaptor;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.util.Optional;
 
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -24,21 +34,26 @@ class QaAnswerUpdateServiceTest {
 
     @Mock private QaAnswerRepository answerRepository;
     @Mock private QaAnswerSourceRepository answerSourceRepository;
+    @Mock private QaQuestionRepository questionRepository;
     @Mock private UserRepository userRepository;
     @Mock private TeamMemberRepository teamMemberRepository;
     @Mock private QaAnswer answer;
     @Mock private QaQuestion question;
     @Mock private Team team;
     @Mock private User reviser;
+    @Mock private User questioner;
     @Mock private QaRequestDto.ReviseAnswer request;
+    @Mock private ApplicationEventPublisher eventPublisher;
 
     @Test
     void removesAiSourcesWhenAnswerIsRevised() {
         QaAnswerUpdateService service = new QaAnswerUpdateService(
                 answerRepository,
                 answerSourceRepository,
+                questionRepository,
                 userRepository,
-                teamMemberRepository
+                teamMemberRepository,
+                eventPublisher
         );
 
         when(answerRepository.findByIdWithQuestionAndTeamForUpdate(1L)).thenReturn(Optional.of(answer));

--- a/src/test/java/com/_penLearning/Noddi/domain/qa/service/QaQuestionQueryServiceTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/qa/service/QaQuestionQueryServiceTest.java
@@ -3,6 +3,7 @@ package com._penLearning.Noddi.domain.qa.service;
 import com._penLearning.Noddi.domain.project.entity.Project;
 import com._penLearning.Noddi.domain.project.repository.ProjectMemberRepository;
 import com._penLearning.Noddi.domain.qa.dto.QaResponseDto;
+import com._penLearning.Noddi.domain.qa.dto.QaResponseStatus;
 import com._penLearning.Noddi.domain.qa.entity.AnswerType;
 import com._penLearning.Noddi.domain.qa.entity.QaAnswer;
 import com._penLearning.Noddi.domain.qa.entity.QaAnswerSource;
@@ -13,7 +14,6 @@ import com._penLearning.Noddi.domain.qa.repository.QaAnswerRepository;
 import com._penLearning.Noddi.domain.qa.repository.QaAnswerSourceRepository;
 import com._penLearning.Noddi.domain.qa.repository.QaQuestionRepository;
 import com._penLearning.Noddi.domain.team.entity.Team;
-import com._penLearning.Noddi.domain.team.repository.TeamMemberRepository;
 import com._penLearning.Noddi.domain.team.repository.TeamRepository;
 import com._penLearning.Noddi.domain.team.repository.TeamMemberRepository;
 import com._penLearning.Noddi.domain.user.entity.User;
@@ -179,7 +179,7 @@ class QaQuestionQueryServiceTest {
         // Repository는 최신순(103 -> 102)으로 반환하지만, 채팅 화면에는 과거 질문부터 보이도록
         // 서비스가 응답 순서를 102 -> 103으로 뒤집었는지 확인한다.
         assertThat(firstItem.getQuestion().getQuestionId()).isEqualTo(102L);
-        assertThat(firstItem.getStatus()).isEqualTo(QaStatus.ANSWERED);
+        assertThat(firstItem.getStatus()).isEqualTo(QaResponseStatus.ANSWERED);
         assertThat(firstItem.getAnswer()).isNotNull();
         assertThat(firstItem.getAnswer().getAnswerId()).isEqualTo(201L);
         assertThat(firstItem.getAnswer().getContent()).isEqualTo("출시일은 9월 5일입니다.");
@@ -188,7 +188,7 @@ class QaQuestionQueryServiceTest {
                 .isEqualTo("8월 기획 회의");
 
         assertThat(secondItem.getQuestion().getQuestionId()).isEqualTo(103L);
-        assertThat(secondItem.getStatus()).isEqualTo(QaStatus.PROCESSING);
+        assertThat(secondItem.getStatus()).isEqualTo(QaResponseStatus.PROCESSING);
         assertThat(secondItem.getAnswer()).isNull();
 
         // hasNext를 별도 count 쿼리 없이 판단하기 위해 요청 크기보다 1개 더 조회했는지 확인한다.
@@ -256,6 +256,31 @@ class QaQuestionQueryServiceTest {
         assertThat(response.getItems()).hasSize(1);
         assertThat(response.getItems().get(0).getAnswer()).isNotNull();
         assertThat(response.getItems().get(0).getAnswer().getSources()).isEmpty();
+    }
+
+    @Test
+    void hidesManualRequiredStatusFromRequesterOutsideTargetTeam() {
+        QaQuestion question = mock(QaQuestion.class);
+        User questioner = mock(User.class);
+
+        allowProjectAccess();
+        when(teamMemberRepository.existsByTeamAndUser(targetTeam, requester)).thenReturn(false);
+        when(question.getQuestionId()).thenReturn(101L);
+        when(question.getQuestioner()).thenReturn(questioner);
+        when(question.getStatus()).thenReturn(QaStatus.MANUAL_REQUIRED);
+        when(question.getContent()).thenReturn("배포 일정을 알려주세요.");
+        when(questioner.getUserId()).thenReturn(5L);
+        when(questioner.getName()).thenReturn("질문자");
+        when(qaQuestionRepository.findFeedByTargetTeam(eq(targetTeam), isNull(), any(Pageable.class)))
+                .thenReturn(List.of(question));
+        when(qaAnswerRepository.findAllByQuestionsWithReviser(anyCollection())).thenReturn(List.of());
+
+        QaResponseDto.Feed response = service.getTeamFeed(1L, 10L, null, 20);
+
+        assertThat(response.getItems().get(0).getStatus())
+                .isEqualTo(QaResponseStatus.TEAM_ANSWER_PENDING);
+        assertThat(response.getItems().get(0).isCanAnswer()).isFalse();
+        verifyNoInteractions(qaAnswerSourceRepository);
     }
 
     @Test

--- a/src/test/java/com/_penLearning/Noddi/domain/qa/service/QaQuestionQueryServiceTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/qa/service/QaQuestionQueryServiceTest.java
@@ -14,6 +14,7 @@ import com._penLearning.Noddi.domain.qa.repository.QaAnswerSourceRepository;
 import com._penLearning.Noddi.domain.qa.repository.QaQuestionRepository;
 import com._penLearning.Noddi.domain.team.entity.Team;
 import com._penLearning.Noddi.domain.team.repository.TeamRepository;
+import com._penLearning.Noddi.domain.team.repository.TeamMemberRepository;
 import com._penLearning.Noddi.domain.user.entity.User;
 import com._penLearning.Noddi.domain.user.repository.UserRepository;
 import com._penLearning.Noddi.global.exception.GeneralException;
@@ -72,6 +73,9 @@ class QaQuestionQueryServiceTest {
     private ProjectMemberRepository projectMemberRepository;
 
     @Mock
+    private TeamMemberRepository teamMemberRepository;
+
+    @Mock
     private Team targetTeam;
 
     @Mock
@@ -90,7 +94,8 @@ class QaQuestionQueryServiceTest {
                 qaAnswerSourceRepository,
                 userRepository,
                 teamRepository,
-                projectMemberRepository
+                projectMemberRepository,
+                teamMemberRepository
         );
     }
 


### PR DESCRIPTION
## <i>PULL REQUEST</i>

## 🎋 작업 브랜치
-  feat/#58-qa-manual-answer -> develop
- #58
## 💡 작업동기

- AI 답변 생성이 반복적으로 실패한 경우에도 질문이 실패 상태로 방치되지 않고, 대상 팀원이 직접 답변할 수 있도록 개선했습니다.
- AI 답변 생성·수정 결과를 추후 알림 기능과 연동할 수 있도록 도메인 이벤트 발행 지점을 마련했습니다.

## 🔑 주요 변경사항

- AI 답변 생성 실패 시 최대 3회 자동 재시도하도록 구현
- 재시도 간 2초, 4초 지수 Backoff 적용
- 이전 생성 작업의 늦은 응답과 중복 실행 방지
- 최종 실패 시 `MANUAL_REQUIRED` 상태 및 시스템 안내 답변 생성
- 대상 팀원 직접 답변 작성 및 권한 검증 구현
- AI 답변, 직접 답변, 수정 답변 이벤트 발행
- 질문자 및 대상 팀원별 `canAnswer` 응답 추가
- 직접 답변과 기존 답변 수정을 구분해 `수정됨` 표시 처리
- 동일 내용 수정 요청의 중복 변경 및 이벤트 발행 방지
- 복구 대상별 트랜잭션 및 예외 격리
- SSE 재시도 및 직접 답변 대기 이벤트 추가

## 🏞 스크린샷 (선택)
> 스크린샷을 첨부해주세요.

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
