### PR TITLE
[Refactor] ProfileImage S3 storage 사용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,13 @@ repositories {
 }
 
 dependencies {
+
+	implementation platform('org.springframework.ai:spring-ai-bom:2.0.0')
+	// AWS SDK 모듈들의 버전을 동일하게 관리한다.
+	implementation platform('software.amazon.awssdk:bom:2.47.6')
+	// S3 저장·조회·삭제에 필요한 AWS SDK v2 모듈
+	implementation 'software.amazon.awssdk:s3'
+
 	implementation platform('org.springframework.ai:spring-ai-bom:2.0.0')
 	implementation 'org.springframework.ai:spring-ai-starter-model-openai'
 	implementation 'org.springframework.ai:spring-ai-starter-vector-store-pinecone'

--- a/build.gradle
+++ b/build.gradle
@@ -24,8 +24,6 @@ dependencies {
 	implementation platform('software.amazon.awssdk:bom:2.47.6')
 	// S3 저장·조회·삭제에 필요한 AWS SDK v2 모듈
 	implementation 'software.amazon.awssdk:s3'
-
-	implementation platform('org.springframework.ai:spring-ai-bom:2.0.0')
 	implementation 'org.springframework.ai:spring-ai-starter-model-openai'
 	implementation 'org.springframework.ai:spring-ai-starter-vector-store-pinecone'
 	implementation 'org.springframework.boot:spring-boot-h2console'

--- a/src/main/java/com/_penLearning/Noddi/domain/summary/code/SummaryApi.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/summary/code/SummaryApi.java
@@ -6,8 +6,13 @@ import com._penLearning.Noddi.domain.summary.dto.SummaryResponseDto;
 import com._penLearning.Noddi.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
+@Tag(
+        name = "Summary API",
+        description = "회의록 기반 요약 API"
+)
 public interface SummaryApi {
 
     @Operation(

--- a/src/main/java/com/_penLearning/Noddi/domain/user/controller/UserController.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/user/controller/UserController.java
@@ -85,7 +85,7 @@ public class UserController implements UserApi {
         ProfileImageResource image = userProfileImageService.getProfileImage(userId);
         return ResponseEntity.ok()
                 .contentType(image.mediaType())
-                .cacheControl(CacheControl.maxAge(Duration.ofDays(365)).cachePublic().immutable())
+                .cacheControl(CacheControl.maxAge(Duration.ofDays(365)).cachePrivate().immutable())
                 .body(image.resource());
     }
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/user/repository/UserRepository.java
@@ -1,7 +1,9 @@
 package com._penLearning.Noddi.domain.user.repository;
 
 import com._penLearning.Noddi.domain.user.entity.User;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.domain.Pageable;
@@ -45,5 +47,21 @@ public interface UserRepository extends JpaRepository<User, Long> {
     List<String> findPopularPositions(
             @Param("organizationId") Long organizationId,
             Pageable pageable
+    );
+
+    /*
+     * 동일 사용자의 프로필 이미지 변경과 삭제를 직렬화한다.
+     *
+     * 두 요청이 동시에 같은 이전 이미지 키를 읽으면
+     * 한쪽 새 이미지가 S3에 남을 수 있으므로 쓰기 락을 사용한다.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+            SELECT user
+            FROM User user
+            WHERE user.userId = :userId
+            """)
+    Optional<User> findByIdForProfileImageUpdate(
+            @Param("userId") Long userId
     );
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/user/service/UserProfileImageService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/user/service/UserProfileImageService.java
@@ -30,7 +30,7 @@ public class UserProfileImageService {
         StoredProfileImage storedImage = profileImageStorage.store(image);
 
         try {
-            User user = getUserOrThrow(userId);
+            User user = getUserForProfileImageUpdateOrThrow(userId);
             String previousKey = user.updateProfileImage(storedImage.key());
             cleanupAfterTransaction(storedImage.key(), previousKey);
             return UserResponseDto.ProfileImageInfo.from(user);
@@ -43,7 +43,7 @@ public class UserProfileImageService {
 
     @Transactional
     public void deleteProfileImage(Long userId) {
-        User user = getUserOrThrow(userId);
+        User user = getUserForProfileImageUpdateOrThrow(userId);
         String previousKey = user.removeProfileImage();
         if (previousKey == null) {
             return;
@@ -108,5 +108,12 @@ public class UserProfileImageService {
             // DB 커밋은 완료됐으므로 파일 정리 실패를 사용자 요청 실패로 되돌리지 않는다.
             log.warn("Profile image cleanup failed. key={}", key, exception);
         }
+    }
+
+    private User getUserForProfileImageUpdateOrThrow(Long userId) {
+        return userRepository.findByIdForProfileImageUpdate(userId)
+                .orElseThrow(() ->
+                        new GeneralException(UserErrorCode.USER_NOT_FOUND)
+                );
     }
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/user/storage/LocalProfileImageStorage.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/user/storage/LocalProfileImageStorage.java
@@ -4,6 +4,7 @@ import com._penLearning.Noddi.domain.user.code.UserErrorCode;
 import com._penLearning.Noddi.global.exception.GeneralException;
 import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -17,6 +18,12 @@ import java.util.UUID;
 import java.util.regex.Pattern;
 
 @Component
+@ConditionalOnProperty(
+        prefix = "profile-image",
+        name = "storage-type",
+        havingValue = "local",
+        matchIfMissing = true
+)
 public class LocalProfileImageStorage implements ProfileImageStorage {
 
     private static final Pattern SAFE_KEY_PATTERN = Pattern.compile(
@@ -27,10 +34,16 @@ public class LocalProfileImageStorage implements ProfileImageStorage {
     private final long maxFileSizeBytes;
 
     public LocalProfileImageStorage(
-            @Value("${profile-image.storage-path:./uploads/profile-images}") String storagePath,
-            @Value("${profile-image.max-file-size-bytes:5242880}") long maxFileSizeBytes
+            @Value("${profile-image.local.storage-path:./uploads/profile-images}")
+            String storagePath,
+
+            @Value("${profile-image.max-file-size-bytes:5242880}")
+            long maxFileSizeBytes
     ) {
-        this.storageRoot = Path.of(storagePath).toAbsolutePath().normalize();
+        this.storageRoot = Path.of(storagePath)
+                .toAbsolutePath()
+                .normalize();
+
         this.maxFileSizeBytes = maxFileSizeBytes;
     }
 

--- a/src/main/java/com/_penLearning/Noddi/domain/user/storage/S3ProfileImageStorage.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/user/storage/S3ProfileImageStorage.java
@@ -1,0 +1,388 @@
+package com._penLearning.Noddi.domain.user.storage;
+
+import com._penLearning.Noddi.domain.user.code.UserErrorCode;
+import com._penLearning.Noddi.global.exception.GeneralException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.core.sync.ResponseTransformer;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import java.io.IOException;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+@Component
+@ConditionalOnProperty(
+        prefix = "profile-image",
+        name = "storage-type",
+        havingValue = "s3"
+)
+public class S3ProfileImageStorage implements ProfileImageStorage {
+
+    /*
+     * DB에 저장되는 키 형식을 제한한다.
+     *
+     * 사용자가 전달한 파일명을 S3 Key로 사용하지 않고
+     * 서버가 생성한 UUID만 사용한다.
+     */
+    private static final Pattern SAFE_KEY_PATTERN = Pattern.compile(
+            "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-"
+                    + "[0-9a-f]{4}-[0-9a-f]{12}\\.(jpg|png|webp)$"
+    );
+
+    private final S3Client s3Client;
+    private final String bucket;
+    private final String prefix;
+    private final long maxFileSizeBytes;
+
+    public S3ProfileImageStorage(
+            S3Client s3Client,
+
+            @Value("${profile-image.s3.bucket}")
+            String bucket,
+
+            @Value("${profile-image.s3.prefix:profile-images}")
+            String prefix,
+
+            @Value("${profile-image.max-file-size-bytes:5242880}")
+            long maxFileSizeBytes
+    ) {
+        /*
+         * storage-type=s3인데 버킷 환경변수가 비어 있으면
+         * 요청 시점이 아닌 서버 시작 시점에 바로 실패시킨다.
+         */
+        Assert.hasText(
+                bucket,
+                "profile-image.s3.bucket must not be blank"
+        );
+
+        this.s3Client = s3Client;
+        this.bucket = bucket;
+        this.prefix = normalizePrefix(prefix);
+        this.maxFileSizeBytes = maxFileSizeBytes;
+    }
+
+    @Override
+    public StoredProfileImage store(MultipartFile image) {
+        validateUpload(image);
+
+        byte[] bytes = readBytes(image);
+        ImageType imageType = detectImageType(bytes);
+
+        /*
+         * 원본 파일명은 사용하지 않는다.
+         * 동일 파일명 충돌과 경로 조작을 방지하기 위해 UUID를 사용한다.
+         */
+        String key = UUID.randomUUID() + imageType.extension();
+        String objectKey = toObjectKey(key);
+
+        PutObjectRequest request = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(objectKey)
+
+                // 브라우저에 반환할 때 사용할 실제 이미지 타입
+                .contentType(imageType.mediaType().toString())
+
+                // 업로드 크기를 명시해서 전송 크기를 예측 가능하게 한다.
+                .contentLength((long) bytes.length)
+                .build();
+
+        try {
+            s3Client.putObject(
+                    request,
+                    RequestBody.fromBytes(bytes)
+            );
+
+            /*
+             * DB에는 prefix가 없는 UUID 키만 저장한다.
+             *
+             * LocalProfileImageStorage와 동일한 키 형식을 유지하므로
+             * 서비스와 DTO는 저장소 종류를 알 필요가 없다.
+             */
+            return new StoredProfileImage(key);
+
+        } catch (SdkException exception) {
+            throw new GeneralException(
+                    UserErrorCode.PROFILE_IMAGE_STORAGE_FAILED
+            );
+        }
+    }
+
+    @Override
+    public ProfileImageResource load(String key) {
+        validateSafeKey(key);
+
+        GetObjectRequest request = GetObjectRequest.builder()
+                .bucket(bucket)
+                .key(toObjectKey(key))
+                .build();
+
+        try {
+            /*
+             * 프로필 이미지는 최대 5MB로 제한되어 있으므로
+             * 현재는 전체 바이트를 메모리로 읽어도 부담이 크지 않다.
+             *
+             * 더 큰 파일을 지원하게 되면 스트리밍 응답으로 변경해야 한다.
+             */
+            ResponseBytes<GetObjectResponse> response =
+                    s3Client.getObject(
+                            request,
+                            ResponseTransformer.toBytes()
+                    );
+
+            ImageType imageType = ImageType.fromKey(key);
+
+            return new ProfileImageResource(
+                    new ByteArrayResource(response.asByteArray()),
+                    imageType.mediaType()
+            );
+
+        } catch (S3Exception exception) {
+            /*
+             * DB에는 키가 있지만 S3 Object가 없는 경우다.
+             * 저장소 장애와 구분해 404로 응답한다.
+             */
+            if (exception.statusCode() == 404) {
+                throw new GeneralException(
+                        UserErrorCode.PROFILE_IMAGE_NOT_FOUND
+                );
+            }
+
+            throw new GeneralException(
+                    UserErrorCode.PROFILE_IMAGE_STORAGE_FAILED
+            );
+
+        } catch (SdkException exception) {
+            /*
+             * 네트워크 오류, IAM 자격 증명 오류 등
+             * S3 서비스 응답 이전에 발생한 SDK 오류다.
+             */
+            throw new GeneralException(
+                    UserErrorCode.PROFILE_IMAGE_STORAGE_FAILED
+            );
+        }
+    }
+
+    @Override
+    public void delete(String key) {
+        if (key == null) {
+            return;
+        }
+
+        validateSafeKey(key);
+
+        DeleteObjectRequest request = DeleteObjectRequest.builder()
+                .bucket(bucket)
+                .key(toObjectKey(key))
+                .build();
+
+        try {
+            /*
+             * S3 DeleteObject는 대상 Object가 없어도 성공처럼 처리되므로
+             * 별도의 존재 확인 요청은 필요하지 않다.
+             */
+            s3Client.deleteObject(request);
+
+        } catch (SdkException exception) {
+            throw new GeneralException(
+                    UserErrorCode.PROFILE_IMAGE_STORAGE_FAILED
+            );
+        }
+    }
+
+    private void validateUpload(MultipartFile image) {
+        if (image == null || image.isEmpty()) {
+            throw new GeneralException(
+                    UserErrorCode.INVALID_PROFILE_IMAGE
+            );
+        }
+
+        if (image.getSize() > maxFileSizeBytes) {
+            throw new GeneralException(
+                    UserErrorCode.PROFILE_IMAGE_TOO_LARGE
+            );
+        }
+    }
+
+    private byte[] readBytes(MultipartFile image) {
+        try {
+            return image.getBytes();
+        } catch (IOException exception) {
+            throw new GeneralException(
+                    UserErrorCode.PROFILE_IMAGE_STORAGE_FAILED
+            );
+        }
+    }
+
+    private String toObjectKey(String key) {
+        validateSafeKey(key);
+
+        if (prefix.isBlank()) {
+            return key;
+        }
+
+        return prefix + "/" + key;
+    }
+
+    private void validateSafeKey(String key) {
+        if (key == null || !SAFE_KEY_PATTERN.matcher(key).matches()) {
+            throw new GeneralException(
+                    UserErrorCode.INVALID_PROFILE_IMAGE
+            );
+        }
+    }
+
+    private String normalizePrefix(String rawPrefix) {
+        if (rawPrefix == null) {
+            return "";
+        }
+
+        String normalized = rawPrefix.strip();
+
+        /*
+         * 환경변수에 /profile-images/처럼 입력해도
+         * 최종 Object Key가 /profile-images//uuid가 되지 않게 한다.
+         */
+        while (normalized.startsWith("/")) {
+            normalized = normalized.substring(1);
+        }
+
+        while (normalized.endsWith("/")) {
+            normalized = normalized.substring(
+                    0,
+                    normalized.length() - 1
+            );
+        }
+
+        if (normalized.contains("..")) {
+            throw new IllegalArgumentException(
+                    "profile-image.s3.prefix must not contain '..'"
+            );
+        }
+
+        return normalized;
+    }
+
+    private ImageType detectImageType(byte[] bytes) {
+        if (isJpeg(bytes)) {
+            return ImageType.JPEG;
+        }
+
+        if (isPng(bytes)) {
+            return ImageType.PNG;
+        }
+
+        if (isWebp(bytes)) {
+            return ImageType.WEBP;
+        }
+
+        throw new GeneralException(
+                UserErrorCode.INVALID_PROFILE_IMAGE
+        );
+    }
+
+    private boolean isJpeg(byte[] bytes) {
+        return bytes.length >= 3
+                && unsigned(bytes[0]) == 0xFF
+                && unsigned(bytes[1]) == 0xD8
+                && unsigned(bytes[2]) == 0xFF;
+    }
+
+    private boolean isPng(byte[] bytes) {
+        int[] signature = {
+                0x89, 0x50, 0x4E, 0x47,
+                0x0D, 0x0A, 0x1A, 0x0A
+        };
+
+        if (bytes.length < signature.length) {
+            return false;
+        }
+
+        for (int index = 0; index < signature.length; index++) {
+            if (unsigned(bytes[index]) != signature[index]) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private boolean isWebp(byte[] bytes) {
+        return bytes.length >= 12
+                && asciiEquals(bytes, 0, "RIFF")
+                && asciiEquals(bytes, 8, "WEBP");
+    }
+
+    private boolean asciiEquals(
+            byte[] bytes,
+            int offset,
+            String expected
+    ) {
+        for (int index = 0; index < expected.length(); index++) {
+            if (bytes[offset + index]
+                    != (byte) expected.charAt(index)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private int unsigned(byte value) {
+        return value & 0xFF;
+    }
+
+    private enum ImageType {
+
+        JPEG(".jpg", MediaType.IMAGE_JPEG),
+        PNG(".png", MediaType.IMAGE_PNG),
+        WEBP(
+                ".webp",
+                MediaType.parseMediaType("image/webp")
+        );
+
+        private final String extension;
+        private final MediaType mediaType;
+
+        ImageType(
+                String extension,
+                MediaType mediaType
+        ) {
+            this.extension = extension;
+            this.mediaType = mediaType;
+        }
+
+        private String extension() {
+            return extension;
+        }
+
+        private MediaType mediaType() {
+            return mediaType;
+        }
+
+        private static ImageType fromKey(String key) {
+            for (ImageType type : values()) {
+                if (key.endsWith(type.extension)) {
+                    return type;
+                }
+            }
+
+            throw new GeneralException(
+                    UserErrorCode.INVALID_PROFILE_IMAGE
+            );
+        }
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/global/config/S3Config.java
+++ b/src/main/java/com/_penLearning/Noddi/global/config/S3Config.java
@@ -1,0 +1,35 @@
+package com._penLearning.Noddi.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+@ConditionalOnProperty(
+        prefix = "profile-image",
+        name = "storage-type",
+        havingValue = "s3"
+)
+public class S3Config {
+
+    @Bean
+    public S3Client s3Client(
+            @Value("${profile-image.s3.region}") String region
+    ) {
+        /*
+         * credentialsProvider를 직접 지정하지 않는다.
+         *
+         * 로컬에서는 AWS CLI의 로그인 정보 또는 AWS_PROFILE을 사용하고,
+         * EC2에서는 인스턴스에 연결된 IAM Role의 임시 자격 증명을
+         * AWS SDK 기본 자격 증명 체인이 자동으로 사용한다.
+         *
+         * Access Key와 Secret Key를 코드에 저장하면 안 된다.
+         */
+        return S3Client.builder()
+                .region(Region.of(region))
+                .build();
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/global/security/SecurityConfig.java
+++ b/src/main/java/com/_penLearning/Noddi/global/security/SecurityConfig.java
@@ -53,8 +53,6 @@ public class SecurityConfig {
                                 .requestMatchers("/api/v1/auth/**").permitAll()
                                 // 조직 조회 관련 API 전체 허용
                                 .requestMatchers("/api/v1/organizations/**").permitAll()
-                                // img src에서 바로 로드할 수 있도록 프로필 이미지 조회만 공개
-                                .requestMatchers(HttpMethod.GET, "/api/v1/users/*/profile-image").permitAll()
                                 // Daily.co 웹훅 수신 주소 허용 (JWT 무인증 외부 알림)
                                 .requestMatchers("/webhooks/**").permitAll()
                                 // 그 외 모든 요청은 인증 필요 (테스트 시 필요시 permitAll로 변경 가능)

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -107,5 +107,12 @@ qa:
     similarity-threshold: ${QA_RAG_SIMILARITY_THRESHOLD:0.2} # 현재 검증 데이터 기준 하한선이며 평가 결과에 따라 환경변수로 조정
 
 profile-image:
-  storage-path: ${PROFILE_IMAGE_STORAGE_PATH:./uploads/profile-images}
+  # 로컬에서는 local, EC2 운영 환경에서는 s3로 지정한다.
+  storage-type: ${PROFILE_IMAGE_STORAGE_TYPE:local}
   max-file-size-bytes: ${PROFILE_IMAGE_MAX_FILE_SIZE_BYTES:5242880}
+  local:
+    storage-path: ${PROFILE_IMAGE_STORAGE_PATH:./uploads/profile-images}
+  s3:
+    bucket: ${PROFILE_IMAGE_S3_BUCKET:}
+    region: ${AWS_REGION:ap-northeast-2}
+    prefix: ${PROFILE_IMAGE_S3_PREFIX:profile-images}

--- a/src/test/java/com/_penLearning/Noddi/domain/user/controller/UserProfileImageSecurityTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/user/controller/UserProfileImageSecurityTest.java
@@ -1,0 +1,109 @@
+package com._penLearning.Noddi.domain.user.controller;
+
+import com._penLearning.Noddi.domain.user.service.UserProfileImageService;
+import com._penLearning.Noddi.domain.user.service.UserService;
+import com._penLearning.Noddi.domain.user.storage.ProfileImageResource;
+import com._penLearning.Noddi.global.security.JwtAccessDeniedHandler;
+import com._penLearning.Noddi.global.security.JwtAuthenticationEntryPoint;
+import com._penLearning.Noddi.global.security.JwtProvider;
+import com._penLearning.Noddi.global.security.SecurityConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserController.class)
+@Import({
+        SecurityConfig.class,
+        JwtAuthenticationEntryPoint.class,
+        JwtAccessDeniedHandler.class
+})
+class UserProfileImageSecurityTest {
+
+    private static final byte[] PNG_BYTES = {
+            (byte) 0x89, 0x50, 0x4E, 0x47,
+            0x0D, 0x0A, 0x1A, 0x0A
+    };
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private UserService userService;
+
+    @MockitoBean
+    private UserProfileImageService userProfileImageService;
+
+    /*
+     * SecurityConfig가 생성하는 JWT 필터의 의존성이다.
+     * 이 테스트는 토큰 파싱이 아니라 URL 접근 정책을 검증하므로 Mock으로 대체한다.
+     */
+    @MockitoBean
+    private JwtProvider jwtProvider;
+
+    /*
+     * 메인 애플리케이션의 @EnableJpaAuditing이 웹 슬라이스에도 적용되지만
+     * @WebMvcTest는 Entity를 로딩하지 않는다. 빈 JPA 메타모델 생성 실패를 막기 위한 테스트 Bean이다.
+     */
+    @MockitoBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @Test
+    void rejectsProfileImageRequestFromUnauthenticatedUser() throws Exception {
+        /*
+         * 과거 permitAll 설정이 다시 추가되는 회귀를 방지한다.
+         * 인증 정보가 없으면 컨트롤러와 S3 조회 서비스까지 도달하지 않고 401이어야 한다.
+         */
+        mockMvc.perform(
+                        get("/api/v1/users/{userId}/profile-image", 10L)
+                )
+                .andExpect(status().isUnauthorized());
+
+        verify(userProfileImageService, never())
+                .getProfileImage(10L);
+    }
+
+    @Test
+    void returnsPrivateCachedImageToAuthenticatedUser() throws Exception {
+        /*
+         * 로그인 사용자는 이미지를 조회할 수 있어야 한다.
+         * 공유 프록시가 인증 이미지를 보관하지 않도록 Cache-Control에는 private이 포함되어야 한다.
+         */
+        when(userProfileImageService.getProfileImage(10L))
+                .thenReturn(
+                        new ProfileImageResource(
+                                new ByteArrayResource(PNG_BYTES),
+                                MediaType.IMAGE_PNG
+                        )
+                );
+
+        mockMvc.perform(
+                        get("/api/v1/users/{userId}/profile-image", 10L)
+                                .with(user("authenticated-member"))
+                )
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.IMAGE_PNG))
+                .andExpect(content().bytes(PNG_BYTES))
+                .andExpect(header().string(
+                        HttpHeaders.CACHE_CONTROL,
+                        "max-age=31536000, private, immutable"
+                ));
+
+        verify(userProfileImageService).getProfileImage(10L);
+    }
+}

--- a/src/test/java/com/_penLearning/Noddi/domain/user/service/UserProfileImageServiceTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/user/service/UserProfileImageServiceTest.java
@@ -33,7 +33,7 @@ class UserProfileImageServiceTest {
         UserProfileImageService service = new UserProfileImageService(userRepository, profileImageStorage);
         MockMultipartFile image = new MockMultipartFile("image", new byte[]{1});
         when(profileImageStorage.store(image)).thenReturn(new StoredProfileImage(NEW_KEY));
-        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userRepository.findByIdForProfileImageUpdate(1L)).thenReturn(Optional.of(user));
         when(user.updateProfileImage(NEW_KEY)).thenReturn(OLD_KEY);
         when(user.getUserId()).thenReturn(1L);
         when(user.getProfileImageKey()).thenReturn(NEW_KEY);
@@ -50,7 +50,8 @@ class UserProfileImageServiceTest {
         UserProfileImageService service = new UserProfileImageService(userRepository, profileImageStorage);
         MockMultipartFile image = new MockMultipartFile("image", new byte[]{1});
         when(profileImageStorage.store(image)).thenReturn(new StoredProfileImage(NEW_KEY));
-        when(userRepository.findById(999L)).thenReturn(Optional.empty());
+        // 이미지 변경은 동시 요청을 직렬화하기 위해 잠금 조회를 사용한다.
+        when(userRepository.findByIdForProfileImageUpdate(999L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.updateProfileImage(999L, image))
                 .isInstanceOf(GeneralException.class);
@@ -61,7 +62,8 @@ class UserProfileImageServiceTest {
     @Test
     void removesProfileImageKeyAndStoredFile() {
         UserProfileImageService service = new UserProfileImageService(userRepository, profileImageStorage);
-        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        // 이미지 삭제도 변경 요청과 동일한 사용자 행 잠금을 사용한다.
+        when(userRepository.findByIdForProfileImageUpdate(1L)).thenReturn(Optional.of(user));
         when(user.removeProfileImage()).thenReturn(OLD_KEY);
 
         service.deleteProfileImage(1L);

--- a/src/test/java/com/_penLearning/Noddi/domain/user/storage/S3ProfileImageStorageTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/user/storage/S3ProfileImageStorageTest.java
@@ -1,0 +1,269 @@
+package com._penLearning.Noddi.domain.user.storage;
+
+import com._penLearning.Noddi.domain.user.code.UserErrorCode;
+import com._penLearning.Noddi.global.exception.GeneralException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.core.sync.ResponseTransformer;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class S3ProfileImageStorageTest {
+
+    private static final String BUCKET = "noddi-profile-images";
+    private static final String PREFIX = "profile-images";
+    private static final String IMAGE_KEY =
+            "11111111-1111-1111-1111-111111111111.png";
+
+    /*
+     * 실제 PNG 전체 파일 대신 PNG 시그니처만 사용한다.
+     * 현재 저장소는 파일 확장자나 Content-Type이 아닌 실제 바이트 시그니처를 검사한다.
+     */
+    private static final byte[] PNG_BYTES = {
+            (byte) 0x89, 0x50, 0x4E, 0x47,
+            0x0D, 0x0A, 0x1A, 0x0A
+    };
+
+    @Mock
+    private S3Client s3Client;
+
+    private S3ProfileImageStorage storage;
+
+    @BeforeEach
+    void setUp() {
+        storage = new S3ProfileImageStorage(
+                s3Client,
+                BUCKET,
+                PREFIX,
+                5 * 1024 * 1024
+        );
+    }
+
+    @Test
+    void uploadsPngToConfiguredBucketAndPrefix() {
+        /*
+         * MultipartFile을 검증한 뒤 UUID.png 키를 만들고,
+         * 설정한 버킷의 profile-images 하위로 업로드하는지 확인한다.
+         */
+        MockMultipartFile image = new MockMultipartFile(
+                "image",
+                "original-file.txt",
+                MediaType.TEXT_PLAIN_VALUE,
+                PNG_BYTES
+        );
+
+        StoredProfileImage result = storage.store(image);
+
+        ArgumentCaptor<PutObjectRequest> requestCaptor =
+                ArgumentCaptor.forClass(PutObjectRequest.class);
+
+        verify(s3Client).putObject(
+                requestCaptor.capture(),
+                any(RequestBody.class)
+        );
+
+        PutObjectRequest request = requestCaptor.getValue();
+
+        assertThat(result.key())
+                .matches("^[0-9a-f-]{36}\\.png$");
+        assertThat(request.bucket()).isEqualTo(BUCKET);
+        assertThat(request.key()).isEqualTo(PREFIX + "/" + result.key());
+        assertThat(request.contentType()).isEqualTo(MediaType.IMAGE_PNG_VALUE);
+        assertThat(request.contentLength()).isEqualTo((long) PNG_BYTES.length);
+    }
+
+    @Test
+    void loadsS3ObjectAsProfileImageResource() throws Exception {
+        /*
+         * DB에 저장된 UUID 키에 prefix를 붙여 S3에서 조회하고,
+         * 응답 바이트와 확장자에 맞는 MediaType을 Resource로 반환하는지 확인한다.
+         */
+        ResponseBytes<GetObjectResponse> responseBytes =
+                ResponseBytes.fromByteArray(
+                        GetObjectResponse.builder()
+                                .contentType(MediaType.IMAGE_PNG_VALUE)
+                                .build(),
+                        PNG_BYTES
+                );
+
+        when(s3Client.getObject(
+                any(GetObjectRequest.class),
+                org.mockito.ArgumentMatchers
+                        .<ResponseTransformer<
+                                GetObjectResponse,
+                                ResponseBytes<GetObjectResponse>
+                                >>any()
+        )).thenReturn(responseBytes);
+
+        ProfileImageResource result = storage.load(IMAGE_KEY);
+
+        ArgumentCaptor<GetObjectRequest> requestCaptor =
+                ArgumentCaptor.forClass(GetObjectRequest.class);
+
+        verify(s3Client).getObject(
+                requestCaptor.capture(),
+                org.mockito.ArgumentMatchers
+                        .<ResponseTransformer<
+                                GetObjectResponse,
+                                ResponseBytes<GetObjectResponse>
+                                >>any()
+        );
+
+        assertThat(requestCaptor.getValue().bucket()).isEqualTo(BUCKET);
+        assertThat(requestCaptor.getValue().key()).isEqualTo(PREFIX + "/" + IMAGE_KEY);
+        assertThat(result.mediaType()).isEqualTo(MediaType.IMAGE_PNG);
+        assertThat(result.resource().getContentAsByteArray()).containsExactly(PNG_BYTES);
+    }
+
+    @Test
+    void deletesObjectUsingConfiguredPrefix() {
+        // DB에는 UUID 키만 저장되지만 실제 삭제 요청에는 S3 prefix가 붙어야 한다.
+        storage.delete(IMAGE_KEY);
+
+        ArgumentCaptor<DeleteObjectRequest> requestCaptor =
+                ArgumentCaptor.forClass(DeleteObjectRequest.class);
+
+        verify(s3Client).deleteObject(requestCaptor.capture());
+
+        assertThat(requestCaptor.getValue().bucket()).isEqualTo(BUCKET);
+        assertThat(requestCaptor.getValue().key()).isEqualTo(PREFIX + "/" + IMAGE_KEY);
+    }
+
+    @Test
+    void rejectsInvalidImageBeforeCallingS3() {
+        /*
+         * 파일 이름과 Content-Type만 PNG인 위장 파일은 거부하고,
+         * 검증 실패 시 S3 요청을 전혀 보내지 않는지 확인한다.
+         */
+        MockMultipartFile invalidImage = new MockMultipartFile(
+                "image",
+                "fake.png",
+                MediaType.IMAGE_PNG_VALUE,
+                "not-an-image".getBytes()
+        );
+
+        GeneralException exception = catchThrowableOfType(
+                GeneralException.class,
+                () -> storage.store(invalidImage)
+        );
+
+        assertThat(exception.getErrorCode())
+                .isEqualTo(UserErrorCode.INVALID_PROFILE_IMAGE);
+        verifyNoInteractions(s3Client);
+    }
+
+    @Test
+    void convertsS3NotFoundResponseToProfileImageNotFound() {
+        /*
+         * DB에는 이미지 키가 있지만 실제 S3 Object가 없을 때,
+         * 일반 저장소 장애가 아닌 프로필 이미지 없음 예외로 변환하는지 확인한다.
+         */
+        when(s3Client.getObject(
+                any(GetObjectRequest.class),
+                org.mockito.ArgumentMatchers
+                        .<ResponseTransformer<
+                                GetObjectResponse,
+                                ResponseBytes<GetObjectResponse>
+                                >>any()
+        )).thenThrow(
+                S3Exception.builder()
+                        .statusCode(404)
+                        .message("No such key")
+                        .build()
+        );
+
+        GeneralException exception = catchThrowableOfType(
+                GeneralException.class,
+                () -> storage.load(IMAGE_KEY)
+        );
+
+        assertThat(exception.getErrorCode())
+                .isEqualTo(UserErrorCode.PROFILE_IMAGE_NOT_FOUND);
+    }
+
+    @Test
+    void convertsS3UploadFailureToStorageFailure() {
+        /*
+         * 이미지 자체는 정상이어도 S3가 500을 반환할 수 있다.
+         * AWS SDK 예외가 컨트롤러까지 노출되지 않고 서비스 공통 저장 실패로 변환되는지 확인한다.
+         */
+        MockMultipartFile image = new MockMultipartFile(
+                "image",
+                "profile.png",
+                MediaType.IMAGE_PNG_VALUE,
+                PNG_BYTES
+        );
+
+        when(s3Client.putObject(
+                any(PutObjectRequest.class),
+                any(RequestBody.class)
+        )).thenThrow(
+                S3Exception.builder()
+                        .statusCode(500)
+                        .message("S3 internal error")
+                        .build()
+        );
+
+        GeneralException exception = catchThrowableOfType(
+                GeneralException.class,
+                () -> storage.store(image)
+        );
+
+        assertThat(exception.getErrorCode())
+                .isEqualTo(UserErrorCode.PROFILE_IMAGE_STORAGE_FAILED);
+    }
+
+    @Test
+    void convertsNon404S3LoadFailureToStorageFailure() {
+        // 404가 아닌 권한·네트워크·S3 서버 오류는 이미지 없음이 아니라 저장소 장애로 처리한다.
+        when(s3Client.getObject(
+                any(GetObjectRequest.class),
+                org.mockito.ArgumentMatchers
+                        .<ResponseTransformer<
+                                GetObjectResponse,
+                                ResponseBytes<GetObjectResponse>
+                                >>any()
+        )).thenThrow(
+                S3Exception.builder()
+                        .statusCode(500)
+                        .message("S3 internal error")
+                        .build()
+        );
+
+        GeneralException exception = catchThrowableOfType(
+                GeneralException.class,
+                () -> storage.load(IMAGE_KEY)
+        );
+
+        assertThat(exception.getErrorCode())
+                .isEqualTo(UserErrorCode.PROFILE_IMAGE_STORAGE_FAILED);
+    }
+
+    @Test
+    void ignoresDeleteWhenImageKeyIsNull() {
+        // 프로필 이미지가 없는 사용자의 삭제 요청은 S3를 호출하지 않는 멱등 동작이어야 한다.
+        storage.delete(null);
+
+        verifyNoInteractions(s3Client);
+    }
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

## 🎋 작업 브랜치
- feature/67 -> develop
- #67  (관련이슈 번호)

## 💡 작업동기
- 기존 localStorage를 사용하던 프로필 이미지를 s3 storage 사용으로 변경합니다

## 🔑 주요 변경사항
- 이번 PR에서 작업한 내용을 간략히 설명해주세요.

## 🏞 스크린샷 (선택)
> 스크린샷을 첨부해주세요.

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
