### PR TITLE
[feat] 홈 AI 답변 현황 조회 API 구현

### DIFF
--- a/src/main/java/com/_penLearning/Noddi/domain/home/code/HomeAiAnswerApi.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/home/code/HomeAiAnswerApi.java
@@ -1,0 +1,37 @@
+package com._penLearning.Noddi.domain.home.code;
+
+import com._penLearning.Noddi.domain.auth.entity.AuthMember;
+import com._penLearning.Noddi.domain.home.dto.HomeAiAnswerResponseDto;
+import com._penLearning.Noddi.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import java.util.List;
+
+@Tag(
+        name = "홈 AI 답변 현황 API",
+        description = "현재 사용자가 검토해야 할 AI 답변 현황 조회 API"
+)
+public interface HomeAiAnswerApi {
+
+    @Operation(
+            summary = "프로젝트별 미확인 AI 답변 개수 조회",
+            description = "현재 사용자가 소속된 팀의 미확인 AI 답변을 프로젝트별로 집계합니다."
+    )
+    ApiResponse<List<HomeAiAnswerResponseDto.ProjectStatus>>
+    getUnreadAnswerCountsByProject(
+            @Parameter(hidden = true) AuthMember authMember
+    );
+
+    @Operation(
+            summary = "프로젝트의 미확인 AI 답변 카드 조회",
+            description = "선택한 프로젝트에서 현재 사용자가 검토해야 할 AI 답변을 최신순으로 조회합니다."
+    )
+    ApiResponse<HomeAiAnswerResponseDto.CardPage> getUnreadAnswerCards(
+            @Parameter(description = "프로젝트 ID") Long projectId,
+            @Parameter(description = "페이지 번호, 0부터 시작", example = "0") int page,
+            @Parameter(description = "페이지 크기, 1 이상 50 이하", example = "10") int size,
+            @Parameter(hidden = true) AuthMember authMember
+    );
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/home/code/HomeErrorCode.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/home/code/HomeErrorCode.java
@@ -1,0 +1,33 @@
+package com._penLearning.Noddi.domain.home.code;
+
+import com._penLearning.Noddi.global.apiPayload.code.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum HomeErrorCode implements BaseErrorCode {
+
+    INVALID_PAGE_REQUEST(
+            HttpStatus.BAD_REQUEST,
+            "HOME400_1",
+            "페이지는 0 이상, 조회 크기는 1 이상 50 이하여야 합니다."
+    ),
+
+    NOT_PROJECT_MEMBER(
+            HttpStatus.FORBIDDEN,
+            "HOME403_1",
+            "해당 프로젝트의 멤버가 아닙니다."
+    ),
+
+    AI_ANSWER_DATA_NOT_FOUND(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "HOME500_1",
+            "홈 AI 답변 카드 데이터를 구성할 수 없습니다."
+    );
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/home/controller/HomeAiAnswerController.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/home/controller/HomeAiAnswerController.java
@@ -1,0 +1,64 @@
+package com._penLearning.Noddi.domain.home.controller;
+
+import com._penLearning.Noddi.domain.auth.entity.AuthMember;
+import com._penLearning.Noddi.domain.home.code.HomeAiAnswerApi;
+import com._penLearning.Noddi.domain.home.dto.HomeAiAnswerResponseDto;
+import com._penLearning.Noddi.domain.home.service.HomeAiAnswerQueryService;
+import com._penLearning.Noddi.global.apiPayload.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/home/ai-answers")
+@RequiredArgsConstructor
+public class HomeAiAnswerController implements HomeAiAnswerApi {
+
+    private final HomeAiAnswerQueryService homeAiAnswerQueryService;
+
+    @Override
+    @GetMapping("/projects")
+    public ApiResponse<List<HomeAiAnswerResponseDto.ProjectStatus>>
+    getUnreadAnswerCountsByProject(
+            @AuthenticationPrincipal AuthMember authMember
+    ) {
+        List<HomeAiAnswerResponseDto.ProjectStatus> response =
+                homeAiAnswerQueryService.getUnreadAnswerCountsByProject(
+                        authMember.getUserId()
+                );
+
+        return ApiResponse.onSuccess(
+                "프로젝트별 미확인 AI 답변 현황 조회에 성공했습니다.",
+                response
+        );
+    }
+
+    @Override
+    @GetMapping("/projects/{projectId}")
+    public ApiResponse<HomeAiAnswerResponseDto.CardPage>
+    getUnreadAnswerCards(
+            @PathVariable Long projectId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @AuthenticationPrincipal AuthMember authMember
+    ) {
+        HomeAiAnswerResponseDto.CardPage response =
+                homeAiAnswerQueryService.getUnreadAnswerCards(
+                        authMember.getUserId(),
+                        projectId,
+                        page,
+                        size
+                );
+
+        return ApiResponse.onSuccess(
+                "미확인 AI 답변 카드 조회에 성공했습니다.",
+                response
+        );
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/home/dto/HomeAiAnswerCountProjection.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/home/dto/HomeAiAnswerCountProjection.java
@@ -1,0 +1,14 @@
+package com._penLearning.Noddi.domain.home.dto;
+
+/**
+ * 프로젝트별 미확인 AI 답변 개수 쿼리 결과를 받는 인터페이스 프로젝션이다.
+ *
+ * JPQL의 별칭(projectId, unreadCount)과 getter 이름이 대응한다.
+ * 엔티티 전체가 필요하지 않은 집계 조회에서 필요한 값만 가져오기 위해 사용한다.
+ */
+public interface HomeAiAnswerCountProjection {
+
+    Long getProjectId();
+
+    long getUnreadCount();
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/home/dto/HomeAiAnswerResponseDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/home/dto/HomeAiAnswerResponseDto.java
@@ -1,0 +1,194 @@
+package com._penLearning.Noddi.domain.home.dto;
+
+import com._penLearning.Noddi.domain.notification.entity.Notification;
+import com._penLearning.Noddi.domain.qa.entity.QaAnswer;
+import com._penLearning.Noddi.domain.qa.entity.QaAnswerSource;
+import com._penLearning.Noddi.domain.qa.entity.QaQuestion;
+import com._penLearning.Noddi.domain.qa.entity.SourceType;
+import com._penLearning.Noddi.domain.team.entity.Team;
+import com._penLearning.Noddi.domain.user.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class HomeAiAnswerResponseDto {
+
+    /** 홈 프로젝트 탭에 표시할 프로젝트명과 미확인 AI 답변 개수다. */
+    @Getter
+    @Builder
+    public static class ProjectStatus {
+
+        private Long projectId;
+        private String projectName;
+        private long unreadAnswerCount;
+
+        public static ProjectStatus of(
+                HomeProjectProjection project,
+                long unreadAnswerCount
+        ) {
+            return ProjectStatus.builder()
+                    .projectId(project.getProjectId())
+                    .projectName(project.getProjectName())
+                    .unreadAnswerCount(unreadAnswerCount)
+                    .build();
+        }
+    }
+
+    /** 선택한 프로젝트의 카드 목록과 페이지 정보를 함께 반환한다. */
+    @Getter
+    @Builder
+    public static class CardPage {
+
+        private List<Card> items;
+        private int page;
+        private int size;
+        private long totalElements;
+        private int totalPages;
+        private boolean hasNext;
+        private boolean hasPrevious;
+    }
+
+    /** 와이어프레임에서 한 장으로 표시할 미확인 AI 답변 카드다. */
+    @Getter
+    @Builder
+    public static class Card {
+
+        private Long notificationId;
+        private Long questionId;
+
+        private Questioner questioner;
+        private String questionContent;
+        private LocalDateTime questionCreatedAt;
+
+        private Long answerId;
+        private String answerContent;
+
+        private Long projectId;
+        private String projectName;
+        private Long teamId;
+        private String teamName;
+
+        private List<Source> sources;
+
+        public static Card of(
+                Notification notification,
+                QaAnswer answer,
+                List<QaAnswerSource> sources
+        ) {
+            QaQuestion question = answer.getQuestion();
+            Team team = question.getTargetTeam();
+
+            return Card.builder()
+                    .notificationId(notification.getNotificationId())
+                    .questionId(question.getQuestionId())
+                    .questioner(Questioner.from(question.getQuestioner()))
+                    .questionContent(question.getContent())
+                    .questionCreatedAt(question.getCreatedAt())
+                    .answerId(answer.getAnswerId())
+                    .answerContent(answer.getContent())
+                    .projectId(team.getProject().getProjectId())
+                    .projectName(team.getProject().getName())
+                    .teamId(team.getTeamId())
+                    .teamName(team.getName())
+                    .sources(sources.stream()
+                            .map(source -> Source.from(
+                                    source,
+                                    team.getTeamId()
+                            ))
+                            .toList())
+                    .build();
+        }
+    }
+
+    /** AI 답변이 실제로 인용한 회의 전사 또는 팀 공유 페이지다. */
+    @Getter
+    @Builder
+    public static class Source {
+
+        private int citationIndex;
+        private SourceType sourceType;
+        private Long referenceId;
+        private String sourceTitle;
+        private String excerpt;
+        private SourceNavigation navigation;
+
+        public static Source from(
+                QaAnswerSource source,
+                Long targetTeamId
+        ) {
+            return Source.builder()
+                    .citationIndex(source.getCitationIndex())
+                    .sourceType(source.getSourceType())
+                    .referenceId(source.getReferenceId())
+                    .sourceTitle(source.getSourceTitle())
+                    .excerpt(source.getExcerpt())
+                    .navigation(SourceNavigation.from(
+                            source,
+                            targetTeamId
+                    ))
+                    .build();
+        }
+    }
+
+    /** 출처 종류별 상세 화면 이동에 필요한 식별자를 구조화한다. */
+    @Getter
+    @Builder
+    public static class SourceNavigation {
+
+        private HomeAiAnswerSourceNavigationType type;
+        private Long meetingId;
+        private Long teamId;
+        private Long pageId;
+
+        public static SourceNavigation from(
+                QaAnswerSource source,
+                Long targetTeamId
+        ) {
+            return switch (source.getSourceType()) {
+                case TRANSCRIPT -> SourceNavigation.builder()
+                        .type(HomeAiAnswerSourceNavigationType.MEETING_SUMMARY)
+                        .meetingId(source.getReferenceId())
+                        .build();
+
+                case TEAM_TEXT -> SourceNavigation.builder()
+                        .type(HomeAiAnswerSourceNavigationType.TEAM_PAGE)
+                        .teamId(targetTeamId)
+                        .pageId(source.getReferenceId())
+                        .build();
+            };
+        }
+    }
+
+    /** 카드 상단에 표시할 질문자의 공개 프로필 정보다. */
+    @Getter
+    @Builder
+    public static class Questioner {
+
+        private Long userId;
+        private String name;
+        private String department;
+        private String position;
+        private String profileImageUrl;
+
+        public static Questioner from(User user) {
+            return Questioner.builder()
+                    .userId(user.getUserId())
+                    .name(user.getName())
+                    .department(user.getDepartment())
+                    .position(user.getPosition())
+                    .profileImageUrl(profileImageUrl(user))
+                    .build();
+        }
+
+        private static String profileImageUrl(User user) {
+            if (user.getProfileImageKey() == null) {
+                return null;
+            }
+
+            return "/api/v1/users/" + user.getUserId()
+                    + "/profile-image?v=" + user.getProfileImageKey();
+        }
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/home/dto/HomeAiAnswerSourceNavigationType.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/home/dto/HomeAiAnswerSourceNavigationType.java
@@ -1,0 +1,7 @@
+package com._penLearning.Noddi.domain.home.dto;
+
+/** 홈 카드의 출처 버튼을 눌렀을 때 이동할 화면 종류다. */
+public enum HomeAiAnswerSourceNavigationType {
+    MEETING_SUMMARY,
+    TEAM_PAGE
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/home/dto/HomeProjectProjection.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/home/dto/HomeProjectProjection.java
@@ -1,0 +1,9 @@
+package com._penLearning.Noddi.domain.home.dto;
+
+/** 현재 사용자가 참여 중인 프로젝트 탭을 구성하기 위한 조회 프로젝션이다. */
+public interface HomeProjectProjection {
+
+    Long getProjectId();
+
+    String getProjectName();
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/home/repository/HomeAiAnswerDetailRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/home/repository/HomeAiAnswerDetailRepository.java
@@ -1,0 +1,34 @@
+package com._penLearning.Noddi.domain.home.repository;
+
+import com._penLearning.Noddi.domain.qa.entity.QaAnswer;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Collection;
+import java.util.List;
+
+/** 홈 카드 조립에 필요한 Q&A 상세 데이터를 일괄 조회한다. */
+public interface HomeAiAnswerDetailRepository
+        extends Repository<QaAnswer, Long> {
+
+    /**
+     * 현재 답변과 카드에 필요한 모든 단일 연관관계를 한 번에 조회한다.
+     *
+     * 출처처럼 컬렉션인 연관관계는 여기서 fetch join하지 않는다.
+     * 컬렉션 fetch join은 결과 행을 증가시켜 페이징 및 중복 처리에 불리하기 때문이다.
+     */
+    @Query("""
+            SELECT answer
+            FROM QaAnswer answer
+            JOIN FETCH answer.question question
+            JOIN FETCH question.questioner
+            JOIN FETCH question.targetTeam team
+            JOIN FETCH team.project
+            LEFT JOIN FETCH answer.revisedBy
+            WHERE question.questionId IN :questionIds
+            """)
+    List<QaAnswer> findAllCardDetailsByQuestionIds(
+            @Param("questionIds") Collection<Long> questionIds
+    );
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/home/repository/HomeAiAnswerRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/home/repository/HomeAiAnswerRepository.java
@@ -18,18 +18,19 @@ public interface HomeAiAnswerRepository
         extends Repository<Notification, Long> {
 
     /**
-     * 홈 상단 탭에 표시할 현재 사용자의 모든 참여 프로젝트를 조회한다.
+     * 홈 상단 탭에 표시할 현재 사용자의 팀 소속 프로젝트를 조회한다.
      *
-     * 알림 유무와 무관하게 조회하므로 미확인 답변이 0개인 프로젝트도 포함된다.
+     * 한 프로젝트의 여러 팀에 속할 수 있으므로 DISTINCT로 중복을 제거한다.
+     * 알림이 없더라도 현재 소속 팀이 하나 이상인 프로젝트는 0개 탭으로 포함된다.
      */
     @Query("""
-            SELECT projectMember.project.projectId AS projectId,
-                   projectMember.project.name AS projectName
-            FROM ProjectMember projectMember
-            WHERE projectMember.user.userId = :userId
-            ORDER BY projectMember.project.projectId ASC
+            SELECT DISTINCT teamMember.team.project.projectId AS projectId,
+                            teamMember.team.project.name AS projectName
+            FROM TeamMember teamMember
+            WHERE teamMember.user.userId = :userId
+            ORDER BY teamMember.team.project.projectId ASC
             """)
-    List<HomeProjectProjection> findProjectsByMemberUserId(
+    List<HomeProjectProjection> findProjectsByTeamMemberUserId(
             @Param("userId") Long userId
     );
 

--- a/src/main/java/com/_penLearning/Noddi/domain/home/repository/HomeAiAnswerRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/home/repository/HomeAiAnswerRepository.java
@@ -1,0 +1,148 @@
+package com._penLearning.Noddi.domain.home.repository;
+
+import com._penLearning.Noddi.domain.home.dto.HomeAiAnswerCountProjection;
+import com._penLearning.Noddi.domain.home.dto.HomeProjectProjection;
+import com._penLearning.Noddi.domain.notification.entity.Notification;
+import com._penLearning.Noddi.domain.notification.entity.NotificationReferenceType;
+import com._penLearning.Noddi.domain.notification.entity.NotificationType;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+/** 홈 AI 답변 현황에 필요한 읽기 전용 쿼리를 관리한다. */
+public interface HomeAiAnswerRepository
+        extends Repository<Notification, Long> {
+
+    /**
+     * 홈 상단 탭에 표시할 현재 사용자의 모든 참여 프로젝트를 조회한다.
+     *
+     * 알림 유무와 무관하게 조회하므로 미확인 답변이 0개인 프로젝트도 포함된다.
+     */
+    @Query("""
+            SELECT projectMember.project.projectId AS projectId,
+                   projectMember.project.name AS projectName
+            FROM ProjectMember projectMember
+            WHERE projectMember.user.userId = :userId
+            ORDER BY projectMember.project.projectId ASC
+            """)
+    List<HomeProjectProjection> findProjectsByMemberUserId(
+            @Param("userId") Long userId
+    );
+
+    /**
+     * 현재 사용자가 아직 검토하지 않은 AI 답변 알림을 프로젝트별로 집계한다.
+     *
+     * Notification의 수신자 조건으로 다른 사용자의 알림을 차단하고,
+     * EXISTS 서브쿼리로 사용자가 현재도 알림의 대상 팀에 소속돼 있는지 확인한다.
+     */
+    @Query("""
+            SELECT notification.projectId AS projectId,
+                   COUNT(notification.notificationId) AS unreadCount
+            FROM Notification notification
+            WHERE notification.user.userId = :userId
+              AND notification.type = :notificationType
+              AND notification.referenceType = :referenceType
+              AND notification.read = false
+              AND notification.hidden = false
+              AND EXISTS (
+                    SELECT teamMember.teamMemberId
+                    FROM TeamMember teamMember
+                    WHERE teamMember.user.userId = :userId
+                      AND teamMember.team.teamId = notification.teamId
+              )
+              AND EXISTS (
+                    SELECT answer.answerId
+                    FROM QaAnswer answer
+                    WHERE answer.question.questionId = notification.referenceId
+                      AND answer.question.targetTeam.teamId = notification.teamId
+                      AND answer.question.targetTeam.project.projectId = notification.projectId
+              )
+            GROUP BY notification.projectId
+            ORDER BY notification.projectId ASC
+            """)
+    List<HomeAiAnswerCountProjection> findUnreadAiAnswerCountsByProject(
+            @Param("userId") Long userId,
+            @Param("notificationType") NotificationType notificationType,
+            @Param("referenceType") NotificationReferenceType referenceType
+    );
+
+    /** 요청자가 현재 프로젝트 멤버인지 ID만으로 확인한다. */
+    @Query("""
+            SELECT CASE WHEN COUNT(projectMember) > 0 THEN true ELSE false END
+            FROM ProjectMember projectMember
+            WHERE projectMember.project.projectId = :projectId
+              AND projectMember.user.userId = :userId
+            """)
+    boolean existsProjectMembership(
+            @Param("projectId") Long projectId,
+            @Param("userId") Long userId
+    );
+
+    /**
+     * 선택한 프로젝트의 유효한 미확인 AI 검토 알림을 최신순으로 조회한다.
+     *
+     * EXISTS 조건은 현재 팀 소속과 질문·답변의 존재를 함께 검증한다.
+     * 삭제된 리소스를 참조하는 오래된 알림이 카드로 노출되는 것을 막는다.
+     */
+    @Query(
+            value = """
+                    SELECT notification
+                    FROM Notification notification
+                    WHERE notification.user.userId = :userId
+                      AND notification.projectId = :projectId
+                      AND notification.type = :notificationType
+                      AND notification.referenceType = :referenceType
+                      AND notification.read = false
+                      AND notification.hidden = false
+                      AND EXISTS (
+                            SELECT teamMember.teamMemberId
+                            FROM TeamMember teamMember
+                            WHERE teamMember.user.userId = :userId
+                              AND teamMember.team.teamId = notification.teamId
+                      )
+                      AND EXISTS (
+                            SELECT answer.answerId
+                            FROM QaAnswer answer
+                            WHERE answer.question.questionId = notification.referenceId
+                              AND answer.question.targetTeam.teamId = notification.teamId
+                              AND answer.question.targetTeam.project.projectId = notification.projectId
+                      )
+                    ORDER BY notification.occurredAt DESC,
+                             notification.notificationId DESC
+                    """,
+            countQuery = """
+                    SELECT COUNT(notification)
+                    FROM Notification notification
+                    WHERE notification.user.userId = :userId
+                      AND notification.projectId = :projectId
+                      AND notification.type = :notificationType
+                      AND notification.referenceType = :referenceType
+                      AND notification.read = false
+                      AND notification.hidden = false
+                      AND EXISTS (
+                            SELECT teamMember.teamMemberId
+                            FROM TeamMember teamMember
+                            WHERE teamMember.user.userId = :userId
+                              AND teamMember.team.teamId = notification.teamId
+                      )
+                      AND EXISTS (
+                            SELECT answer.answerId
+                            FROM QaAnswer answer
+                            WHERE answer.question.questionId = notification.referenceId
+                              AND answer.question.targetTeam.teamId = notification.teamId
+                              AND answer.question.targetTeam.project.projectId = notification.projectId
+                      )
+                    """
+    )
+    Page<Notification> findUnreadAiAnswerNotifications(
+            @Param("userId") Long userId,
+            @Param("projectId") Long projectId,
+            @Param("notificationType") NotificationType notificationType,
+            @Param("referenceType") NotificationReferenceType referenceType,
+            Pageable pageable
+    );
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/home/service/HomeAiAnswerQueryService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/home/service/HomeAiAnswerQueryService.java
@@ -45,7 +45,7 @@ public class HomeAiAnswerQueryService {
                         projection -> projection.getUnreadCount()
                 ));
 
-        return homeAiAnswerRepository.findProjectsByMemberUserId(userId)
+        return homeAiAnswerRepository.findProjectsByTeamMemberUserId(userId)
                 .stream()
                 .map(project -> HomeAiAnswerResponseDto.ProjectStatus.of(
                         project,

--- a/src/main/java/com/_penLearning/Noddi/domain/home/service/HomeAiAnswerQueryService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/home/service/HomeAiAnswerQueryService.java
@@ -1,0 +1,173 @@
+package com._penLearning.Noddi.domain.home.service;
+
+import com._penLearning.Noddi.domain.home.code.HomeErrorCode;
+import com._penLearning.Noddi.domain.home.dto.HomeAiAnswerResponseDto;
+import com._penLearning.Noddi.domain.home.repository.HomeAiAnswerDetailRepository;
+import com._penLearning.Noddi.domain.home.repository.HomeAiAnswerRepository;
+import com._penLearning.Noddi.domain.notification.entity.Notification;
+import com._penLearning.Noddi.domain.notification.entity.NotificationReferenceType;
+import com._penLearning.Noddi.domain.notification.entity.NotificationType;
+import com._penLearning.Noddi.domain.qa.entity.QaAnswer;
+import com._penLearning.Noddi.domain.qa.entity.QaAnswerSource;
+import com._penLearning.Noddi.domain.qa.repository.QaAnswerSourceRepository;
+import com._penLearning.Noddi.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HomeAiAnswerQueryService {
+
+    private final HomeAiAnswerRepository homeAiAnswerRepository;
+    private final HomeAiAnswerDetailRepository homeAiAnswerDetailRepository;
+    private final QaAnswerSourceRepository qaAnswerSourceRepository;
+
+    /** 홈 프로젝트 탭에 표시할 미확인 AI 답변 개수를 조회한다. */
+    public List<HomeAiAnswerResponseDto.ProjectStatus>
+    getUnreadAnswerCountsByProject(Long userId) {
+        Map<Long, Long> unreadCountByProjectId =
+                homeAiAnswerRepository.findUnreadAiAnswerCountsByProject(
+                        userId,
+                        NotificationType.QA_AI_REVIEW_REQUIRED,
+                        NotificationReferenceType.QA_QUESTION
+                ).stream()
+                .collect(Collectors.toMap(
+                        projection -> projection.getProjectId(),
+                        projection -> projection.getUnreadCount()
+                ));
+
+        return homeAiAnswerRepository.findProjectsByMemberUserId(userId)
+                .stream()
+                .map(project -> HomeAiAnswerResponseDto.ProjectStatus.of(
+                        project,
+                        unreadCountByProjectId.getOrDefault(
+                                project.getProjectId(),
+                                0L
+                        )
+                ))
+                .toList();
+    }
+
+    /** 선택한 프로젝트의 미확인 AI 답변을 홈 카드 형태로 조회한다. */
+    public HomeAiAnswerResponseDto.CardPage getUnreadAnswerCards(
+            Long userId,
+            Long projectId,
+            int page,
+            int size
+    ) {
+        validatePageRequest(page, size);
+        validateProjectMembership(userId, projectId);
+
+        Page<Notification> notificationPage =
+                homeAiAnswerRepository.findUnreadAiAnswerNotifications(
+                        userId,
+                        projectId,
+                        NotificationType.QA_AI_REVIEW_REQUIRED,
+                        NotificationReferenceType.QA_QUESTION,
+                        PageRequest.of(page, size)
+                );
+
+        List<Long> questionIds = notificationPage.getContent().stream()
+                .map(Notification::getReferenceId)
+                .toList();
+
+        List<QaAnswer> answers = findAnswers(questionIds);
+
+        Map<Long, QaAnswer> answerByQuestionId = answers
+                .stream()
+                .collect(Collectors.toMap(
+                        answer -> answer.getQuestion().getQuestionId(),
+                        Function.identity()
+                ));
+
+        Map<Long, List<QaAnswerSource>> sourcesByAnswerId =
+                findSources(answers).stream()
+                        .collect(Collectors.groupingBy(
+                                source -> source.getAnswer().getAnswerId()
+                        ));
+
+        List<HomeAiAnswerResponseDto.Card> cards =
+                notificationPage.getContent().stream()
+                        .map(notification -> {
+                            QaAnswer answer = getAnswerOrThrow(
+                                    answerByQuestionId,
+                                    notification.getReferenceId()
+                            );
+
+                            return HomeAiAnswerResponseDto.Card.of(
+                                    notification,
+                                    answer,
+                                    sourcesByAnswerId.getOrDefault(
+                                            answer.getAnswerId(),
+                                            List.of()
+                                    )
+                            );
+                        })
+                        .toList();
+
+        return HomeAiAnswerResponseDto.CardPage.builder()
+                .items(cards)
+                .page(notificationPage.getNumber())
+                .size(notificationPage.getSize())
+                .totalElements(notificationPage.getTotalElements())
+                .totalPages(notificationPage.getTotalPages())
+                .hasNext(notificationPage.hasNext())
+                .hasPrevious(notificationPage.hasPrevious())
+                .build();
+    }
+
+    private List<QaAnswer> findAnswers(List<Long> questionIds) {
+        if (questionIds.isEmpty()) {
+            return List.of();
+        }
+
+        return homeAiAnswerDetailRepository
+                .findAllCardDetailsByQuestionIds(questionIds);
+    }
+
+    private List<QaAnswerSource> findSources(List<QaAnswer> answers) {
+        if (answers.isEmpty()) {
+            return List.of();
+        }
+
+        return qaAnswerSourceRepository
+                .findAllByAnswersOrderByCitationIndex(answers);
+    }
+
+    private QaAnswer getAnswerOrThrow(
+            Map<Long, QaAnswer> answerByQuestionId,
+            Long questionId
+    ) {
+        QaAnswer answer = answerByQuestionId.get(questionId);
+        if (answer == null) {
+            throw new GeneralException(
+                    HomeErrorCode.AI_ANSWER_DATA_NOT_FOUND
+            );
+        }
+        return answer;
+    }
+
+    private void validateProjectMembership(Long userId, Long projectId) {
+        if (!homeAiAnswerRepository.existsProjectMembership(
+                projectId,
+                userId
+        )) {
+            throw new GeneralException(HomeErrorCode.NOT_PROJECT_MEMBER);
+        }
+    }
+
+    private void validatePageRequest(int page, int size) {
+        if (page < 0 || size < 1 || size > 50) {
+            throw new GeneralException(HomeErrorCode.INVALID_PAGE_REQUEST);
+        }
+    }
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/qa/dto/QaResponseDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/dto/QaResponseDto.java
@@ -9,6 +9,7 @@ import com._penLearning.Noddi.domain.qa.entity.SourceType;
 import com._penLearning.Noddi.domain.qa.entity.QaAnswerRevision;
 import com._penLearning.Noddi.domain.qa.entity.RevisionEditorType;
 import com._penLearning.Noddi.domain.team.entity.Team;
+import com._penLearning.Noddi.domain.user.entity.User;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -223,19 +224,35 @@ public class QaResponseDto {
 
         private Long questionerId;
         private String questionerName;
+        private String questionerDepartment;
+        private String questionerPosition;
+        private String questionerProfileImageUrl;
 
         private String content;
         private LocalDateTime createdAt;
-        //현재 소속 부서 + 직함 엔티티가 없어서 일단 빼고 이름만 반환
 
         public static FeedQuestion from(QaQuestion question){
+            User questioner = question.getQuestioner();
+
             return FeedQuestion.builder()
                     .questionId(question.getQuestionId())
-                    .questionerId(question.getQuestioner().getUserId())
-                    .questionerName(question.getQuestioner().getName())
+                    .questionerId(questioner.getUserId())
+                    .questionerName(questioner.getName())
+                    .questionerDepartment(questioner.getDepartment())
+                    .questionerPosition(questioner.getPosition())
+                    .questionerProfileImageUrl(profileImageUrl(questioner))
                     .content(question.getContent())
                     .createdAt(question.getCreatedAt())
                     .build();
+        }
+
+        private static String profileImageUrl(User user) {
+            if (user.getProfileImageKey() == null) {
+                return null;
+            }
+
+            return "/api/v1/users/" + user.getUserId()
+                    + "/profile-image?v=" + user.getProfileImageKey();
         }
     }
 

--- a/src/main/java/com/_penLearning/Noddi/global/config/SwaggerConfig.java
+++ b/src/main/java/com/_penLearning/Noddi/global/config/SwaggerConfig.java
@@ -40,6 +40,7 @@ public class SwaggerConfig {
         return openApi -> openApi.setTags(List.of(
                 new Tag().name("Auth API").description("인증 API"),
                 new Tag().name("User API").description("사용자 API"),
+                new Tag().name("홈 AI 답변 현황 API").description("홈 미확인 AI 답변 현황 API"),
                 new Tag().name("Organization API").description("조직 API"),
                 new Tag().name("Announcement API").description("프로젝트 전체 공지 API"),
                 new Tag().name("Project API").description("프로젝트 API"),
@@ -48,7 +49,8 @@ public class SwaggerConfig {
                 new Tag().name("Team Page API").description("팀 공유 페이지 API"),
                 new Tag().name("Meeting API").description("회의 API"),
                 new Tag().name("ActionItem API").description("회의 할 일 API"),
-                new Tag().name("Q&A API").description("질의응답 API")
+                new Tag().name("Q&A API").description("질의응답 API"),
+                new Tag().name("알림 API").description("공통 알림함 API")
         ));
     }
 }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

## 🎋 작업 브랜치
- feat/#70-home-ai-answer-status -> develop
- #70

## 💡 작업동기

- 홈 화면에서 프로젝트별 미확인 AI 답변 현황을 확인할 수 있도록 구현했습니다.

## 🔑 주요 변경사항

- 프로젝트별 미확인 AI 답변 개수 조회 API 구현
- 미확인 AI 답변 카드 페이징 조회 API 구현
- 질문자·답변·프로젝트·팀·답변 근거 정보 제공
- 기존 알림의 읽음 상태와 홈 카드 상태 연동
- 프로젝트 및 팀 접근 권한 검증
- Swagger 문서 추가

## 🏞 스크린샷 (선택)
> 스크린샷을 첨부해주세요.

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
