### PR TITLE
[Feat] 팀별 개인 todolist 조회 api 구현

### DIFF
--- a/src/main/java/com/_penLearning/Noddi/domain/actionItem/code/ActionItemApi.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/actionItem/code/ActionItemApi.java
@@ -28,9 +28,18 @@ public interface ActionItemApi {
 
     @Operation(
             summary = "내 ActionItem 목록 조회",
-            description = "현재 로그인한 사용자가 담당자로 지정된 ActionItem을 조회합니다."
+            description = "현재 로그인한 사용자가 담당자로 지정된 미완료 ActionItem(PENDING, IN_PROGRESS)을 조회합니다."
     )
     ApiResponse<List<ActionItemResponseDto.Info>> getMyActionItems(
+            @Parameter(hidden = true) AuthMember authMember
+    );
+
+    @Operation(
+            summary = "팀별 개인 To-do 조회",
+            description = "현재 사용자가 소속된 모든 팀과 담당 미완료 ActionItem(PENDING, IN_PROGRESS)을 팀별로 묶어 조회합니다. 할 일이 없는 팀도 포함합니다."
+    )
+    ApiResponse<List<ActionItemResponseDto.TeamTodoGroup>>
+    getMyActionItemsByTeam(
             @Parameter(hidden = true) AuthMember authMember
     );
 

--- a/src/main/java/com/_penLearning/Noddi/domain/actionItem/controller/ActionItemController.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/actionItem/controller/ActionItemController.java
@@ -58,6 +58,23 @@ public class ActionItemController implements ActionItemApi {
     }
 
     @Override
+    @GetMapping("/action-items/me/by-team")
+    public ApiResponse<List<ActionItemResponseDto.TeamTodoGroup>>
+    getMyActionItemsByTeam(
+            @AuthenticationPrincipal AuthMember authMember
+    ) {
+        List<ActionItemResponseDto.TeamTodoGroup> response =
+                actionItemQueryService.getMyActionItemsByTeam(
+                        authMember.getUserId()
+                );
+
+        return ApiResponse.onSuccess(
+                "팀별 개인 To-do 조회가 완료되었습니다.",
+                response
+        );
+    }
+
+    @Override
     @PatchMapping("/action-items/{actionItemId}")
     public ApiResponse<Void> updateActionItem(
             @PathVariable Long actionItemId,

--- a/src/main/java/com/_penLearning/Noddi/domain/actionItem/dto/ActionItemResponseDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/actionItem/dto/ActionItemResponseDto.java
@@ -2,13 +2,45 @@ package com._penLearning.Noddi.domain.actionItem.dto;
 
 import com._penLearning.Noddi.domain.actionItem.code.ActionItemStatus;
 import com._penLearning.Noddi.domain.actionItem.entity.ActionItem;
+import com._penLearning.Noddi.domain.team.entity.Team;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class ActionItemResponseDto {
+
+    /** 내 팀 카드 한 개에 표시할 프로젝트·팀 정보와 개인 To-do 목록이다. */
+    @Getter
+    @Builder
+    public static class TeamTodoGroup {
+        private Long projectId;
+        private String projectName;
+        private Long teamId;
+        private String teamName;
+        private int todoCount;
+        private List<Info> actionItems;
+
+        public static TeamTodoGroup of(
+                Team team,
+                List<ActionItem> actionItems
+        ) {
+            List<Info> items = actionItems.stream()
+                    .map(Info::from)
+                    .toList();
+
+            return TeamTodoGroup.builder()
+                    .projectId(team.getProject().getProjectId())
+                    .projectName(team.getProject().getName())
+                    .teamId(team.getTeamId())
+                    .teamName(team.getName())
+                    .todoCount(items.size())
+                    .actionItems(items)
+                    .build();
+        }
+    }
 
     @Getter
     @Builder

--- a/src/main/java/com/_penLearning/Noddi/domain/actionItem/repository/ActionItemRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/actionItem/repository/ActionItemRepository.java
@@ -1,5 +1,6 @@
 package com._penLearning.Noddi.domain.actionItem.repository;
 
+import com._penLearning.Noddi.domain.actionItem.code.ActionItemStatus;
 import com._penLearning.Noddi.domain.actionItem.entity.ActionItem;
 import com._penLearning.Noddi.domain.project.entity.Project;
 import com._penLearning.Noddi.domain.team.entity.Team;
@@ -27,8 +28,8 @@ public interface ActionItemRepository extends JpaRepository<ActionItem, Long> {
     );
 
     /**
-     * 현재 사용자가 담당자인 ActionItem을 회의 정보와 함께 조회
-     * ActionItem이 속한 팀에 현재도 가입된 경우만 조회
+     * 마이페이지에 표시할 현재 사용자의 ActionItem을 회의 정보와 함께 조회한다.
+     * 전달받은 진행 상태에 해당하고, ActionItem이 속한 팀에 현재도 가입된 경우만 조회한다.
      */
     @Query("""
     SELECT ai
@@ -36,16 +37,51 @@ public interface ActionItemRepository extends JpaRepository<ActionItem, Long> {
     JOIN FETCH ai.meeting m
     JOIN FETCH ai.assignee a
     WHERE a.userId = :userId
+      AND ai.status IN :statuses
       AND EXISTS (
           SELECT 1
           FROM TeamMember tm
           WHERE tm.team = m.team
             AND tm.user = a
       )
-    ORDER BY ai.dueDate ASC, ai.actionItemId ASC
+    ORDER BY CASE WHEN ai.dueDate IS NULL THEN 1 ELSE 0 END ASC,
+             ai.dueDate ASC,
+             ai.actionItemId ASC
     """)
     List<ActionItem> findAllByAssigneeIdWithDetails(
-            @Param("userId") Long userId
+            @Param("userId") Long userId,
+            @Param("statuses") List<ActionItemStatus> statuses
+    );
+
+    /**
+     * 팀별 개인 To-do 응답 조립에 필요한 진행 중 ActionItem과
+     * Meeting·Team·Project를 일괄 조회한다.
+     * 기존 개인 목록 API의 전체 마감일순 계약과 분리해 프로젝트·팀별로 정렬한다.
+     */
+    @Query("""
+    SELECT ai
+    FROM ActionItem ai
+    JOIN FETCH ai.meeting m
+    JOIN FETCH m.team t
+    JOIN FETCH t.project
+    JOIN FETCH ai.assignee a
+    WHERE a.userId = :userId
+      AND ai.status IN :statuses
+      AND EXISTS (
+          SELECT 1
+          FROM TeamMember tm
+          WHERE tm.team = t
+            AND tm.user = a
+      )
+    ORDER BY t.project.projectId ASC,
+             t.teamId ASC,
+             CASE WHEN ai.dueDate IS NULL THEN 1 ELSE 0 END ASC,
+             ai.dueDate ASC,
+             ai.actionItemId ASC
+    """)
+    List<ActionItem> findAllByAssigneeIdWithTeamDetails(
+            @Param("userId") Long userId,
+            @Param("statuses") List<ActionItemStatus> statuses
     );
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)

--- a/src/main/java/com/_penLearning/Noddi/domain/actionItem/service/ActionItemQueryService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/actionItem/service/ActionItemQueryService.java
@@ -1,8 +1,13 @@
 package com._penLearning.Noddi.domain.actionItem.service;
 
+import com._penLearning.Noddi.domain.actionItem.code.ActionItemStatus;
 import com._penLearning.Noddi.domain.actionItem.dto.ActionItemResponseDto;
+import com._penLearning.Noddi.domain.actionItem.entity.ActionItem;
 import com._penLearning.Noddi.domain.actionItem.repository.ActionItemRepository;
+import com._penLearning.Noddi.domain.team.entity.TeamMember;
+import com._penLearning.Noddi.domain.team.repository.TeamMemberRepository;
 import com._penLearning.Noddi.domain.user.code.UserErrorCode;
+import com._penLearning.Noddi.domain.user.entity.User;
 import com._penLearning.Noddi.domain.user.repository.UserRepository;
 import com._penLearning.Noddi.global.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
@@ -10,13 +15,21 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ActionItemQueryService {
 
+    private static final List<ActionItemStatus> ACTIVE_STATUSES = List.of(
+            ActionItemStatus.PENDING,
+            ActionItemStatus.IN_PROGRESS
+    );
+
     private final ActionItemRepository actionItemRepository;
+    private final TeamMemberRepository teamMemberRepository;
     private final UserRepository userRepository;
 
     public List<ActionItemResponseDto.Info> getMyActionItems(Long currentUserId) {
@@ -24,10 +37,57 @@ public class ActionItemQueryService {
             throw new GeneralException(UserErrorCode.USER_NOT_FOUND);
         }
 
-        return actionItemRepository.findAllByAssigneeIdWithDetails(currentUserId)
+        return actionItemRepository.findAllByAssigneeIdWithDetails(
+                        currentUserId,
+                        ACTIVE_STATUSES
+                )
                 .stream()
                 .map(ActionItemResponseDto.Info::from)
                 .toList();
     }
 
+    /**
+     * 현재 사용자의 모든 소속 팀을 기준으로 개인 ActionItem을 그룹화한다.
+     *
+     * ActionItem부터 그룹화하면 할 일이 없는 팀이 사라지므로 TeamMember 목록을
+     * 응답의 기준으로 삼고, 별도로 조회한 ActionItem을 teamId로 연결한다.
+     */
+    public List<ActionItemResponseDto.TeamTodoGroup>
+    getMyActionItemsByTeam(Long currentUserId) {
+        User currentUser = userRepository.findById(currentUserId)
+                .orElseThrow(() ->
+                        new GeneralException(UserErrorCode.USER_NOT_FOUND)
+                );
+
+        List<TeamMember> teamMemberships =
+                teamMemberRepository
+                        .findAllByUserWithTeamAndProject(currentUser);
+
+        Map<Long, List<ActionItem>> actionItemsByTeamId =
+                actionItemRepository
+                        .findAllByAssigneeIdWithTeamDetails(
+                                currentUserId,
+                                ACTIVE_STATUSES
+                        )
+                        .stream()
+                        .collect(Collectors.groupingBy(
+                                actionItem -> actionItem.getMeeting()
+                                        .getTeam()
+                                        .getTeamId()
+                        ));
+
+        return teamMemberships.stream()
+                .map(teamMember -> {
+                    Long teamId = teamMember.getTeam().getTeamId();
+
+                    return ActionItemResponseDto.TeamTodoGroup.of(
+                            teamMember.getTeam(),
+                            actionItemsByTeamId.getOrDefault(
+                                    teamId,
+                                    List.of()
+                            )
+                    );
+                })
+                .toList();
+    }
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/team/repository/TeamMemberRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/team/repository/TeamMemberRepository.java
@@ -23,6 +23,19 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
     @Query("SELECT tm FROM TeamMember tm JOIN FETCH tm.team WHERE tm.user = :user")
     List<TeamMember> findAllByUserWithTeam(@Param("user") User user);
 
+    // 팀별 개인 To-do 조립을 위해 팀과 프로젝트를 고정된 순서로 일괄 조회한다.
+    @Query("""
+            SELECT tm
+            FROM TeamMember tm
+            JOIN FETCH tm.team team
+            JOIN FETCH team.project project
+            WHERE tm.user = :user
+            ORDER BY project.projectId ASC, team.teamId ASC
+            """)
+    List<TeamMember> findAllByUserWithTeamAndProject(
+            @Param("user") User user
+    );
+
     // 특정 유저의 팀 멤버 정보 단건 조회
     Optional<TeamMember> findByTeamAndUser(Team team, User user);
 


### PR DESCRIPTION
## <i>PULL REQUEST</i>

## 🎋 작업 브랜치
-feat/#76-my-todos-by-team -> develop
- #76(관련이슈 번호)

## 💡 작업동기

- 사용자가 담당하는 개인 To-do를 소속 팀별로 확인할 수 있도록 조회 기능을 추가했습니다.

## 🔑 주요 변경사항

- 팀별 개인 To-do 조회 API 추가
- 할 일이 없는 소속 팀도 응답에 포함
- `PENDING`, `IN_PROGRESS` 항목만 마이페이지에 노출
- 프로젝트·팀 정보 및 To-do 개수 제공
- 마감일 기준 정렬 정책 통일

## 🏞 스크린샷 (선택)
> 스크린샷을 첨부해주세요.

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
