### PR TITLE
[Feat] 회원 소속 부서, 직함 정보 추가 및 프로필 이미지 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ out/
 .vscode/
 
 .Ds_Store
+
+# EC2/local profile image storage
+/uploads/

--- a/src/main/java/com/_penLearning/Noddi/domain/auth/code/AuthApi.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/auth/code/AuthApi.java
@@ -23,6 +23,12 @@ public interface AuthApi {
     ApiResponse<AuthResponseDto.AuthSignupResponseDto> signup( AuthRequestDto.SignupRequestDto requestDto
     );
 
+    @Operation(
+            summary = "회원가입 부서·직함 추천 조회",
+            description = "선택한 조직의 기존 회원이 입력한 부서와 직함을 사용 빈도순으로 최대 20개씩 조회합니다."
+    )
+    ApiResponse<AuthResponseDto.SignupProfileOptions> getSignupProfileOptions(Long organizationId);
+
     @Operation(summary = "일반 로그인", description = "이메일과 비밀번호로 로그인하여 JWT Access Token을 발급받습니다.")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공"),

--- a/src/main/java/com/_penLearning/Noddi/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/auth/controller/AuthController.java
@@ -9,8 +9,10 @@ import com._penLearning.Noddi.global.apiPayload.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -29,6 +31,17 @@ public class AuthController implements AuthApi {
         AuthResponseDto.AuthSignupResponseDto response = authService.signup(request);
 
         return ApiResponse.onSuccess("회원가입이 완료되었습니다.", response);
+    }
+
+    @Override
+    @GetMapping("/profile-options")
+    public ApiResponse<AuthResponseDto.SignupProfileOptions> getSignupProfileOptions(
+            @RequestParam Long organizationId
+    ) {
+        return ApiResponse.onSuccess(
+                "부서 및 직함 추천 목록 조회에 성공했습니다.",
+                authService.getSignupProfileOptions(organizationId)
+        );
     }
 
     @Override

--- a/src/main/java/com/_penLearning/Noddi/domain/auth/dto/AuthRequestDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/auth/dto/AuthRequestDto.java
@@ -20,6 +20,14 @@ public class AuthRequestDto {
         @NotBlank(message = "이름은 필수 입력 값입니다.")
         private String name;
 
+        @NotBlank(message = "부서는 필수 입력 값입니다.")
+        @Size(max = 20, message = "부서는 최대 20자까지 입력 가능합니다.")
+        private String department;
+
+        @NotBlank(message = "직함은 필수 입력 값입니다.")
+        @Size(max = 20, message = "직함은 최대 20자까지 입력 가능합니다.")
+        private String position;
+
         @NotBlank(message = "이메일은 필수 입력 값입니다.")
         @Email(message = "올바른 이메일 형식이 아닙니다.")
         @Size(max =254, message = "이메일은 최대 254자까지 입력 가능합니다.")

--- a/src/main/java/com/_penLearning/Noddi/domain/auth/dto/AuthResponseDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/auth/dto/AuthResponseDto.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 public class AuthResponseDto {
 
     // 회원가입 응답 DTO
@@ -16,6 +18,24 @@ public class AuthResponseDto {
 
         public static AuthSignupResponseDto from(Long userId) {
             return new AuthSignupResponseDto(userId);
+        }
+    }
+
+    // 회원가입 화면에서 다른 회원들이 입력한 부서와 직함을 추천해주는 DTO
+    @Getter
+    @AllArgsConstructor
+    public static class SignupProfileOptions {
+        private List<String> departments;
+        private List<String> positions;
+
+        public static SignupProfileOptions of(
+                List<String> departments,
+                List<String> positions
+        ) {
+            return new SignupProfileOptions(
+                    List.copyOf(departments),
+                    List.copyOf(positions)
+            );
         }
     }
 

--- a/src/main/java/com/_penLearning/Noddi/domain/auth/service/AuthService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/auth/service/AuthService.java
@@ -53,6 +53,8 @@ public class AuthService {
                 .email(request.getEmail())
                 .password(encodedPassword)
                 .name(request.getName())
+                .department(request.getDepartment())
+                .position(request.getPosition())
                 .organization(organization)
                 .build();
 

--- a/src/main/java/com/_penLearning/Noddi/domain/auth/service/AuthService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/auth/service/AuthService.java
@@ -14,6 +14,7 @@ import com._penLearning.Noddi.global.security.JwtProvider;
 import com._penLearning.Noddi.global.util.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +22,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class AuthService {
+
+    private static final int PROFILE_OPTION_LIMIT = 20;
 
     private final UserRepository userRepository;
     private final BCryptPasswordEncoder passwordEncoder;
@@ -81,5 +84,18 @@ public class AuthService {
 
         // 4. AuthLoginResponseDto 형태로 변환하여 반환
         return AuthResponseDto.AuthLoginResponseDto.of(user.getUserId(), tokenResponse.getAccessToken());
+    }
+
+    /** 선택한 조직에서 실제 사용 중인 부서와 직함을 회원가입 자동완성 목록으로 제공한다. */
+    public AuthResponseDto.SignupProfileOptions getSignupProfileOptions(Long organizationId) {
+        if (!organizationRepository.existsById(organizationId)) {
+            throw new GeneralException(OrganizationErrorCode.ORGANIZATION_NOT_FOUND);
+        }
+
+        PageRequest limit = PageRequest.of(0, PROFILE_OPTION_LIMIT);
+        return AuthResponseDto.SignupProfileOptions.of(
+                userRepository.findPopularDepartments(organizationId, limit),
+                userRepository.findPopularPositions(organizationId, limit)
+        );
     }
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/user/code/UserApi.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/user/code/UserApi.java
@@ -16,7 +16,7 @@ public interface UserApi {
             @Parameter(hidden = true) AuthMember authMember
     );
 
-    @Operation(summary = "내 프로필 수정", description = "현재 로그인한 유저의 프로필(이름 등)을 수정합니다.")
+    @Operation(summary = "내 프로필 수정", description = "현재 로그인한 유저의 이름, 부서, 직함을 수정합니다.")
     ApiResponse<Void> updateProfile(
             UserRequestDto.UpdateProfile request,
             @Parameter(hidden = true) AuthMember authMember

--- a/src/main/java/com/_penLearning/Noddi/domain/user/code/UserApi.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/user/code/UserApi.java
@@ -7,6 +7,9 @@ import com._penLearning.Noddi.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.core.io.Resource;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "User API", description = "유저 프로필 및 개인정보 관리 API")
 public interface UserApi {
@@ -27,4 +30,18 @@ public interface UserApi {
             UserRequestDto.UpdatePassword request,
             @Parameter(hidden = true) AuthMember authMember
     );
+
+    @Operation(summary = "프로필 이미지 등록·변경", description = "JPEG, PNG, WebP 이미지를 최대 5MB까지 업로드합니다.")
+    ApiResponse<UserResponseDto.ProfileImageInfo> updateProfileImage(
+            MultipartFile image,
+            @Parameter(hidden = true) AuthMember authMember
+    );
+
+    @Operation(summary = "프로필 이미지 삭제", description = "현재 등록된 프로필 이미지를 삭제합니다.")
+    ApiResponse<Void> deleteProfileImage(
+            @Parameter(hidden = true) AuthMember authMember
+    );
+
+    @Operation(summary = "프로필 이미지 조회", description = "사용자의 프로필 이미지 바이너리를 조회합니다.")
+    ResponseEntity<Resource> getProfileImage(Long userId);
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/user/code/UserErrorCode.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/user/code/UserErrorCode.java
@@ -13,8 +13,13 @@ public enum UserErrorCode implements BaseErrorCode {
 
     INVALID_CURRENT_PASSWORD(HttpStatus.BAD_REQUEST, "USER400_1", "현재 비밀번호가 일치하지 않습니다."),
     SAME_AS_OLD_PASSWORD(HttpStatus.BAD_REQUEST, "USER400_2", "새로운 비밀번호는 기존 비밀번호와 달라야 합니다."),
+    INVALID_PROFILE_IMAGE(HttpStatus.BAD_REQUEST, "USER400_3", "JPEG, PNG, WebP 형식의 프로필 이미지만 업로드할 수 있습니다."),
+    PROFILE_IMAGE_TOO_LARGE(HttpStatus.CONTENT_TOO_LARGE, "USER413_1", "프로필 이미지는 최대 5MB까지 업로드할 수 있습니다."),
 
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER404", "사용자를 찾을 수 없습니다." );
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER404", "사용자를 찾을 수 없습니다."),
+    PROFILE_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "USER404_2", "프로필 이미지를 찾을 수 없습니다."),
+
+    PROFILE_IMAGE_STORAGE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "USER500_1", "프로필 이미지 저장 중 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/_penLearning/Noddi/domain/user/controller/UserController.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/user/controller/UserController.java
@@ -5,11 +5,19 @@ import com._penLearning.Noddi.domain.user.code.UserApi;
 import com._penLearning.Noddi.domain.user.dto.UserRequestDto;
 import com._penLearning.Noddi.domain.user.dto.UserResponseDto;
 import com._penLearning.Noddi.domain.user.service.UserService;
+import com._penLearning.Noddi.domain.user.service.UserProfileImageService;
+import com._penLearning.Noddi.domain.user.storage.ProfileImageResource;
 import com._penLearning.Noddi.global.apiPayload.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.core.io.Resource;
+import org.springframework.http.CacheControl;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.Duration;
 
 @RestController
 @RequestMapping("/api/v1/users")
@@ -17,6 +25,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserController implements UserApi {
 
     private final UserService userService;
+    private final UserProfileImageService userProfileImageService;
 
     // 내 프로필 조회
     @Override
@@ -47,5 +56,36 @@ public class UserController implements UserApi {
 
         userService.updatePassword(authMember.getUserId(), request);
         return ApiResponse.onSuccess("비밀번호가 성공적으로 변경되었습니다.", null);
+    }
+
+    @Override
+    @PutMapping(value = "/me/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<UserResponseDto.ProfileImageInfo> updateProfileImage(
+            @RequestPart("image") org.springframework.web.multipart.MultipartFile image,
+            @AuthenticationPrincipal AuthMember authMember
+    ) {
+        return ApiResponse.onSuccess(
+                "프로필 이미지가 성공적으로 등록되었습니다.",
+                userProfileImageService.updateProfileImage(authMember.getUserId(), image)
+        );
+    }
+
+    @Override
+    @DeleteMapping("/me/profile-image")
+    public ApiResponse<Void> deleteProfileImage(
+            @AuthenticationPrincipal AuthMember authMember
+    ) {
+        userProfileImageService.deleteProfileImage(authMember.getUserId());
+        return ApiResponse.onSuccess("프로필 이미지가 삭제되었습니다.", null);
+    }
+
+    @Override
+    @GetMapping("/{userId}/profile-image")
+    public ResponseEntity<Resource> getProfileImage(@PathVariable Long userId) {
+        ProfileImageResource image = userProfileImageService.getProfileImage(userId);
+        return ResponseEntity.ok()
+                .contentType(image.mediaType())
+                .cacheControl(CacheControl.maxAge(Duration.ofDays(365)).cachePublic().immutable())
+                .body(image.resource());
     }
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/user/controller/UserController.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/user/controller/UserController.java
@@ -34,7 +34,7 @@ public class UserController implements UserApi {
             @RequestBody @Valid UserRequestDto.UpdateProfile request,
             @AuthenticationPrincipal AuthMember authMember) {
 
-        userService.updateProfile(authMember.getUserId(), request.getName());
+        userService.updateProfile(authMember.getUserId(), request);
         return ApiResponse.onSuccess("프로필이 성공적으로 수정되었습니다.", null);
     }
 

--- a/src/main/java/com/_penLearning/Noddi/domain/user/dto/UserRequestDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/user/dto/UserRequestDto.java
@@ -2,6 +2,7 @@ package com._penLearning.Noddi.domain.user.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -12,6 +13,14 @@ public class UserRequestDto {
     public static class UpdateProfile {
         @NotBlank(message = "변경할 이름을 입력해주세요.")
         private String name;
+
+        @Size(max = 20, message = "부서는 최대 20자까지 입력 가능합니다.")
+        @Pattern(regexp = ".*\\S.*", message = "부서는 공백만 입력할 수 없습니다.")
+        private String department;
+
+        @Size(max = 20, message = "직함은 최대 20자까지 입력 가능합니다.")
+        @Pattern(regexp = ".*\\S.*", message = "직함은 공백만 입력할 수 없습니다.")
+        private String position;
     }
 
     @Getter

--- a/src/main/java/com/_penLearning/Noddi/domain/user/dto/UserResponseDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/user/dto/UserResponseDto.java
@@ -12,6 +12,8 @@ public class UserResponseDto {
         private Long userId;
         private String email;
         private String name;
+        private String department;
+        private String position;
         private Long organizationId;
         private String organizationName;
 
@@ -20,6 +22,8 @@ public class UserResponseDto {
                     .userId(user.getUserId())
                     .email(user.getEmail())
                     .name(user.getName())
+                    .department(user.getDepartment())
+                    .position(user.getPosition())
                     .organizationId(user.getOrganization().getOrganizationId())
                     .organizationName(user.getOrganization().getName())
                     .build();

--- a/src/main/java/com/_penLearning/Noddi/domain/user/dto/UserResponseDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/user/dto/UserResponseDto.java
@@ -14,6 +14,7 @@ public class UserResponseDto {
         private String name;
         private String department;
         private String position;
+        private String profileImageUrl;
         private Long organizationId;
         private String organizationName;
 
@@ -24,8 +25,32 @@ public class UserResponseDto {
                     .name(user.getName())
                     .department(user.getDepartment())
                     .position(user.getPosition())
+                    .profileImageUrl(profileImageUrl(user))
                     .organizationId(user.getOrganization().getOrganizationId())
                     .organizationName(user.getOrganization().getName())
+                    .build();
+        }
+
+        private static String profileImageUrl(User user) {
+            if (user.getProfileImageKey() == null) {
+                return null;
+            }
+            return "/api/v1/users/" + user.getUserId()
+                    + "/profile-image?v=" + user.getProfileImageKey();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class ProfileImageInfo {
+        private String profileImageUrl;
+
+        public static ProfileImageInfo from(User user) {
+            return ProfileImageInfo.builder()
+                    .profileImageUrl(
+                            "/api/v1/users/" + user.getUserId()
+                                    + "/profile-image?v=" + user.getProfileImageKey()
+                    )
                     .build();
         }
     }

--- a/src/main/java/com/_penLearning/Noddi/domain/user/entity/User.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/user/entity/User.java
@@ -39,6 +39,10 @@ public class User extends BaseEntity {
     @Column(length = 20)
     private String position;
 
+    /** EC2 로컬 저장소의 프로필 이미지 파일 키다. */
+    @Column(length = 100)
+    private String profileImageKey;
+
     @Builder
     public User(
             Organization organization,
@@ -68,6 +72,20 @@ public class User extends BaseEntity {
 
     public void updatePassword(String encodedPassword) {
         this.password = encodedPassword;
+    }
+
+    /** 새 프로필 이미지 키로 교체하고 이전 키를 반환한다. */
+    public String updateProfileImage(String newProfileImageKey) {
+        String previousKey = this.profileImageKey;
+        this.profileImageKey = newProfileImageKey;
+        return previousKey;
+    }
+
+    /** 프로필 이미지 연결을 해제하고 이전 키를 반환한다. */
+    public String removeProfileImage() {
+        String previousKey = this.profileImageKey;
+        this.profileImageKey = null;
+        return previousKey;
     }
 
     private static String normalizeProfileValue(String value) {

--- a/src/main/java/com/_penLearning/Noddi/domain/user/entity/User.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/user/entity/User.java
@@ -31,19 +31,46 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private String password;
 
+    /** 사용자 프로필에 표시할 자유 입력 부서명이다. 권한 판단에는 사용하지 않는다. */
+    @Column(length = 20)
+    private String department;
+
+    /** 사용자 프로필에 표시할 자유 입력 직함이다. 권한 판단에는 사용하지 않는다. */
+    @Column(length = 20)
+    private String position;
+
     @Builder
-    public User(Organization organization, String email, String name, String password) {
+    public User(
+            Organization organization,
+            String email,
+            String name,
+            String password,
+            String department,
+            String position
+    ) {
         this.organization = organization;
         this.email = email;
         this.name = name;
         this.password = password;
+        this.department = normalizeProfileValue(department);
+        this.position = normalizeProfileValue(position);
     }
 
-    public void updateProfile(String name) {
+    public void updateProfile(String name, String department, String position) {
         this.name = name;
+        if (department != null) {
+            this.department = normalizeProfileValue(department);
+        }
+        if (position != null) {
+            this.position = normalizeProfileValue(position);
+        }
     }
 
     public void updatePassword(String encodedPassword) {
         this.password = encodedPassword;
+    }
+
+    private static String normalizeProfileValue(String value) {
+        return value == null ? null : value.strip();
     }
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/user/repository/UserRepository.java
@@ -4,7 +4,9 @@ import com._penLearning.Noddi.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -14,4 +16,34 @@ public interface UserRepository extends JpaRepository<User, Long> {
     // 유저 정보와 소속 조직 정보를 한 번의 쿼리로 조회 (N+1 방어)
     @Query("SELECT u FROM User u JOIN FETCH u.organization WHERE u.userId = :userId")
     Optional<User> findByIdWithOrganization(@Param("userId") Long userId);
+
+    /** 같은 조직 사용자가 입력한 부서를 사용 빈도순으로 중복 없이 조회한다. */
+    @Query("""
+            SELECT user.department
+            FROM User user
+            WHERE user.organization.organizationId = :organizationId
+              AND user.department IS NOT NULL
+              AND user.department <> ''
+            GROUP BY user.department
+            ORDER BY COUNT(user) DESC, user.department ASC
+            """)
+    List<String> findPopularDepartments(
+            @Param("organizationId") Long organizationId,
+            Pageable pageable
+    );
+
+    /** 같은 조직 사용자가 입력한 직함을 사용 빈도순으로 중복 없이 조회한다. */
+    @Query("""
+            SELECT user.position
+            FROM User user
+            WHERE user.organization.organizationId = :organizationId
+              AND user.position IS NOT NULL
+              AND user.position <> ''
+            GROUP BY user.position
+            ORDER BY COUNT(user) DESC, user.position ASC
+            """)
+    List<String> findPopularPositions(
+            @Param("organizationId") Long organizationId,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/user/service/UserProfileImageService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/user/service/UserProfileImageService.java
@@ -1,0 +1,112 @@
+package com._penLearning.Noddi.domain.user.service;
+
+import com._penLearning.Noddi.domain.user.code.UserErrorCode;
+import com._penLearning.Noddi.domain.user.dto.UserResponseDto;
+import com._penLearning.Noddi.domain.user.entity.User;
+import com._penLearning.Noddi.domain.user.repository.UserRepository;
+import com._penLearning.Noddi.domain.user.storage.ProfileImageResource;
+import com._penLearning.Noddi.domain.user.storage.ProfileImageStorage;
+import com._penLearning.Noddi.domain.user.storage.StoredProfileImage;
+import com._penLearning.Noddi.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserProfileImageService {
+
+    private final UserRepository userRepository;
+    private final ProfileImageStorage profileImageStorage;
+
+    @Transactional
+    public UserResponseDto.ProfileImageInfo updateProfileImage(Long userId, MultipartFile image) {
+        StoredProfileImage storedImage = profileImageStorage.store(image);
+
+        try {
+            User user = getUserOrThrow(userId);
+            String previousKey = user.updateProfileImage(storedImage.key());
+            cleanupAfterTransaction(storedImage.key(), previousKey);
+            return UserResponseDto.ProfileImageInfo.from(user);
+        } catch (RuntimeException exception) {
+            // DB 변경 전에 오류가 난 경우 방금 저장한 파일을 남기지 않는다.
+            safeDelete(storedImage.key());
+            throw exception;
+        }
+    }
+
+    @Transactional
+    public void deleteProfileImage(Long userId) {
+        User user = getUserOrThrow(userId);
+        String previousKey = user.removeProfileImage();
+        if (previousKey == null) {
+            return;
+        }
+
+        deleteAfterCommit(previousKey);
+    }
+
+    public ProfileImageResource getProfileImage(Long userId) {
+        User user = getUserOrThrow(userId);
+        if (user.getProfileImageKey() == null) {
+            throw new GeneralException(UserErrorCode.PROFILE_IMAGE_NOT_FOUND);
+        }
+        return profileImageStorage.load(user.getProfileImageKey());
+    }
+
+    private User getUserOrThrow(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    private void cleanupAfterTransaction(String newKey, String previousKey) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            safeDelete(previousKey);
+            return;
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCompletion(int status) {
+                if (status == STATUS_COMMITTED) {
+                    safeDelete(previousKey);
+                } else {
+                    safeDelete(newKey);
+                }
+            }
+        });
+    }
+
+    private void deleteAfterCommit(String key) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            safeDelete(key);
+            return;
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                safeDelete(key);
+            }
+        });
+    }
+
+    private void safeDelete(String key) {
+        if (key == null) {
+            return;
+        }
+
+        try {
+            profileImageStorage.delete(key);
+        } catch (RuntimeException exception) {
+            // DB 커밋은 완료됐으므로 파일 정리 실패를 사용자 요청 실패로 되돌리지 않는다.
+            log.warn("Profile image cleanup failed. key={}", key, exception);
+        }
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/user/service/UserService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/user/service/UserService.java
@@ -31,11 +31,15 @@ public class UserService {
 
     // 내 프로필 수정
     @Transactional
-    public void updateProfile(Long userId, String newName) {
+    public void updateProfile(Long userId, UserRequestDto.UpdateProfile request) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(UserErrorCode.USER_NOT_FOUND));
 
-        user.updateProfile(newName);
+        user.updateProfile(
+                request.getName(),
+                request.getDepartment(),
+                request.getPosition()
+        );
     }
 
     // 비번 변경

--- a/src/main/java/com/_penLearning/Noddi/domain/user/storage/LocalProfileImageStorage.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/user/storage/LocalProfileImageStorage.java
@@ -1,0 +1,183 @@
+package com._penLearning.Noddi.domain.user.storage;
+
+import com._penLearning.Noddi.domain.user.code.UserErrorCode;
+import com._penLearning.Noddi.global.exception.GeneralException;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+@Component
+public class LocalProfileImageStorage implements ProfileImageStorage {
+
+    private static final Pattern SAFE_KEY_PATTERN = Pattern.compile(
+            "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\.(jpg|png|webp)$"
+    );
+
+    private final Path storageRoot;
+    private final long maxFileSizeBytes;
+
+    public LocalProfileImageStorage(
+            @Value("${profile-image.storage-path:./uploads/profile-images}") String storagePath,
+            @Value("${profile-image.max-file-size-bytes:5242880}") long maxFileSizeBytes
+    ) {
+        this.storageRoot = Path.of(storagePath).toAbsolutePath().normalize();
+        this.maxFileSizeBytes = maxFileSizeBytes;
+    }
+
+    @PostConstruct
+    void initializeStorageDirectory() {
+        try {
+            Files.createDirectories(storageRoot);
+        } catch (IOException exception) {
+            throw new GeneralException(UserErrorCode.PROFILE_IMAGE_STORAGE_FAILED);
+        }
+    }
+
+    @Override
+    public StoredProfileImage store(MultipartFile image) {
+        if (image == null || image.isEmpty()) {
+            throw new GeneralException(UserErrorCode.INVALID_PROFILE_IMAGE);
+        }
+        if (image.getSize() > maxFileSizeBytes) {
+            throw new GeneralException(UserErrorCode.PROFILE_IMAGE_TOO_LARGE);
+        }
+
+        try {
+            byte[] bytes = image.getBytes();
+            ImageType imageType = detectImageType(bytes);
+            String key = UUID.randomUUID() + imageType.extension;
+            Path target = resolveSafeKey(key);
+
+            Files.write(target, bytes, StandardOpenOption.CREATE_NEW);
+            return new StoredProfileImage(key);
+        } catch (GeneralException exception) {
+            throw exception;
+        } catch (IOException exception) {
+            throw new GeneralException(UserErrorCode.PROFILE_IMAGE_STORAGE_FAILED);
+        }
+    }
+
+    @Override
+    public ProfileImageResource load(String key) {
+        Path imagePath = resolveSafeKey(key);
+        if (!Files.isRegularFile(imagePath)) {
+            throw new GeneralException(UserErrorCode.PROFILE_IMAGE_NOT_FOUND);
+        }
+
+        ImageType imageType = ImageType.fromExtension(key);
+        return new ProfileImageResource(
+                new FileSystemResource(imagePath),
+                imageType.mediaType
+        );
+    }
+
+    @Override
+    public void delete(String key) {
+        if (key == null) {
+            return;
+        }
+
+        try {
+            Files.deleteIfExists(resolveSafeKey(key));
+        } catch (IOException exception) {
+            throw new GeneralException(UserErrorCode.PROFILE_IMAGE_STORAGE_FAILED);
+        }
+    }
+
+    private Path resolveSafeKey(String key) {
+        if (key == null || !SAFE_KEY_PATTERN.matcher(key).matches()) {
+            throw new GeneralException(UserErrorCode.INVALID_PROFILE_IMAGE);
+        }
+
+        Path resolved = storageRoot.resolve(key).normalize();
+        if (!resolved.startsWith(storageRoot)) {
+            throw new GeneralException(UserErrorCode.INVALID_PROFILE_IMAGE);
+        }
+        return resolved;
+    }
+
+    private ImageType detectImageType(byte[] bytes) {
+        if (isJpeg(bytes)) {
+            return ImageType.JPEG;
+        }
+        if (isPng(bytes)) {
+            return ImageType.PNG;
+        }
+        if (isWebp(bytes)) {
+            return ImageType.WEBP;
+        }
+        throw new GeneralException(UserErrorCode.INVALID_PROFILE_IMAGE);
+    }
+
+    private boolean isJpeg(byte[] bytes) {
+        return bytes.length >= 3
+                && unsigned(bytes[0]) == 0xFF
+                && unsigned(bytes[1]) == 0xD8
+                && unsigned(bytes[2]) == 0xFF;
+    }
+
+    private boolean isPng(byte[] bytes) {
+        int[] signature = {0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A};
+        if (bytes.length < signature.length) {
+            return false;
+        }
+        for (int i = 0; i < signature.length; i++) {
+            if (unsigned(bytes[i]) != signature[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean isWebp(byte[] bytes) {
+        return bytes.length >= 12
+                && asciiEquals(bytes, 0, "RIFF")
+                && asciiEquals(bytes, 8, "WEBP");
+    }
+
+    private boolean asciiEquals(byte[] bytes, int offset, String expected) {
+        for (int i = 0; i < expected.length(); i++) {
+            if (bytes[offset + i] != (byte) expected.charAt(i)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private int unsigned(byte value) {
+        return value & 0xFF;
+    }
+
+    private enum ImageType {
+        JPEG(".jpg", MediaType.IMAGE_JPEG),
+        PNG(".png", MediaType.IMAGE_PNG),
+        WEBP(".webp", MediaType.parseMediaType("image/webp"));
+
+        private final String extension;
+        private final MediaType mediaType;
+
+        ImageType(String extension, MediaType mediaType) {
+            this.extension = extension;
+            this.mediaType = mediaType;
+        }
+
+        private static ImageType fromExtension(String key) {
+            for (ImageType type : values()) {
+                if (key.endsWith(type.extension)) {
+                    return type;
+                }
+            }
+            throw new GeneralException(UserErrorCode.INVALID_PROFILE_IMAGE);
+        }
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/user/storage/ProfileImageResource.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/user/storage/ProfileImageResource.java
@@ -1,0 +1,7 @@
+package com._penLearning.Noddi.domain.user.storage;
+
+import org.springframework.core.io.Resource;
+import org.springframework.http.MediaType;
+
+public record ProfileImageResource(Resource resource, MediaType mediaType) {
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/user/storage/ProfileImageStorage.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/user/storage/ProfileImageStorage.java
@@ -1,0 +1,12 @@
+package com._penLearning.Noddi.domain.user.storage;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ProfileImageStorage {
+
+    StoredProfileImage store(MultipartFile image);
+
+    ProfileImageResource load(String key);
+
+    void delete(String key);
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/user/storage/StoredProfileImage.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/user/storage/StoredProfileImage.java
@@ -1,0 +1,4 @@
+package com._penLearning.Noddi.domain.user.storage;
+
+public record StoredProfileImage(String key) {
+}

--- a/src/main/java/com/_penLearning/Noddi/global/config/TestDataInitializer.java
+++ b/src/main/java/com/_penLearning/Noddi/global/config/TestDataInitializer.java
@@ -53,6 +53,8 @@ public class TestDataInitializer implements CommandLineRunner {
                     .organization(testOrg)
                     .email("test1@gmail.com")
                     .name("테스트 유저 1")
+                    .department("백엔드팀")
+                    .position("백엔드 개발자")
                     .password(encodedPassword)
                     .build();
 
@@ -60,6 +62,8 @@ public class TestDataInitializer implements CommandLineRunner {
                     .organization(testOrg)
                     .email("test2@gmail.com")
                     .name("테스트 유저 2")
+                    .department("백엔드팀")
+                    .position("백엔드 개발자")
                     .password(encodedPassword)
                     .build();
 
@@ -67,6 +71,8 @@ public class TestDataInitializer implements CommandLineRunner {
                     .organization(testOrg)
                     .email("test3@gmail.com")
                     .name("테스트 유저 3")
+                    .department("기획팀")
+                    .position("서비스 기획자")
                     .password(encodedPassword)
                     .build();
 

--- a/src/main/java/com/_penLearning/Noddi/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/_penLearning/Noddi/global/exception/GlobalExceptionHandler.java
@@ -7,6 +7,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import com._penLearning.Noddi.domain.user.code.UserErrorCode;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -49,5 +51,11 @@ public class GlobalExceptionHandler {
         BaseErrorCode code = GeneralErrorCode.BAD_REQUEST;
         return ResponseEntity.status(code.getHttpStatus())
                 .body(ApiResponse.onFailure(code, errors));
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMaxUploadSizeExceededException() {
+        return ResponseEntity.status(UserErrorCode.PROFILE_IMAGE_TOO_LARGE.getHttpStatus())
+                .body(ApiResponse.onFailure(UserErrorCode.PROFILE_IMAGE_TOO_LARGE, null));
     }
 }

--- a/src/main/java/com/_penLearning/Noddi/global/security/SecurityConfig.java
+++ b/src/main/java/com/_penLearning/Noddi/global/security/SecurityConfig.java
@@ -11,6 +11,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.http.HttpMethod;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -52,6 +53,8 @@ public class SecurityConfig {
                                 .requestMatchers("/api/v1/auth/**").permitAll()
                                 // 조직 조회 관련 API 전체 허용
                                 .requestMatchers("/api/v1/organizations/**").permitAll()
+                                // img src에서 바로 로드할 수 있도록 프로필 이미지 조회만 공개
+                                .requestMatchers(HttpMethod.GET, "/api/v1/users/*/profile-image").permitAll()
                                 // Daily.co 웹훅 수신 주소 허용 (JWT 무인증 외부 알림)
                                 .requestMatchers("/webhooks/**").permitAll()
                                 // 그 외 모든 요청은 인증 필요 (테스트 시 필요시 permitAll로 변경 가능)

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -18,6 +18,11 @@ spring:
       host: localhost
       port: 6379
 
+  servlet:
+    multipart:
+      max-file-size: ${PROFILE_IMAGE_MAX_FILE_SIZE:5MB}
+      max-request-size: ${PROFILE_IMAGE_MAX_REQUEST_SIZE:6MB}
+
   ai:
     openai:
       api-key: ${OPENAI_API_KEY}
@@ -98,3 +103,7 @@ qa:
   rag:
     top-k: ${QA_RAG_TOP_K:5} # 사용자의 질문과 가장 유사한 청크를 몇 개까지 가져올 것인지 설정
     similarity-threshold: ${QA_RAG_SIMILARITY_THRESHOLD:0.2} # 현재 검증 데이터 기준 하한선이며 평가 결과에 따라 환경변수로 조정
+
+profile-image:
+  storage-path: ${PROFILE_IMAGE_STORAGE_PATH:./uploads/profile-images}
+  max-file-size-bytes: ${PROFILE_IMAGE_MAX_FILE_SIZE_BYTES:5242880}

--- a/src/test/java/com/_penLearning/Noddi/domain/auth/dto/SignupProfileValidationTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/auth/dto/SignupProfileValidationTest.java
@@ -1,0 +1,36 @@
+package com._penLearning.Noddi.domain.auth.dto;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SignupProfileValidationTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void acceptsTwentyCharactersAndRejectsTwentyOneCharacters() {
+        AuthRequestDto.SignupRequestDto request = validRequest();
+        ReflectionTestUtils.setField(request, "department", "가".repeat(20));
+        ReflectionTestUtils.setField(request, "position", "나".repeat(20));
+        assertThat(validator.validate(request)).isEmpty();
+
+        ReflectionTestUtils.setField(request, "department", "가".repeat(21));
+        ReflectionTestUtils.setField(request, "position", "나".repeat(21));
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getPropertyPath().toString())
+                .containsExactlyInAnyOrder("department", "position");
+    }
+
+    private AuthRequestDto.SignupRequestDto validRequest() {
+        AuthRequestDto.SignupRequestDto request = new AuthRequestDto.SignupRequestDto();
+        ReflectionTestUtils.setField(request, "organizationId", 1L);
+        ReflectionTestUtils.setField(request, "name", "김노디");
+        ReflectionTestUtils.setField(request, "email", "member@noddi.com");
+        ReflectionTestUtils.setField(request, "password", "Password1!");
+        return request;
+    }
+}

--- a/src/test/java/com/_penLearning/Noddi/domain/auth/service/AuthProfileOptionsServiceTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/auth/service/AuthProfileOptionsServiceTest.java
@@ -1,0 +1,79 @@
+package com._penLearning.Noddi.domain.auth.service;
+
+import com._penLearning.Noddi.domain.organization.repository.OrganizationRepository;
+import com._penLearning.Noddi.domain.user.repository.UserRepository;
+import com._penLearning.Noddi.global.exception.GeneralException;
+import com._penLearning.Noddi.global.security.JwtProvider;
+import com._penLearning.Noddi.global.util.RedisUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuthProfileOptionsServiceTest {
+
+    @Mock private UserRepository userRepository;
+    @Mock private BCryptPasswordEncoder passwordEncoder;
+    @Mock private OrganizationRepository organizationRepository;
+    @Mock private JwtProvider jwtProvider;
+    @Mock private RedisUtil redisUtil;
+
+    @Test
+    void returnsOrganizationProfileOptionsWithTwentyItemLimit() {
+        AuthService service = service();
+        when(organizationRepository.existsById(1L)).thenReturn(true);
+        when(userRepository.findPopularDepartments(
+                org.mockito.ArgumentMatchers.eq(1L),
+                org.mockito.ArgumentMatchers.any(Pageable.class)
+        )).thenReturn(List.of("백엔드팀", "기획팀"));
+        when(userRepository.findPopularPositions(
+                org.mockito.ArgumentMatchers.eq(1L),
+                org.mockito.ArgumentMatchers.any(Pageable.class)
+        )).thenReturn(List.of("백엔드 개발자", "서비스 기획자"));
+
+        var response = service.getSignupProfileOptions(1L);
+
+        assertThat(response.getDepartments()).containsExactly("백엔드팀", "기획팀");
+        assertThat(response.getPositions()).containsExactly("백엔드 개발자", "서비스 기획자");
+
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(userRepository).findPopularDepartments(
+                org.mockito.ArgumentMatchers.eq(1L),
+                pageableCaptor.capture()
+        );
+        assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(20);
+    }
+
+    @Test
+    void rejectsUnknownOrganizationBeforeQueryingUserProfiles() {
+        AuthService service = service();
+        when(organizationRepository.existsById(999L)).thenReturn(false);
+
+        assertThatThrownBy(() -> service.getSignupProfileOptions(999L))
+                .isInstanceOf(GeneralException.class);
+
+        verifyNoInteractions(userRepository);
+    }
+
+    private AuthService service() {
+        return new AuthService(
+                userRepository,
+                passwordEncoder,
+                organizationRepository,
+                jwtProvider,
+                redisUtil
+        );
+    }
+}

--- a/src/test/java/com/_penLearning/Noddi/domain/auth/service/AuthSignupProfileServiceTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/auth/service/AuthSignupProfileServiceTest.java
@@ -1,0 +1,70 @@
+package com._penLearning.Noddi.domain.auth.service;
+
+import com._penLearning.Noddi.domain.auth.dto.AuthRequestDto;
+import com._penLearning.Noddi.domain.organization.entity.Organization;
+import com._penLearning.Noddi.domain.organization.repository.OrganizationRepository;
+import com._penLearning.Noddi.domain.user.entity.User;
+import com._penLearning.Noddi.domain.user.repository.UserRepository;
+import com._penLearning.Noddi.global.security.JwtProvider;
+import com._penLearning.Noddi.global.util.RedisUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuthSignupProfileServiceTest {
+
+    @Mock private UserRepository userRepository;
+    @Mock private BCryptPasswordEncoder passwordEncoder;
+    @Mock private OrganizationRepository organizationRepository;
+    @Mock private JwtProvider jwtProvider;
+    @Mock private RedisUtil redisUtil;
+    @Mock private AuthRequestDto.SignupRequestDto request;
+    @Mock private Organization organization;
+
+    @Test
+    void savesDepartmentAndPositionDuringSignup() {
+        AuthService service = new AuthService(
+                userRepository,
+                passwordEncoder,
+                organizationRepository,
+                jwtProvider,
+                redisUtil
+        );
+        when(request.getOrganizationId()).thenReturn(1L);
+        when(request.getEmail()).thenReturn("member@noddi.com");
+        when(request.getPassword()).thenReturn("Password1!");
+        when(request.getName()).thenReturn("김노디");
+        when(request.getDepartment()).thenReturn("  백엔드팀  ");
+        when(request.getPosition()).thenReturn("  백엔드 개발자  ");
+        when(userRepository.existsByEmail("member@noddi.com")).thenReturn(false);
+        when(redisUtil.getData("EMAIL_VERIFIED:1:member@noddi.com")).thenReturn("true");
+        when(organizationRepository.findById(1L)).thenReturn(Optional.of(organization));
+        when(passwordEncoder.encode("Password1!")).thenReturn("encoded-password");
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> {
+            User user = invocation.getArgument(0);
+            ReflectionTestUtils.setField(user, "userId", 10L);
+            return user;
+        });
+
+        var response = service.signup(request);
+
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(userCaptor.capture());
+        assertThat(userCaptor.getValue().getDepartment()).isEqualTo("백엔드팀");
+        assertThat(userCaptor.getValue().getPosition()).isEqualTo("백엔드 개발자");
+        assertThat(response.getUserId()).isEqualTo(10L);
+        verify(redisUtil).deleteData("EMAIL_VERIFIED:1:member@noddi.com");
+    }
+}

--- a/src/test/java/com/_penLearning/Noddi/domain/user/service/UserProfileImageServiceTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/user/service/UserProfileImageServiceTest.java
@@ -1,0 +1,71 @@
+package com._penLearning.Noddi.domain.user.service;
+
+import com._penLearning.Noddi.domain.user.entity.User;
+import com._penLearning.Noddi.domain.user.repository.UserRepository;
+import com._penLearning.Noddi.domain.user.storage.ProfileImageStorage;
+import com._penLearning.Noddi.domain.user.storage.StoredProfileImage;
+import com._penLearning.Noddi.global.exception.GeneralException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserProfileImageServiceTest {
+
+    private static final String NEW_KEY = "11111111-1111-1111-1111-111111111111.png";
+    private static final String OLD_KEY = "22222222-2222-2222-2222-222222222222.jpg";
+
+    @Mock private UserRepository userRepository;
+    @Mock private ProfileImageStorage profileImageStorage;
+    @Mock private User user;
+
+    @Test
+    void replacesProfileImageAndDeletesPreviousFile() {
+        UserProfileImageService service = new UserProfileImageService(userRepository, profileImageStorage);
+        MockMultipartFile image = new MockMultipartFile("image", new byte[]{1});
+        when(profileImageStorage.store(image)).thenReturn(new StoredProfileImage(NEW_KEY));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(user.updateProfileImage(NEW_KEY)).thenReturn(OLD_KEY);
+        when(user.getUserId()).thenReturn(1L);
+        when(user.getProfileImageKey()).thenReturn(NEW_KEY);
+
+        var response = service.updateProfileImage(1L, image);
+
+        assertThat(response.getProfileImageUrl())
+                .isEqualTo("/api/v1/users/1/profile-image?v=" + NEW_KEY);
+        verify(profileImageStorage).delete(OLD_KEY);
+    }
+
+    @Test
+    void deletesNewFileWhenUserDoesNotExist() {
+        UserProfileImageService service = new UserProfileImageService(userRepository, profileImageStorage);
+        MockMultipartFile image = new MockMultipartFile("image", new byte[]{1});
+        when(profileImageStorage.store(image)).thenReturn(new StoredProfileImage(NEW_KEY));
+        when(userRepository.findById(999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.updateProfileImage(999L, image))
+                .isInstanceOf(GeneralException.class);
+
+        verify(profileImageStorage).delete(NEW_KEY);
+    }
+
+    @Test
+    void removesProfileImageKeyAndStoredFile() {
+        UserProfileImageService service = new UserProfileImageService(userRepository, profileImageStorage);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(user.removeProfileImage()).thenReturn(OLD_KEY);
+
+        service.deleteProfileImage(1L);
+
+        verify(profileImageStorage).delete(OLD_KEY);
+    }
+}

--- a/src/test/java/com/_penLearning/Noddi/domain/user/service/UserProfileServiceTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/user/service/UserProfileServiceTest.java
@@ -1,0 +1,37 @@
+package com._penLearning.Noddi.domain.user.service;
+
+import com._penLearning.Noddi.domain.user.dto.UserRequestDto;
+import com._penLearning.Noddi.domain.user.entity.User;
+import com._penLearning.Noddi.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserProfileServiceTest {
+
+    @Mock private UserRepository userRepository;
+    @Mock private PasswordEncoder passwordEncoder;
+    @Mock private User user;
+    @Mock private UserRequestDto.UpdateProfile request;
+
+    @Test
+    void updatesNameDepartmentAndPosition() {
+        UserService service = new UserService(userRepository, passwordEncoder);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(request.getName()).thenReturn("김노디");
+        when(request.getDepartment()).thenReturn("플랫폼팀");
+        when(request.getPosition()).thenReturn("백엔드 개발자");
+
+        service.updateProfile(1L, request);
+
+        verify(user).updateProfile("김노디", "플랫폼팀", "백엔드 개발자");
+    }
+}

--- a/src/test/java/com/_penLearning/Noddi/domain/user/storage/LocalProfileImageStorageTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/user/storage/LocalProfileImageStorageTest.java
@@ -1,0 +1,84 @@
+package com._penLearning.Noddi.domain.user.storage;
+
+import com._penLearning.Noddi.global.exception.GeneralException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class LocalProfileImageStorageTest {
+
+    @TempDir
+    Path tempDirectory;
+
+    private LocalProfileImageStorage storage;
+
+    @BeforeEach
+    void setUp() {
+        storage = new LocalProfileImageStorage(tempDirectory.toString(), 20);
+        storage.initializeStorageDirectory();
+    }
+
+    @Test
+    void storesLoadsAndDeletesPngByFileSignature() throws Exception {
+        byte[] pngBytes = {
+                (byte) 0x89, 0x50, 0x4E, 0x47,
+                0x0D, 0x0A, 0x1A, 0x0A
+        };
+        MockMultipartFile image = new MockMultipartFile(
+                "image",
+                "profile.txt",
+                MediaType.TEXT_PLAIN_VALUE,
+                pngBytes
+        );
+
+        StoredProfileImage stored = storage.store(image);
+        ProfileImageResource loaded = storage.load(stored.key());
+
+        assertThat(stored.key()).endsWith(".png");
+        assertThat(loaded.mediaType()).isEqualTo(MediaType.IMAGE_PNG);
+        assertThat(loaded.resource().getContentAsByteArray()).containsExactly(pngBytes);
+
+        storage.delete(stored.key());
+        assertThatThrownBy(() -> storage.load(stored.key()))
+                .isInstanceOf(GeneralException.class);
+    }
+
+    @Test
+    void rejectsUnsupportedFileContent() {
+        MockMultipartFile image = new MockMultipartFile(
+                "image",
+                "profile.png",
+                MediaType.IMAGE_PNG_VALUE,
+                "not-an-image".getBytes()
+        );
+
+        assertThatThrownBy(() -> storage.store(image))
+                .isInstanceOf(GeneralException.class);
+    }
+
+    @Test
+    void rejectsFileLargerThanConfiguredLimit() {
+        MockMultipartFile image = new MockMultipartFile(
+                "image",
+                "profile.jpg",
+                MediaType.IMAGE_JPEG_VALUE,
+                new byte[21]
+        );
+
+        assertThatThrownBy(() -> storage.store(image))
+                .isInstanceOf(GeneralException.class);
+    }
+
+    @Test
+    void rejectsUnsafeStorageKey() {
+        assertThatThrownBy(() -> storage.load("../secret.png"))
+                .isInstanceOf(GeneralException.class);
+    }
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

## 🎋 작업 브랜치
- feat/#59-user-img-role -> develop
- #59

## 💡 작업동기

- 회원의 소속 정보를 확인할 수 있도록 부서와 직함 정보를 추가했습니다.
- 사용자가 개인 프로필 이미지를 등록하고 관리할 수 있도록 기능을 구현했습니다.

## 🔑 주요 변경사항

- 회원가입 및 마이페이지 부서·직함 입력/수정 기능 추가
- 기존 회원 데이터 기반 부서·직함 추천 API 추가
- 프로필 이미지 업로드·조회·삭제 API 구현
- UUID 기반 이미지 파일 저장 및 파일 형식·용량 검증
- 프로필 이미지 저장 경로 및 업로드 용량 환경변수 설정
- 관련 서비스 및 API 테스트 추가

## 🏞 스크린샷 (선택)
> 스크린샷을 첨부해주세요.

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
