### PR TITLE
[feat] 전사 api 전환

### DIFF
--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingAiProcessingService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/service/MeetingAiProcessingService.java
@@ -12,6 +12,7 @@ import com._penLearning.Noddi.domain.summary.code.SummaryErrorCode;
 import com._penLearning.Noddi.domain.actionItem.entity.ActionItem;
 import com._penLearning.Noddi.domain.summary.entity.MeetingSummary;
 import com._penLearning.Noddi.domain.actionItem.repository.ActionItemRepository;
+import com._penLearning.Noddi.domain.summary.model.MeetingTranscriptSegment;
 import com._penLearning.Noddi.domain.summary.repository.MeetingSummaryRepository;
 import com._penLearning.Noddi.domain.team.entity.Team;
 import com._penLearning.Noddi.domain.team.entity.TeamMember;
@@ -37,6 +38,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.IntStream;
 
 @Slf4j
 @Service
@@ -78,7 +80,13 @@ public class MeetingAiProcessingService {
                     meetingId
             );
 
-            String rawTranscript = openAiClient.transcribeAudio(recordingAccessLink);
+            OpenAiResponseDto.Transcription transcription =
+                    openAiClient.transcribeAudio(recordingAccessLink);
+            String rawTranscript = transcription.text();
+
+            List<MeetingTranscriptSegment> transcriptSegments =
+                    convertSegments(transcription.segments());
+
             log.info(
                     "[MeetingAiProcessingService] 회의 음성 전사 완료: meetingId={}, transcriptLength={}",
                     meetingId,
@@ -96,7 +104,7 @@ public class MeetingAiProcessingService {
                     meetingId,
                     actionItemCount
             );
-            saveResultAtomically(meetingId, rawTranscript, aiResult);
+            saveResultAtomically(meetingId, rawTranscript, transcriptSegments, aiResult);
             log.info(
                     "[MeetingAiProcessingService] AI 회의록 DB 저장 완료: meetingId={}",
                     meetingId
@@ -198,7 +206,7 @@ public class MeetingAiProcessingService {
                 .build();
     }
     //MeetingSummary와 ActionItem을 하나의 트랜잭션에서 저장
-    private void saveResultAtomically(Long meetingId, String rawTranscript, OpenAiResponseDto.MeetingSummary aiResult) {
+    private void    saveResultAtomically(Long meetingId, String rawTranscript, List<MeetingTranscriptSegment> transcriptSegments, OpenAiResponseDto.MeetingSummary aiResult) {
         transactionTemplate.executeWithoutResult(status -> {
             Meeting meeting = meetingRepository.findByIdWithPessimisticLock(meetingId)
                     .orElseThrow(() -> new GeneralException(MeetingErrorCode.MEETING_NOT_FOUND));
@@ -219,6 +227,7 @@ public class MeetingAiProcessingService {
                     .decisions(aiResult.decisions())
                     .issues(aiResult.issues())
                     .rawTranscript(rawTranscript)
+                    .transcriptSegments(transcriptSegments)
                     .build();
             meetingSummaryRepository.save(meetingSummary);
 
@@ -272,5 +281,37 @@ public class MeetingAiProcessingService {
     }
 
     private record ProcessingContext(String recordingId, List<OpenAiRequestDto.TeamMember> teamMembers) {
+    }
+
+    private List<MeetingTranscriptSegment> convertSegments(
+            List<OpenAiResponseDto.TranscriptionSegment> segments
+    ) {
+        // OpenAI가 세그먼트를 반환하지 않아도 회의록 생성 전체를 실패시키지 않는다.
+        if (segments == null || segments.isEmpty()) {
+            return List.of();
+        }
+
+        return IntStream.range(0, segments.size())
+                .mapToObj(index -> {
+                    OpenAiResponseDto.TranscriptionSegment segment =
+                            segments.get(index);
+
+                    return new MeetingTranscriptSegment(
+                            index + 1,
+                            segment.speaker(),
+                            toMilliseconds(segment.start()),
+                            toMilliseconds(segment.end()),
+                            segment.text()
+                    );
+                })
+                .toList();
+    }
+
+    private long toMilliseconds(Double seconds) {
+        if (seconds == null || seconds < 0) {
+            return 0L;
+        }
+
+        return Math.round(seconds * 1000);
     }
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/summary/dto/SummaryResponseDto.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/summary/dto/SummaryResponseDto.java
@@ -5,6 +5,7 @@ import com._penLearning.Noddi.domain.actionItem.entity.ActionItem;
 import com._penLearning.Noddi.domain.meeting.code.AiStatus;
 import com._penLearning.Noddi.domain.meeting.entity.Meeting;
 import com._penLearning.Noddi.domain.summary.entity.MeetingSummary;
+import com._penLearning.Noddi.domain.summary.model.MeetingTranscriptSegment;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -23,6 +24,7 @@ public class SummaryResponseDto {
         private List<String> decisions;
         private List<String> issues;
         private String rawTranscript;
+        private List<TranscriptSegmentDto> transcriptSegments;
 
         private List<ActionItemResponseDto.Info> actionItems;
 
@@ -36,6 +38,17 @@ public class SummaryResponseDto {
         ) {
             Meeting meeting = meetingSummary.getMeeting();
 
+            // 기존 데이터에는 JSON 값이 null일 수 있으므로 빈 목록으로 처리한다.
+            List<MeetingTranscriptSegment> storedSegments =
+                    meetingSummary.getTranscriptSegments();
+
+            List<TranscriptSegmentDto> transcriptSegmentDtos =
+                    storedSegments == null
+                            ? List.of()
+                            : storedSegments.stream()
+                            .map(TranscriptSegmentDto::from)
+                            .toList();
+
             return Detail.builder()
                     .meetingId(meeting.getMeetingId())
                     .summaryId(meetingSummary.getSummaryId())
@@ -44,6 +57,7 @@ public class SummaryResponseDto {
                     .decisions(meetingSummary.getDecisions())
                     .issues(meetingSummary.getIssues())
                     .rawTranscript(formattedTranscript)
+                    .transcriptSegments(transcriptSegmentDtos)
                     .actionItems(
                             actionItems.stream()
                                     .map(ActionItemResponseDto.Info::from)
@@ -65,8 +79,29 @@ public class SummaryResponseDto {
                     .decisions(List.of())
                     .issues(List.of())
                     .rawTranscript(null)
+                    .transcriptSegments(List.of())
                     .actionItems(List.of())
                     .build();
+        }
+    }
+
+    public record TranscriptSegmentDto(
+            int sequence,
+            String speakerLabel,
+            long startTimeMs,
+            long endTimeMs,
+            String text
+    ) {
+        public static TranscriptSegmentDto from(
+                MeetingTranscriptSegment segment
+        ) {
+            return new TranscriptSegmentDto(
+                    segment.sequence(),
+                    segment.speakerLabel(),
+                    segment.startTimeMs(),
+                    segment.endTimeMs(),
+                    segment.text()
+            );
         }
     }
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/summary/entity/MeetingSummary.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/summary/entity/MeetingSummary.java
@@ -1,6 +1,7 @@
 package com._penLearning.Noddi.domain.summary.entity;
 
 import com._penLearning.Noddi.domain.meeting.entity.Meeting;
+import com._penLearning.Noddi.domain.summary.model.MeetingTranscriptSegment;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -46,8 +47,19 @@ public class MeetingSummary {
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "JSON")
+    private List<MeetingTranscriptSegment> transcriptSegments;
+
+
     @Builder
-    public MeetingSummary(Meeting meeting, String summaryText, List<String> decisions, List<String> issues, String rawTranscript) {
+    public MeetingSummary(
+            Meeting meeting,
+            String summaryText,
+            List<String> decisions,
+            List<String> issues,
+            String rawTranscript,
+            List<MeetingTranscriptSegment> transcriptSegments) {
         this.meeting = meeting;
         this.summaryText = summaryText;
         // OpenAI가 null을 반환하더라도 DB에는 빈 JSON 배열을 저장한다.
@@ -60,6 +72,9 @@ public class MeetingSummary {
                 : new ArrayList<>();
         this.createdAt = LocalDateTime.now();
         this.rawTranscript = rawTranscript;
+        this.transcriptSegments = transcriptSegments != null
+                ? new ArrayList<>(transcriptSegments)
+                : new ArrayList<>();
     }
 
     public void update(

--- a/src/main/java/com/_penLearning/Noddi/domain/summary/model/MeetingTranscriptSegment.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/summary/model/MeetingTranscriptSegment.java
@@ -1,0 +1,11 @@
+package com._penLearning.Noddi.domain.summary.model;
+
+public record MeetingTranscriptSegment(
+        int sequence,
+        String speakerLabel,
+        long startTimeMs,
+        long endTimeMs,
+        String text
+) {
+
+}

--- a/src/main/java/com/_penLearning/Noddi/domain/summary/service/SummaryQueryService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/summary/service/SummaryQueryService.java
@@ -48,14 +48,21 @@ public class SummaryQueryService {
                 .orElseThrow(() -> new GeneralException(SummaryErrorCode.SUMMARY_NOT_FOUND));
         List<ActionItem> actionItems = actionItemRepository.findAllByMeetingIdWithDetails(meetingId);
 
-        String formattedTranscript = transcriptFormatter.format(
-                meetingSummary.getRawTranscript()
-        );
+        boolean hasSegments =
+                meetingSummary.getTranscriptSegments() != null
+                        && !meetingSummary.getTranscriptSegments().isEmpty();
+
+        String fallbackTranscript =
+                hasSegments
+                        ? null
+                        : transcriptFormatter.format(
+                        meetingSummary.getRawTranscript()
+                );
 
         return SummaryResponseDto.Detail.completed(
                 meetingSummary,
                 actionItems,
-                formattedTranscript
+                fallbackTranscript
         );
     }
 

--- a/src/main/java/com/_penLearning/Noddi/global/infrastructure/openAi/OpenAiClient.java
+++ b/src/main/java/com/_penLearning/Noddi/global/infrastructure/openAi/OpenAiClient.java
@@ -63,7 +63,7 @@ public class OpenAiClient {
         this.audioDownloadReadTimeoutMs = audioDownloadReadTimeoutMs;
     }
 
-    public String transcribeAudio(String audioUrl) {
+    public OpenAiResponseDto.Transcription transcribeAudio(String audioUrl) {
         log.info("[OpenAI Whisper] STT 변환 시작");
 
         Path temporaryAudioFile = null;
@@ -134,14 +134,16 @@ public class OpenAiClient {
         }
     }
 
-    private String requestWhisperTranscription(Path audioFile) {
+    private OpenAiResponseDto.Transcription requestWhisperTranscription(Path audioFile) {
         // FileSystemResource는 디스크 파일을 multipart의 file 항목으로 전달할 수 있게 포장
         FileSystemResource audioResource = new FileSystemResource(audioFile);
         MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
 
         body.add("file", audioResource);
-        body.add("model", "whisper-1");
+        body.add("model", "gpt-4o-transcribe-diarize");
         body.add("language", "ko");
+        body.add("response_format", "diarized_json");
+        body.add("chunking_strategy", "auto");
 
         OpenAiResponseDto.Transcription response = openAiRestClient.post()
                 .uri("/audio/transcriptions")
@@ -150,11 +152,13 @@ public class OpenAiClient {
                 .retrieve()
                 .body(OpenAiResponseDto.Transcription.class);
 
-        if (response != null && StringUtils.hasText(response.text())) {
-            return response.text();
+        if (response == null || !StringUtils.hasText(response.text())) {
+            throw new GeneralException(
+                    SummaryErrorCode.STT_PROCESSING_FAILED
+            );
         }
 
-        throw new GeneralException(SummaryErrorCode.STT_PROCESSING_FAILED);
+        return response;
     }
 
     private void deleteTemporaryFile(Path temporaryAudioFile) {

--- a/src/main/java/com/_penLearning/Noddi/global/infrastructure/openAi/dto/OpenAiResponseDto.java
+++ b/src/main/java/com/_penLearning/Noddi/global/infrastructure/openAi/dto/OpenAiResponseDto.java
@@ -9,8 +9,21 @@ public class OpenAiResponseDto {
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record Transcription(
-            String text
+            String text,
+            Double duration,
+            List<TranscriptionSegment> segments
     ) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record TranscriptionSegment(
+            String id,
+            Double start,
+            Double end,
+            String speaker,
+            String text
+    ){
+
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)


### PR DESCRIPTION
## <i>PULL REQUEST</i>

## 🎋 작업 브랜치
- feature/78 -> develop
- #78 (관련이슈 번호)

## 💡 작업동기
- 작업 배경을 알려주세요.

## 🔑 주요 변경사항
- 기존 전사 자료가 정리에 한계가 있어 타임스탬프와 화자 구분이 가능한 api로 교체했습니다.
- 응답 dto에 segment 필드를 추가해 구성했습니다.
- 조회 서비스에서 기존 데이터를 조회할 수 있도록 로직을 추가했습니다.

## 🏞 스크린샷 (선택)
> 스크린샷을 첨부해주세요.

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
