### PR TITLE
[fix] 녹음본 미수신 PENDING 회의 타임아웃 복구 스케줄러 추가

### DIFF
--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/repository/MeetingRepository.java
@@ -1,6 +1,7 @@
 package com._penLearning.Noddi.domain.meeting.repository;
 
 import com._penLearning.Noddi.domain.meeting.code.AiStatus;
+import com._penLearning.Noddi.domain.meeting.code.MeetingStatus;
 import com._penLearning.Noddi.domain.meeting.entity.Meeting;
 import com._penLearning.Noddi.domain.project.entity.Project;
 import com._penLearning.Noddi.domain.team.entity.Team;
@@ -46,6 +47,18 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
     int failStuckAiProcessing(
             @Param("threshold") LocalDateTime threshold,
             @Param("processingStatus") AiStatus processingStatus,
+            @Param("failedStatus") AiStatus failedStatus
+    );
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE Meeting m SET m.aiStatus = :failedStatus " +
+            "WHERE m.status = :endedStatus " +
+            "AND m.aiStatus = :pendingStatus " +
+            "AND m.endedAt < :threshold")
+    int failStuckPendingAiMeetings(
+            @Param("threshold") LocalDateTime threshold,
+            @Param("endedStatus") MeetingStatus endedStatus,
+            @Param("pendingStatus") AiStatus pendingStatus,
             @Param("failedStatus") AiStatus failedStatus
     );
 }

--- a/src/main/java/com/_penLearning/Noddi/domain/meeting/scheduler/MeetingAiRecoveryScheduler.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/meeting/scheduler/MeetingAiRecoveryScheduler.java
@@ -1,6 +1,7 @@
 package com._penLearning.Noddi.domain.meeting.scheduler;
 
 import com._penLearning.Noddi.domain.meeting.code.AiStatus;
+import com._penLearning.Noddi.domain.meeting.code.MeetingStatus;
 import com._penLearning.Noddi.domain.meeting.repository.MeetingRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,11 +22,22 @@ public class MeetingAiRecoveryScheduler {
     @Value("${scheduler.meeting-ai.processing-timeout-minutes:30}")
     private long processingTimeoutMinutes;
 
+    @Value("${scheduler.meeting-ai.pending-timeout-minutes:10}")
+    private long pendingTimeoutMinutes;
+
     @Scheduled(
             cron = "${scheduler.meeting-ai.recovery-cron:0 */5 * * * *}",
             zone = "${scheduler.meeting-ai.zone:Asia/Seoul}"
     )
+
     @Transactional
+    public void recoverStuckMeetings() {
+        // (1) 기존: 30분 초과 PROCESSING 상태 복구
+        failStuckProcessingMeetings();
+        // 💡 (2) 추가: 종료 후 10분 초과 PENDING(녹음 미수신) 상태 복구
+        failStuckPendingMeetings();
+    }
+
     public void failStuckProcessingMeetings() {
         LocalDateTime threshold = LocalDateTime.now()
                 .minusMinutes(processingTimeoutMinutes);
@@ -42,6 +54,18 @@ public class MeetingAiRecoveryScheduler {
                     processingTimeoutMinutes,
                     recoveredCount
             );
+        }
+    }
+    public void failStuckPendingMeetings() {
+        LocalDateTime threshold = LocalDateTime.now().minusMinutes(pendingTimeoutMinutes);
+        int count = meetingRepository.failStuckPendingAiMeetings(
+                threshold,
+                MeetingStatus.ENDED,
+                AiStatus.PENDING,
+                AiStatus.FAILED
+        );
+        if (count > 0){
+            log.warn("[스케줄러] 녹음본 미수신({}분 경과) PENDING AI 작업 {}건 FAILED 전환", pendingTimeoutMinutes, count);
         }
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -63,6 +63,8 @@ scheduler:
     zone: "${MEETING_AI_RECOVERY_ZONE:Asia/Seoul}"
     # 정상 처리 시간을 충분히 고려해 30분을 초과한 작업만 FAILED로 복구한다.
     processing-timeout-minutes: ${MEETING_AI_PROCESSING_TIMEOUT_MINUTES:30}
+    # PENDING 타임아웃 추가 (기본 10분)
+    pending-timeout-minutes: ${MEETING_AI_PENDING_TIMEOUT_MINUTES:10}
   qa-ai:
     recovery-cron: "${QA_AI_RECOVERY_CRON:0 */5 * * * *}"
     zone: "${QA_AI_RECOVERY_ZONE:Asia/Seoul}"


### PR DESCRIPTION
## <i>PULL REQUEST</i>

## 🎋 작업 브랜치
- fix/80 -> develop
- #80 (관련이슈 번호)

## 💡 작업동기
- 작업 배경을 알려주세요.

## 🔑 주요 변경사항
- 회의가 종료된 지 10분이 지났는데도 여전히 PENDING 상태(녹음본 미수신)인 회의를 FAILED로 정리하는 스케줄러를 추가했습니다

## 🏞 스크린샷 (선택)
> 스크린샷을 첨부해주세요.

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
