### PR TITLE
[Fix] 공유페이지 빈 청크 색인 방어 및 스케줄러 복구 오류 해결

### DIFF
--- a/src/main/java/com/_penLearning/Noddi/domain/qa/rag/indexing/KnowledgeIndexService.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/qa/rag/indexing/KnowledgeIndexService.java
@@ -34,6 +34,13 @@ public class KnowledgeIndexService {
 
         if (source.content() == null || source.content().isBlank()) {
             removePreviousSource(source, previousState);
+            indexStateService.recordSuccess(
+                    source.sourceId(),
+                    source.teamId(),
+                    source.sourceType(),
+                    sha256(""),
+                    0
+            );
             return KnowledgeIndexResult.skippedResult();
         }
 
@@ -43,6 +50,24 @@ public class KnowledgeIndexService {
         }
 
         List<Document> documents = documentFactory.create(source);
+
+        if (documents.isEmpty()) {
+            removePreviousSource(source, previousState);
+            indexStateService.recordSuccess(
+                    source.sourceId(),
+                    source.teamId(),
+                    source.sourceType(),
+                    contentHash,
+                    0
+            );
+            log.info(
+                    "[KnowledgeIndex] 내용이 너무 짧아 색인 대상 청크가 없습니다: sourceId={}, sourceType={}",
+                    source.sourceId(),
+                    source.sourceType()
+            );
+            return KnowledgeIndexResult.skippedResult();
+        }
+
         vectorStore.add(documents);
 
         previousState.ifPresent(state -> deleteStaleDocuments(

--- a/src/main/java/com/_penLearning/Noddi/domain/summary/entity/MeetingSummary.java
+++ b/src/main/java/com/_penLearning/Noddi/domain/summary/entity/MeetingSummary.java
@@ -28,8 +28,7 @@ public class MeetingSummary {
     @JoinColumn(name = "meetingId", nullable = false, unique = true)
     private Meeting meeting;
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String summaryText;
 
     @Column(nullable = false, columnDefinition = "LONGTEXT")
@@ -48,7 +47,7 @@ public class MeetingSummary {
     private LocalDateTime createdAt;
 
     @JdbcTypeCode(SqlTypes.JSON)
-    @Column(columnDefinition = "JSON")
+    @Column(columnDefinition = "JSON", nullable = false)
     private List<MeetingTranscriptSegment> transcriptSegments;
 
 

--- a/src/test/java/com/_penLearning/Noddi/domain/qa/rag/indexing/KnowledgeIndexServiceTest.java
+++ b/src/test/java/com/_penLearning/Noddi/domain/qa/rag/indexing/KnowledgeIndexServiceTest.java
@@ -85,6 +85,43 @@ class KnowledgeIndexServiceTest {
         verify(vectorStore).delete(staleIds);
     }
 
+    @Test
+    void skipsVectorStoreWhenDocumentsAreEmptyAndRecordsZeroChunks() throws Exception {
+        KnowledgeSourceContent source = source("short");
+        when(indexStateService.get(20L, SourceType.TEAM_TEXT)).thenReturn(Optional.empty());
+        when(documentFactory.create(source)).thenReturn(List.of());
+
+        KnowledgeIndexResult result = indexService.synchronize(source);
+
+        assertThat(result.skipped()).isTrue();
+        verify(vectorStore, never()).add(org.mockito.ArgumentMatchers.anyList());
+        verify(indexStateService).recordSuccess(
+                eq(20L),
+                eq(10L),
+                eq(SourceType.TEAM_TEXT),
+                eq(sha256("short")),
+                eq(0)
+        );
+    }
+
+    @Test
+    void recordsZeroChunksWhenSourceContentIsBlank() throws Exception {
+        KnowledgeSourceContent source = source("   ");
+        when(indexStateService.get(20L, SourceType.TEAM_TEXT)).thenReturn(Optional.empty());
+
+        KnowledgeIndexResult result = indexService.synchronize(source);
+
+        assertThat(result.skipped()).isTrue();
+        verify(vectorStore, never()).add(org.mockito.ArgumentMatchers.anyList());
+        verify(indexStateService).recordSuccess(
+                eq(20L),
+                eq(10L),
+                eq(SourceType.TEAM_TEXT),
+                eq(sha256("")),
+                eq(0)
+        );
+    }
+
     private KnowledgeSourceContent source(String content) {
         return new KnowledgeSourceContent(20L, 10L, SourceType.TEAM_TEXT, "team page", content);
     }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

## 🎋 작업 브랜치
- fix/86 -> develop
- #86  (관련이슈 번호)

## 💡 작업동기
- 공유페이지 빈 청크 색인 방어 및 스케줄러 복구 오류 해결

## 🔑 주요 변경사항
- 방어 로직 추가

## 🏞 스크린샷 (선택)
> 스크린샷을 첨부해주세요.

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
