### PR TITLE
[Fix] 서버 런타임 오류 수정 (Pinecone 빈 청크 색인, Spring Security 비동기 예외)

### DIFF
--- a/src/main/java/com/_penLearning/Noddi/domain/qa/rag/indexing/MeetingKnowledgeIndexService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/rag/indexing/MeetingKnowledgeIndexService.java
@@ -1,24 +1,166 @@
 package com._penLearning.Noddi.domain.qa.rag.indexing;
 
+import com._penLearning.Noddi.domain.qa.entity.SourceType;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.vectorstore.VectorStore;
 import org.springframework.stereotype.Service;
 
-/** 회의 전사를 공통 지식 인덱싱 흐름에 전달한다. */
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Optional;
+
+// 회의 전사를 실제로 Pinecone에 넣는 전체 과정을 제어함
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class MeetingKnowledgeIndexService {
 
     private final MeetingKnowledgeSourceReader sourceReader;
-    private final KnowledgeIndexService knowledgeIndexService;
+    private final QaKnowledgeIndexStateService indexStateService;
+    private final KnowledgeDocumentFactory documentFactory;
+    private final VectorStore vectorStore;
 
     public MeetingKnowledgeIndexResult index(Long meetingId) {
         KnowledgeSourceContent source = sourceReader.read(meetingId);
-        KnowledgeIndexResult result = knowledgeIndexService.synchronize(source);
+
+        // 회의 전사를 공통 소스 형식으로 전달하여 팀 작성 텍스트와 같은 색인 규칙을 사용한다.
+        SourceSyncResult transcriptResult = synchronize(source);
 
         return new MeetingKnowledgeIndexResult(
                 meetingId,
-                result.indexedChunkCount(),
-                result.skipped() ? 1 : 0
+                transcriptResult.indexedChunkCount(),
+                transcriptResult.skippedSourceCount()
         );
+    }
+
+    private SourceSyncResult synchronize(KnowledgeSourceContent source) {
+        Optional<KnowledgeIndexState> previousState = indexStateService.get(
+                source.sourceId(),
+                source.sourceType()
+        );
+
+        if (source.content() == null || source.content().isBlank()) {
+            removePreviousSource(source.sourceId(), source.sourceType(), previousState);
+            indexStateService.recordSuccess(
+                    source.sourceId(),
+                    source.teamId(),
+                    source.sourceType(),
+                    sha256(""),
+                    0
+            );
+            return SourceSyncResult.skipped();
+        }
+
+        String contentHash = sha256(source.content());
+        if (previousState.map(KnowledgeIndexState::contentHash).filter(contentHash::equals).isPresent()) {
+            return SourceSyncResult.skipped();
+        }
+
+        List<Document> documents = documentFactory.create(source);
+
+        if (documents.isEmpty()) {
+            removePreviousSource(source.sourceId(), source.sourceType(), previousState);
+            indexStateService.recordSuccess(
+                    source.sourceId(),
+                    source.teamId(),
+                    source.sourceType(),
+                    contentHash,
+                    0
+            );
+            log.info(
+                    "[MeetingKnowledgeIndex] 전사 내용이 너무 짧아 색인 대상 청크가 없습니다: sourceId={}, sourceType={}",
+                    source.sourceId(),
+                    source.sourceType()
+            );
+            return SourceSyncResult.skipped();
+        }
+
+        // Pinecone 저장이 성공한 뒤에만 MySQL 색인 상태를 갱신한다.
+        vectorStore.add(documents);
+
+        previousState.ifPresent(state -> deleteStaleDocuments(
+                source.sourceId(),
+                source.sourceType(),
+                documents.size(),
+                state.chunkCount()
+        ));
+
+        indexStateService.recordSuccess(
+                source.sourceId(),
+                source.teamId(),
+                source.sourceType(),
+                contentHash,
+                documents.size()
+        );
+
+        log.info(
+                "[MeetingKnowledgeIndex] 색인 완료: sourceId={}, sourceType={}, chunkCount={}",
+                source.sourceId(),
+                source.sourceType(),
+                documents.size()
+        );
+        return SourceSyncResult.indexed(documents.size());
+    }
+
+    private void removePreviousSource(
+            Long sourceId,
+            SourceType sourceType,
+            Optional<KnowledgeIndexState> previousState
+    ) {
+        previousState.ifPresent(state -> {
+            List<String> ids = documentFactory.documentIds(
+                    sourceId,
+                    sourceType,
+                    0,
+                    state.chunkCount()
+            );
+            if (!ids.isEmpty()) {
+                vectorStore.delete(ids);
+            }
+            indexStateService.remove(sourceId, sourceType);
+        });
+    }
+
+    private void deleteStaleDocuments(
+            Long sourceId,
+            SourceType sourceType,
+            int newChunkCount,
+            int previousChunkCount
+    ) {
+        if (previousChunkCount <= newChunkCount) {
+            return;
+        }
+
+        vectorStore.delete(documentFactory.documentIds(
+                sourceId,
+                sourceType,
+                newChunkCount,
+                previousChunkCount
+        ));
+    }
+
+    private String sha256(String content) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(content.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("SHA-256 algorithm is not available", exception);
+        }
+    }
+
+    private record SourceSyncResult(int indexedChunkCount, int skippedSourceCount) {
+
+        private static SourceSyncResult indexed(int chunkCount) {
+            return new SourceSyncResult(chunkCount, 0);
+        }
+
+        private static SourceSyncResult skipped() {
+            return new SourceSyncResult(0, 1);
+        }
     }
 }

--- a/src/main/java/com/_penLearning/Noddi/global/security/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/_penLearning/Noddi/global/security/JwtAccessDeniedHandler.java
@@ -23,6 +23,10 @@ public class JwtAccessDeniedHandler implements AccessDeniedHandler {
     public void handle(HttpServletRequest request, HttpServletResponse response,
                        AccessDeniedException accessDeniedException) throws IOException {
 
+        if (response.isCommitted()) {
+            return;
+        }
+
         // 403 Forbidden 에러 코드 지정 (AuthErrorCode에 FORBIDDEN 또는 ACCESS_DENIED 항목 정의 필요)
         AuthErrorCode errorCode = AuthErrorCode.FORBIDDEN;
 

--- a/src/main/java/com/_penLearning/Noddi/global/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/_penLearning/Noddi/global/security/JwtAuthenticationEntryPoint.java
@@ -22,6 +22,10 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     public void commence(HttpServletRequest request, HttpServletResponse response,
                          AuthenticationException authException) throws IOException {
 
+        if (response.isCommitted()) {
+            return;
+        }
+
         // 필터에서 저장했던 에러 코드 조회 (없으면 기본 토큰 에러)
         AuthErrorCode errorCode = (AuthErrorCode) request.getAttribute("exception");
 

--- a/src/main/java/com/_penLearning/Noddi/global/security/SecurityConfig.java
+++ b/src/main/java/com/_penLearning/Noddi/global/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com._penLearning.Noddi.global.security;
 
+import jakarta.servlet.DispatcherType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -11,7 +12,6 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.http.HttpMethod;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -47,6 +47,10 @@ public class SecurityConfig {
                 )
                 // 3. URL 차단 및 개방 규칙
                 .authorizeHttpRequests(auth -> auth
+                                // 비동기 디스패치 및 에러 포워딩 허용
+                                .dispatcherTypeMatchers(DispatcherType.ASYNC, DispatcherType.ERROR).permitAll()
+                                // 에러 페이지 허용
+                                .requestMatchers("/error").permitAll()
                                 // Swagger 문서 접속 주소 허용
                                 .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/api-docs/**", "/v3/api-docs/**").permitAll()
                                 // 회원가입, 로그인 API 허용

--- a/src/test/java/com/_penLearning/Noddi/domain/qa/rag/indexing/MeetingKnowledgeIndexServiceTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/qa/rag/indexing/MeetingKnowledgeIndexServiceTest.java
@@ -6,8 +6,20 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.vectorstore.VectorStore;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -16,37 +28,107 @@ class MeetingKnowledgeIndexServiceTest {
     @Mock
     private MeetingKnowledgeSourceReader sourceReader;
     @Mock
-    private KnowledgeIndexService knowledgeIndexService;
+    private QaKnowledgeIndexStateService indexStateService;
+    @Mock
+    private KnowledgeDocumentFactory documentFactory;
+    @Mock
+    private VectorStore vectorStore;
 
     @InjectMocks
     private MeetingKnowledgeIndexService indexService;
 
     @Test
-    void delegatesTranscriptToCommonKnowledgeIndexer() {
-        KnowledgeSourceContent source = new KnowledgeSourceContent(
-                20L, 10L, SourceType.TRANSCRIPT, "weekly meeting", "new transcript"
-        );
+    void skipsEmbeddingWhenSourceContentHasNotChanged() throws Exception {
+        KnowledgeSourceContent source = source("same transcript");
         when(sourceReader.read(20L)).thenReturn(source);
-        when(knowledgeIndexService.synchronize(source)).thenReturn(KnowledgeIndexResult.indexed(2));
-
-        MeetingKnowledgeIndexResult result = indexService.index(20L);
-
-        assertThat(result.meetingId()).isEqualTo(20L);
-        assertThat(result.indexedChunkCount()).isEqualTo(2);
-        assertThat(result.skippedSourceCount()).isZero();
-    }
-
-    @Test
-    void mapsSkippedSynchronizationToMeetingResult() {
-        KnowledgeSourceContent source = new KnowledgeSourceContent(
-                20L, 10L, SourceType.TRANSCRIPT, "weekly meeting", "same transcript"
-        );
-        when(sourceReader.read(20L)).thenReturn(source);
-        when(knowledgeIndexService.synchronize(source)).thenReturn(KnowledgeIndexResult.skippedResult());
+        when(indexStateService.get(20L, SourceType.TRANSCRIPT))
+                .thenReturn(Optional.of(new KnowledgeIndexState(sha256("same transcript"), 1)));
 
         MeetingKnowledgeIndexResult result = indexService.index(20L);
 
         assertThat(result.indexedChunkCount()).isZero();
         assertThat(result.skippedSourceCount()).isEqualTo(1);
+        verify(vectorStore, never()).add(org.mockito.ArgumentMatchers.anyList());
+    }
+
+    @Test
+    void indexesChangedContentAndRecordsStateAfterVectorStoreWrite() {
+        KnowledgeSourceContent source = source("new transcript");
+        List<Document> documents = List.of(
+                Document.builder().id("doc-1").text("chunk 1").build(),
+                Document.builder().id("doc-2").text("chunk 2").build()
+        );
+        when(sourceReader.read(20L)).thenReturn(source);
+        when(indexStateService.get(20L, SourceType.TRANSCRIPT)).thenReturn(Optional.empty());
+        when(documentFactory.create(source)).thenReturn(documents);
+
+        MeetingKnowledgeIndexResult result = indexService.index(20L);
+
+        assertThat(result.indexedChunkCount()).isEqualTo(2);
+        assertThat(result.skippedSourceCount()).isZero();
+        verify(vectorStore).add(documents);
+        verify(indexStateService).recordSuccess(
+                eq(20L),
+                eq(10L),
+                eq(SourceType.TRANSCRIPT),
+                anyString(),
+                eq(2)
+        );
+    }
+
+    @Test
+    void skipsVectorStoreWhenDocumentsAreEmptyAndRecordsZeroChunks() throws Exception {
+        KnowledgeSourceContent source = source("short");
+        when(sourceReader.read(20L)).thenReturn(source);
+        when(indexStateService.get(20L, SourceType.TRANSCRIPT)).thenReturn(Optional.empty());
+        when(documentFactory.create(source)).thenReturn(List.of());
+
+        MeetingKnowledgeIndexResult result = indexService.index(20L);
+
+        assertThat(result.indexedChunkCount()).isZero();
+        assertThat(result.skippedSourceCount()).isEqualTo(1);
+        verify(vectorStore, never()).add(org.mockito.ArgumentMatchers.anyList());
+        verify(indexStateService).recordSuccess(
+                eq(20L),
+                eq(10L),
+                eq(SourceType.TRANSCRIPT),
+                eq(sha256("short")),
+                eq(0)
+        );
+    }
+
+    @Test
+    void recordsZeroChunksWhenSourceContentIsBlank() throws Exception {
+        KnowledgeSourceContent source = source("   ");
+        when(sourceReader.read(20L)).thenReturn(source);
+        when(indexStateService.get(20L, SourceType.TRANSCRIPT)).thenReturn(Optional.empty());
+
+        MeetingKnowledgeIndexResult result = indexService.index(20L);
+
+        assertThat(result.indexedChunkCount()).isZero();
+        assertThat(result.skippedSourceCount()).isEqualTo(1);
+        verify(vectorStore, never()).add(org.mockito.ArgumentMatchers.anyList());
+        verify(indexStateService).recordSuccess(
+                eq(20L),
+                eq(10L),
+                eq(SourceType.TRANSCRIPT),
+                eq(sha256("")),
+                eq(0)
+        );
+    }
+
+    private KnowledgeSourceContent source(String transcript) {
+        return new KnowledgeSourceContent(
+                20L,
+                10L,
+                SourceType.TRANSCRIPT,
+                "weekly meeting",
+                transcript
+        );
+    }
+
+    private String sha256(String content) throws Exception {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        return HexFormat.of().formatHex(digest.digest(content.getBytes(StandardCharsets.UTF_8)));
     }
 }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

## 🎋 작업 브랜치
- fix/82 -> develop
- #82  (관련이슈 번호)

## 💡 작업동기
- 작업 배경을 알려주세요.

## 🔑 주요 변경사항
- Spring Security 비동기/에러 디스패치 권한 허용 및 응답 커밋 방어
- Pinecone 빈 청크 재색인 실패 및 스케줄러 무한 반복 방지
## 🏞 스크린샷 (선택)
> 스크린샷을 첨부해주세요.

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
